### PR TITLE
split uri back out from path, added flattener (not yet enabled).

### DIFF
--- a/.scripts/generate-tests.ps1
+++ b/.scripts/generate-tests.ps1
@@ -46,7 +46,7 @@ function run-autorest($src) {
   $txt = "$autorest --pipeline-model:v3 --input-file:$swaggerRoot$src --output-folder:$outputFolder --title:$name --output-artifact:openapi-document $args" 
   write-host -fore GREEN "`n--------------------------------------------------------`nGenerating [$name]`n--------------------------------------------------------`n"
   echo $txt
-  & $autorest "--version:c:\work\2019\autorest.megarepo\autorest" "--pipeline-model:v3" "--input-file:$swaggerRoot$src" "--output-folder:$outputFolder" "--clear-output-folder" "--title:$name" "--output-artifact:openapi-document" $args
+  & $autorest "--version:c:\work\2019\autorest.megarepo\autorest" "--pipeline-model:v3" "--input-file:$swaggerRoot$src" "--output-folder:$outputFolder" "--clear-output-folder" "--title:$name" "--output-artifact:openapi-document" "--deduplicate-inline-models" $args
   $rc = $LastExitCode
   if( $rc -gt 0 ) {
     write-host -fore RED "`n--------------------------------------------------------`nFAILED GENERATION [$name]`n--------------------------------------------------------`n"

--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/modelerfour",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "AutoRest Modeler Version Four (component)",
   "directories": {
     "doc": "docs"
@@ -12,7 +12,7 @@
   "typings": "dist/exports.d.ts",
   "scripts": {
     "start": "node --max_old_space_size=4096 ./dist/main.js",
-    "debug": "node --max_old_space_size=4096 --inspect-brk ./dist/main.js",
+    "debug": "node --max_old_space_size=4096 --inspect-brk=localhost:19229 ./dist/main.js",
     "eslint-fix": "eslint  . --fix --ext .ts",
     "eslint": "eslint  . --ext .ts",
     "watch": "tsc -p . --watch",

--- a/modelerfour/prenamer/plugin-prenamer.ts
+++ b/modelerfour/prenamer/plugin-prenamer.ts
@@ -8,7 +8,6 @@ import { Host, startSession } from '@azure-tools/autorest-extension-base';
 import { codeModelSchema, CodeModel } from '@azure-tools/codemodel';
 import { PreNamer } from './prenamer';
 
-
 export async function processRequest(host: Host) {
   const debug = await host.GetValue('debug') || false;
 

--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -1,3 +1,29 @@
+# AutoRest Modeler Four 
+
+## Changelog:
+
+#### 4.1.56 - Breaking change: 
+  - version bump, change your configuration to specify version `~4.1.0` or greater
+  
+  ``` yaml 
+  use-extension:
+  "@autorest/modelerfour" : "~4.1.0" 
+  ```
+  - each Http operation (via `.protocol.http`) will now have a separate `path` and `uri` properties. 
+  <br>Both are still templates, and will have parameters. 
+  <br>The parameters for the `uri` property will have `in` set to `ParameterLocation.Uri`
+  <br>The parameters for the `path` property will continue to have `in` set to `ParameterLocation.Path`
+
+  - this package contains the initial code for the flattener plugin, however it is not yet enabled.
+  - autorest-core recently added an option to aggressively deduplicate inline models (ie, ones without a name)
+  and modeler-four based generator will have that enabled by default. (ie `deduplicate-inline-models: true`)
+  <br>This may increase deduplication time on extremely large openapi models.
+
+  - updated `@azure-tools/codemodel` package to `3.0.241`:
+  <br>`uri` (required) was added to `HttpRequest`
+  <br>`flattenedNames` (optional) was added to `Property` (in anticipation of supporting flattening)
+
+
 
 # Contributing
 
@@ -63,4 +89,7 @@ scope-modelerfour/notags/emitter: # writing to disk settings
   output-uri-expr: | # forces filename if it gets written to disk.
     "code-model-v4-no-tags.yaml"  
 
+# the default preference for modeler-four based generators is to deduplicate inline models fully.
+# this may impact performance on extremely large models with a lot of inline schemas.
+deduplicate-inline-models: true
 ```

--- a/modelerfour/test/inputs/additionalProperties/openapi-document.json
+++ b/modelerfour/test/inputs/additionalProperties/openapi-document.json
@@ -108,7 +108,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -159,7 +159,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -210,7 +210,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -261,7 +261,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -312,7 +312,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -557,11 +557,11 @@
      ],
      "name": "components·schemas·petaptrue·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petaptrue·additionalproperties"
+      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petaptrue·additionalproperties",
+      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapobject·additionalproperties"
      ]
     },
-    "type": "object",
-    "x-format": "any"
+    "type": "object"
    },
    "schemas:5": {
     "x-ms-metadata": {
@@ -615,7 +615,7 @@
      }
     },
     "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:8"
+     "$ref": "#/components/schemas/schemas:4"
     },
     "required": [
      "id"
@@ -635,21 +635,6 @@
      ]
     },
     "type": "string"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "components·schemas·petapobject·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapobject·additionalproperties"
-     ]
-    },
-    "type": "object"
    },
    "schemas:9": {
     "x-ms-metadata": {
@@ -709,7 +694,8 @@
      ],
      "name": "components·schemas·petapstring·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapstring·additionalproperties"
+      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapstring·additionalproperties",
+      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapinpropertieswithapstring·additionalproperties"
      ]
     },
     "type": "string"
@@ -790,7 +776,8 @@
      ],
      "name": "components·schemas·petapinproperties·properties·additionalproperties·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapinproperties·properties·additionalproperties·additionalproperties"
+      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapinproperties·properties·additionalproperties·additionalproperties",
+      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties"
      ]
     },
     "type": "number"
@@ -828,7 +815,7 @@
      }
     },
     "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:21"
+     "$ref": "#/components/schemas/schemas:11"
     },
     "required": [
      "id",
@@ -880,38 +867,8 @@
     },
     "type": "object",
     "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:20"
+     "$ref": "#/components/schemas/schemas:15"
     }
-   },
-   "schemas:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties"
-     ]
-    },
-    "type": "number"
-   },
-   "schemas:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "components·schemas·petapinpropertieswithapstring·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/schemas/components·schemas·petapinpropertieswithapstring·additionalproperties"
-     ]
-    },
-    "type": "string"
    }
   },
   "responses": {
@@ -947,7 +904,12 @@
      ],
      "name": "paths·additionalproperties-true·put·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-true·put·responses·default"
+      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-true·put·responses·default",
+      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-true_subclass·put·responses·default",
+      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-type-object·put·responses·default",
+      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-type-string·put·responses·default",
+      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-in-properties·put·responses·default",
+      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-in-properties-with-additionalproperties-string·put·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -981,28 +943,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·additionalproperties-true_subclass·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-true_subclass·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:4": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1021,28 +961,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·additionalproperties-type-object·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-type-object·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -1069,28 +987,6 @@
      }
     }
    },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·additionalproperties-type-string·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-type-string·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:8": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1113,28 +1009,6 @@
      }
     }
    },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·additionalproperties-in-properties·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-in-properties·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:10": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1153,28 +1027,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:16"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·additionalproperties-in-properties-with-additionalproperties-string·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/additionalProperties.json#/components/responses/paths·additionalproperties-in-properties-with-additionalproperties-string·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }

--- a/modelerfour/test/inputs/azure-parameter-grouping/openapi-document.json
+++ b/modelerfour/test/inputs/azure-parameter-grouping/openapi-document.json
@@ -112,21 +112,21 @@
     "description": "Post a bunch of optional parameters grouped",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:3"
+      "$ref": "#/components/parameters/parameters:0"
      },
      {
-      "$ref": "#/components/parameters/parameters:4",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "Query parameter with default"
      }
     ],
     "responses": {
      "200": {
       "description": "Success",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -185,11 +185,11 @@
     "responses": {
      "200": {
       "description": "Success",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -231,21 +231,21 @@
     "description": "Post parameters with a shared parameter group object",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:9"
+      "$ref": "#/components/parameters/parameters:5"
      },
      {
-      "$ref": "#/components/parameters/parameters:10",
+      "$ref": "#/components/parameters/parameters:6",
       "description": "Query parameter with default"
      }
     ],
     "responses": {
      "200": {
       "description": "Success",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -305,7 +305,12 @@
      ],
      "name": "paths·parametergrouping-postrequired-path·post·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postrequired-path·post·parameters·0·schema"
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postrequired-path·post·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postrequired-path·post·parameters·2·schema",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postoptional·post·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postmultipleparametergroups·post·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postmultipleparametergroups·post·parameters·2·schema",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-sharedparametergroupobject·post·parameters·0·schema"
      ]
     },
     "type": "string"
@@ -320,149 +325,10 @@
      ],
      "name": "paths·parametergrouping-postrequired-path·post·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postrequired-path·post·parameters·1·schema"
-     ]
-    },
-    "format": "int32",
-    "default": 30,
-    "type": "integer"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postrequired-path·post·parameters·2·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postrequired-path·post·parameters·2·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postoptional·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postoptional·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postoptional·post·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postoptional·post·parameters·1·schema"
-     ]
-    },
-    "format": "int32",
-    "default": 30,
-    "type": "integer"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postmultipleparametergroups·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postmultipleparametergroups·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postmultipleparametergroups·post·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postmultipleparametergroups·post·parameters·1·schema"
-     ]
-    },
-    "format": "int32",
-    "default": 30,
-    "type": "integer"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postmultipleparametergroups·post·parameters·2·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postmultipleparametergroups·post·parameters·2·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postmultipleparametergroups·post·parameters·3·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postmultipleparametergroups·post·parameters·3·schema"
-     ]
-    },
-    "format": "int32",
-    "default": 30,
-    "type": "integer"
-   },
-   "schemas:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-sharedparametergroupobject·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-sharedparametergroupobject·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-sharedparametergroupobject·post·parameters·1·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postrequired-path·post·parameters·1·schema",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postoptional·post·parameters·1·schema",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postmultipleparametergroups·post·parameters·1·schema",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-postmultipleparametergroups·post·parameters·3·schema",
       "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/schemas/paths·parametergrouping-sharedparametergroupobject·post·parameters·1·schema"
      ]
     },
@@ -521,7 +387,8 @@
      ],
      "name": "paths·parametergrouping-postrequired-path·post·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postrequired-path·post·parameters·0"
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postrequired-path·post·parameters·0",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postoptional·post·parameters·0"
      ]
     },
     "name": "customHeader",
@@ -543,7 +410,8 @@
      ],
      "name": "paths·parametergrouping-postrequired-path·post·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postrequired-path·post·parameters·1"
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postrequired-path·post·parameters·1",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postoptional·post·parameters·1"
      ]
     },
     "name": "query",
@@ -574,54 +442,9 @@
     "description": "Path parameter",
     "x-ms-parameter-grouping": {},
     "schema": {
-     "$ref": "#/components/schemas/schemas:3"
+     "$ref": "#/components/schemas/schemas:1"
     },
     "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postoptional·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postoptional·post·parameters·0"
-     ]
-    },
-    "name": "customHeader",
-    "in": "header",
-    "x-ms-parameter-grouping": {},
-    "schema": {
-     "$ref": "#/components/schemas/schemas:4"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postoptional·post·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postoptional·post·parameters·1"
-     ]
-    },
-    "name": "query",
-    "in": "query",
-    "description": "Query parameter with default",
-    "x-ms-parameter-grouping": {},
-    "schema": {
-     "$ref": "#/components/schemas/schemas:5"
-    },
-    "required": false,
     "x-ms-parameter-location": "method"
    },
    "parameters:5": {
@@ -634,7 +457,8 @@
      ],
      "name": "paths·parametergrouping-postmultipleparametergroups·post·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postmultipleparametergroups·post·parameters·0"
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postmultipleparametergroups·post·parameters·0",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-sharedparametergroupobject·post·parameters·0"
      ]
     },
     "name": "header-one",
@@ -643,7 +467,7 @@
      "name": "first-parameter-group"
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:6"
+     "$ref": "#/components/schemas/schemas:1"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -658,7 +482,8 @@
      ],
      "name": "paths·parametergrouping-postmultipleparametergroups·post·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postmultipleparametergroups·post·parameters·1"
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-postmultipleparametergroups·post·parameters·1",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-sharedparametergroupobject·post·parameters·1"
      ]
     },
     "name": "query-one",
@@ -668,7 +493,7 @@
      "name": "first-parameter-group"
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:7"
+     "$ref": "#/components/schemas/schemas:2"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -692,7 +517,7 @@
      "postfix": "second-param-group"
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:8"
+     "$ref": "#/components/schemas/schemas:1"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -717,56 +542,7 @@
      "postfix": "second-param-group"
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:9"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-sharedparametergroupobject·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-sharedparametergroupobject·post·parameters·0"
-     ]
-    },
-    "name": "header-one",
-    "in": "header",
-    "x-ms-parameter-grouping": {
-     "name": "first-parameter-group"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:10"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-sharedparametergroupobject·post·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/parameters/paths·parametergrouping-sharedparametergroupobject·post·parameters·1"
-     ]
-    },
-    "name": "query-one",
-    "in": "query",
-    "description": "Query parameter with default",
-    "x-ms-parameter-grouping": {
-     "name": "first-parameter-group"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:11"
+     "$ref": "#/components/schemas/schemas:2"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -783,7 +559,10 @@
      ],
      "name": "paths·parametergrouping-postrequired-path·post·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postrequired-path·post·responses·200"
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postrequired-path·post·responses·200",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postoptional·post·responses·200",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postmultipleparametergroups·post·responses·200",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-sharedparametergroupobject·post·responses·200"
      ]
     },
     "description": "Success"
@@ -798,117 +577,9 @@
      ],
      "name": "paths·parametergrouping-postrequired-path·post·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postrequired-path·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:12"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postoptional·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postoptional·post·responses·200"
-     ]
-    },
-    "description": "Success"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postoptional·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postoptional·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:12"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postmultipleparametergroups·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postmultipleparametergroups·post·responses·200"
-     ]
-    },
-    "description": "Success"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-postmultipleparametergroups·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postmultipleparametergroups·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:12"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-sharedparametergroupobject·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-sharedparametergroupobject·post·responses·200"
-     ]
-    },
-    "description": "Success"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·parametergrouping-sharedparametergroupobject·post·responses·default",
-     "originalLocations": [
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postrequired-path·post·responses·default",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postoptional·post·responses·default",
+      "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-postmultipleparametergroups·post·responses·default",
       "http://localhost:3000/swagger/azure-parameter-grouping.json#/components/responses/paths·parametergrouping-sharedparametergroupobject·post·responses·default"
      ]
     },

--- a/modelerfour/test/inputs/azure-resource-x/openapi-document.json
+++ b/modelerfour/test/inputs/azure-resource-x/openapi-document.json
@@ -97,7 +97,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -148,11 +148,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -188,7 +188,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -239,11 +239,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -279,7 +279,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -402,11 +402,10 @@
      "filename": [
       "mem:///94?oai3.shaken.json"
      ],
-     "name": "ResourceCollection-dictionaryofresources",
+     "name": "paths·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema",
      "originalLocations": [
       "http://localhost:3000/swagger/azure-resource-x.json#/components/schemas/paths·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema",
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/schemas/paths·azure-resource_flatten-dictionary·get·responses·200·content·application-json·schema",
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/schemas/ResourceCollection-dictionaryofresources"
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/schemas/paths·azure-resource_flatten-dictionary·get·responses·200·content·application-json·schema"
      ]
     },
     "type": "object",
@@ -703,7 +702,7 @@
       "$ref": "#/components/schemas/schemas:18"
      },
      "dictionaryofresources": {
-      "$ref": "#/components/schemas/schemas:2"
+      "$ref": "#/components/schemas/schemas:19"
      }
     }
    },
@@ -724,6 +723,24 @@
     "items": {
      "$ref": "#/components/schemas/schemas:13"
     }
+   },
+   "schemas:19": {
+    "x-ms-metadata": {
+     "apiVersions": [
+      "1.0.0"
+     ],
+     "filename": [
+      "mem:///94?oai3.shaken.json"
+     ],
+     "name": "ResourceCollection-dictionaryofresources",
+     "originalLocations": [
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/schemas/ResourceCollection-dictionaryofresources"
+     ]
+    },
+    "type": "object",
+    "additionalProperties": {
+     "$ref": "#/components/schemas/schemas:13"
+    }
    }
   },
   "responses": {
@@ -737,7 +754,9 @@
      ],
      "name": "paths·azure-resource_flatten-array·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-array·put·responses·200"
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-array·put·responses·200",
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-dictionary·put·responses·200",
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-resourcecollection·put·responses·200"
      ]
     },
     "description": "Successful Response"
@@ -752,7 +771,12 @@
      ],
      "name": "paths·azure-resource_flatten-array·put·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-array·put·responses·default"
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-array·put·responses·default",
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-array·get·responses·default",
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-dictionary·put·responses·default",
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-dictionary·get·responses·default",
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-resourcecollection·put·responses·default",
+      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-resourcecollection·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -786,65 +810,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-array·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-array·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-dictionary·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-dictionary·put·responses·200"
-     ]
-    },
-    "description": "Successful Response"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-dictionary·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-dictionary·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
    "responses:6": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -867,65 +832,6 @@
      }
     }
    },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-dictionary·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-dictionary·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-resourcecollection·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-resourcecollection·put·responses·200"
-     ]
-    },
-    "description": "Successful Response"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-resourcecollection·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-resourcecollection·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
    "responses:10": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -944,28 +850,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:17"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-resourcecollection·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource-x.json#/components/responses/paths·azure-resource_flatten-resourcecollection·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
       }
      }
     }

--- a/modelerfour/test/inputs/azure-resource/openapi-document.json
+++ b/modelerfour/test/inputs/azure-resource/openapi-document.json
@@ -97,7 +97,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -148,11 +148,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -188,7 +188,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -239,11 +239,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -279,7 +279,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -402,11 +402,10 @@
      "filename": [
       "mem:///94?oai3.shaken.json"
      ],
-     "name": "ResourceCollection-dictionaryofresources",
+     "name": "paths·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema",
      "originalLocations": [
       "http://localhost:3000/swagger/azure-resource.json#/components/schemas/paths·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema",
-      "http://localhost:3000/swagger/azure-resource.json#/components/schemas/paths·azure-resource_flatten-dictionary·get·responses·200·content·application-json·schema",
-      "http://localhost:3000/swagger/azure-resource.json#/components/schemas/ResourceCollection-dictionaryofresources"
+      "http://localhost:3000/swagger/azure-resource.json#/components/schemas/paths·azure-resource_flatten-dictionary·get·responses·200·content·application-json·schema"
      ]
     },
     "type": "object",
@@ -703,7 +702,7 @@
       "$ref": "#/components/schemas/schemas:18"
      },
      "dictionaryofresources": {
-      "$ref": "#/components/schemas/schemas:2"
+      "$ref": "#/components/schemas/schemas:19"
      }
     }
    },
@@ -724,6 +723,24 @@
     "items": {
      "$ref": "#/components/schemas/schemas:13"
     }
+   },
+   "schemas:19": {
+    "x-ms-metadata": {
+     "apiVersions": [
+      "1.0.0"
+     ],
+     "filename": [
+      "mem:///94?oai3.shaken.json"
+     ],
+     "name": "ResourceCollection-dictionaryofresources",
+     "originalLocations": [
+      "http://localhost:3000/swagger/azure-resource.json#/components/schemas/ResourceCollection-dictionaryofresources"
+     ]
+    },
+    "type": "object",
+    "additionalProperties": {
+     "$ref": "#/components/schemas/schemas:13"
+    }
    }
   },
   "responses": {
@@ -737,7 +754,9 @@
      ],
      "name": "paths·azure-resource_flatten-array·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-array·put·responses·200"
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-array·put·responses·200",
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-dictionary·put·responses·200",
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-resourcecollection·put·responses·200"
      ]
     },
     "description": "Successful Response"
@@ -752,7 +771,12 @@
      ],
      "name": "paths·azure-resource_flatten-array·put·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-array·put·responses·default"
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-array·put·responses·default",
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-array·get·responses·default",
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-dictionary·put·responses·default",
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-dictionary·get·responses·default",
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-resourcecollection·put·responses·default",
+      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-resourcecollection·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -786,65 +810,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-array·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-array·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-dictionary·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-dictionary·put·responses·200"
-     ]
-    },
-    "description": "Successful Response"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-dictionary·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-dictionary·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
    "responses:6": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -867,65 +832,6 @@
      }
     }
    },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-dictionary·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-dictionary·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-resourcecollection·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-resourcecollection·put·responses·200"
-     ]
-    },
-    "description": "Successful Response"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-resourcecollection·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-resourcecollection·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
    "responses:10": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -944,28 +850,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:17"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azure-resource_flatten-resourcecollection·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-resource.json#/components/responses/paths·azure-resource_flatten-resourcecollection·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
       }
      }
     }

--- a/modelerfour/test/inputs/azure-special-properties/openapi-document.json
+++ b/modelerfour/test/inputs/azure-special-properties/openapi-document.json
@@ -56,7 +56,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:1"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -108,7 +108,7 @@
     "responses": {
      "200": {
       "description": "Successfully received the '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0' x-ms-client-request header",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
@@ -163,11 +163,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '1234-5678-9012-3456' credential value from credentials",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -218,11 +218,11 @@
     "responses": {
      "200": {
       "description": "This should never occur - you should be prevented from calling this method with null subscription Id in credentials",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -276,11 +276,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '1234-5678-9012-3456' credential value from credentials",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -332,11 +332,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '1234-5678-9012-3456' credential value from the local parameter",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -381,18 +381,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:2",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "This should appear as a method parameter, use value null, client-side validation should prvenet the call"
      }
     ],
     "responses": {
      "200": {
       "description": "You should not reach this response - client side validation should prevent yopu from sending a null subscriptionId",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -438,11 +438,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '1234-5678-9012-3456' credential value from credentials",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:3"
      }
     },
     "parameters": [
@@ -493,11 +493,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '1234-5678-9012-3456' credential value from the local parameter",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:3"
      }
     },
     "parameters": [
@@ -559,11 +559,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '1234-5678-9012-3456' credential value from credentials",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -608,18 +608,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:3",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received the '1234-5678-9012-3456' credential value from the local parameter",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -670,11 +670,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '2015-07-01-preview' api-version value from global client settings",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -725,11 +725,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '2015-07-01-preview' credential value from global client settings",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -781,11 +781,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '2.0' api-version value from the local parameter",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -837,11 +837,11 @@
     "responses": {
      "200": {
       "description": "Successfully received no api-version value from the local parameter",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -887,11 +887,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '2015-07-01-preview' api-version value from global client settings",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:3"
      }
     },
     "parameters": [
@@ -942,11 +942,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '2.0' api-version value from the local parameter",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:3"
      }
     },
     "parameters": [
@@ -1011,11 +1011,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the '2015-07-01-preview' api-version value from global client settings",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1060,18 +1060,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:6",
+      "$ref": "#/components/parameters/parameters:4",
       "description": "The api version, which appears in the query, the value is always '2.0'"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received the '2.0' api-version value from the local parameter",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1123,11 +1123,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the path parameter with value 'path1/path2/path3'",
-      "$ref": "#/components/responses/responses:38"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1173,11 +1173,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the path parameter with value 'path1/path2/path3'",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:3"
      }
     },
     "parameters": [
@@ -1241,11 +1241,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the path parameter with value 'path1/path2/path3'",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1297,11 +1297,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the unencoded query parameter with value 'value1&q2=value2&q3=value3'",
-      "$ref": "#/components/responses/responses:44"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1353,11 +1353,11 @@
     "responses": {
      "200": {
       "description": "Successfully received no query parameter",
-      "$ref": "#/components/responses/responses:46"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:47"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1403,11 +1403,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the unencoded query parameter with value 'value1&q2=value2&q3=value3'",
-      "$ref": "#/components/responses/responses:48"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:49"
+      "$ref": "#/components/responses/responses:3"
      }
     },
     "parameters": [
@@ -1471,11 +1471,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the unencoded query parameter with value 'value1&q2=value2&q3=value3'",
-      "$ref": "#/components/responses/responses:50"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1535,11 +1535,11 @@
     "responses": {
      "200": {
       "description": "Successfully received filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'",
-      "$ref": "#/components/responses/responses:52"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:53"
+      "$ref": "#/components/responses/responses:3"
      }
     },
     "x-ms-odata": "#/components/schemas/OdataFilter"
@@ -1597,7 +1597,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:55"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1650,11 +1650,11 @@
     "responses": {
      "200": {
       "description": "Gets the foo-request-id",
-      "$ref": "#/components/responses/responses:56"
+      "$ref": "#/components/responses/responses:54"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1696,7 +1696,7 @@
     "description": "Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:17",
+      "$ref": "#/components/parameters/parameters:15",
       "description": "The fooRequestId"
      }
     ],
@@ -1707,15 +1707,15 @@
     "responses": {
      "200": {
       "description": "Gets the foo-request-id",
-      "$ref": "#/components/responses/responses:58"
+      "$ref": "#/components/responses/responses:54"
      },
      "404": {
       "description": "Gets the foo-request-id",
-      "$ref": "#/components/responses/responses:59"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:60"
+      "$ref": "#/components/responses/responses:3"
      }
     }
    }
@@ -1733,37 +1733,35 @@
      ],
      "name": "paths·azurespecials-overwrite-x_ms_client_request_id-method·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-overwrite-x_ms_client_request_id-method·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0' x-ms-client-request header"
-   },
-   "responses:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-overwrite-x_ms_client_request_id-method·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-overwrite-x_ms_client_request_id-method·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·responses·200"
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-overwrite-x_ms_client_request_id-method·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-overwrite-x_ms_client_request_id-method·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-global-null-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-globalnotprovided-1234_5678_9012_3456-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-path-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-path-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-swagger-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-global-2015_07_01_preview·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-globalnotprovided-2015_07_01_preview·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-local-null·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-path-string-none-query-global-2015_07_01_preview·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-path-string-none-query-local-2-0·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-swagger-string-none-query-global-2015_07_01_preview·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-path-path-valid-unencodedpathparam·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-swagger-path-valid-unencodedpathparam·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-query-valid·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-query-null·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-path-query-valid·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-swagger-query-valid·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-odata-filter·get·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidhead·head·responses·404"
      ]
     },
     "description": "Successfully received the '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0' x-ms-client-request header"
@@ -1778,932 +1776,35 @@
      ],
      "name": "paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the '1234-5678-9012-3456' credential value from credentials"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-global-null-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-global-null-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "This should never occur - you should be prevented from calling this method with null subscription Id in credentials"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-global-null-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-global-null-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-globalnotprovided-1234_5678_9012_3456-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-globalnotprovided-1234_5678_9012_3456-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the '1234-5678-9012-3456' credential value from credentials"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-globalnotprovided-1234_5678_9012_3456-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-globalnotprovided-1234_5678_9012_3456-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the '1234-5678-9012-3456' credential value from the local parameter"
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "You should not reach this response - client side validation should prevent yopu from sending a null subscriptionId"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-path-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-path-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the '1234-5678-9012-3456' credential value from credentials"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-path-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-path-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-path-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-path-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the '1234-5678-9012-3456' credential value from the local parameter"
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-path-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-path-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-swagger-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-swagger-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the '1234-5678-9012-3456' credential value from credentials"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-swagger-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-swagger-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the '1234-5678-9012-3456' credential value from the local parameter"
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-global-2015_07_01_preview·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-global-2015_07_01_preview·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the '2015-07-01-preview' api-version value from global client settings"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-global-2015_07_01_preview·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-global-2015_07_01_preview·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-globalnotprovided-2015_07_01_preview·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-globalnotprovided-2015_07_01_preview·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the '2015-07-01-preview' credential value from global client settings"
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-globalnotprovided-2015_07_01_preview·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-globalnotprovided-2015_07_01_preview·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the '2.0' api-version value from the local parameter"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-local-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-local-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received no api-version value from the local parameter"
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-local-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-local-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-path-string-none-query-global-2015_07_01_preview·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-path-string-none-query-global-2015_07_01_preview·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the '2015-07-01-preview' api-version value from global client settings"
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-path-string-none-query-global-2015_07_01_preview·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-path-string-none-query-global-2015_07_01_preview·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-path-string-none-query-local-2-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-path-string-none-query-local-2-0·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the '2.0' api-version value from the local parameter"
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-path-string-none-query-local-2-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-path-string-none-query-local-2-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-swagger-string-none-query-global-2015_07_01_preview·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-swagger-string-none-query-global-2015_07_01_preview·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the '2015-07-01-preview' api-version value from global client settings"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-swagger-string-none-query-global-2015_07_01_preview·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-swagger-string-none-query-global-2015_07_01_preview·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the '2.0' api-version value from the local parameter"
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the path parameter with value 'path1/path2/path3'"
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-path-path-valid-unencodedpathparam·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-path-path-valid-unencodedpathparam·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the path parameter with value 'path1/path2/path3'"
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-path-path-valid-unencodedpathparam·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-path-path-valid-unencodedpathparam·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-swagger-path-valid-unencodedpathparam·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-swagger-path-valid-unencodedpathparam·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the path parameter with value 'path1/path2/path3'"
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-swagger-path-valid-unencodedpathparam·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-swagger-path-valid-unencodedpathparam·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-query-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-query-valid·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the unencoded query parameter with value 'value1&q2=value2&q3=value3'"
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-query-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-query-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-query-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-query-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received no query parameter"
-   },
-   "responses:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-query-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-query-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-path-query-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-path-query-valid·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the unencoded query parameter with value 'value1&q2=value2&q3=value3'"
-   },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-path-query-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-path-query-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-swagger-query-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-swagger-query-valid·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the unencoded query parameter with value 'value1&q2=value2&q3=value3'"
-   },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-swagger-query-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-swagger-query-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-odata-filter·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-odata-filter·get·responses·200"
-     ]
-    },
-    "description": "Successfully received filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'"
-   },
-   "responses:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-odata-filter·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-odata-filter·get·responses·default"
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-global-null-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-globalnotprovided-1234_5678_9012_3456-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-path-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-path-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-swagger-string-none-path-global-1234_5678_9012_3456-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-global-2015_07_01_preview·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-globalnotprovided-2015_07_01_preview·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-method-string-none-query-local-null·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-path-string-none-query-global-2015_07_01_preview·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-path-string-none-query-local-2-0·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-swagger-string-none-query-global-2015_07_01_preview·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-path-path-valid-unencodedpathparam·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-swagger-path-valid-unencodedpathparam·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-query-valid·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-method-query-null·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-path-query-valid·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-skipurlencoding-swagger-query-valid·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-odata-filter·get·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestid·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidparamgrouping·post·responses·default",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidhead·head·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -2725,92 +1826,8 @@
      ],
      "name": "paths·azurespecials-customnamedrequestid·post·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestid·post·responses·200"
-     ]
-    },
-    "description": "Gets the foo-request-id",
-    "headers": {
-     "foo-request-id": {
-      "description": "Gets the foo-request-id.",
-      "$ref": "#/components/headers/headers:0"
-     }
-    }
-   },
-   "responses:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestid·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestid·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200"
-     ]
-    },
-    "description": "Gets the foo-request-id",
-    "headers": {
-     "foo-request-id": {
-      "description": "Gets the foo-request-id.",
-      "$ref": "#/components/headers/headers:1"
-     }
-    }
-   },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidparamgrouping·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidparamgrouping·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidhead·head·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestid·post·responses·200",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200",
       "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidhead·head·responses·200"
      ]
     },
@@ -2818,44 +1835,7 @@
     "headers": {
      "foo-request-id": {
       "description": "Gets the foo-request-id.",
-      "$ref": "#/components/headers/headers:2"
-     }
-    }
-   },
-   "responses:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidhead·head·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidhead·head·responses·404"
-     ]
-    },
-    "description": "Gets the foo-request-id"
-   },
-   "responses:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidhead·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/responses/paths·azurespecials-customnamedrequestidhead·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
+      "$ref": "#/components/headers/headers:0"
      }
     }
    }
@@ -2878,7 +1858,7 @@
     "in": "header",
     "description": "This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'",
     "schema": {
-     "$ref": "#/components/schemas/schemas:0"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2893,58 +1873,16 @@
      ],
      "name": "paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0"
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·parameters·0",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0"
      ]
     },
     "name": "subscriptionId",
     "in": "path",
     "description": "This should appear as a method parameter, use value '1234-5678-9012-3456'",
     "schema": {
-     "$ref": "#/components/schemas/schemas:1"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·parameters·0"
-     ]
-    },
-    "name": "subscriptionId",
-    "in": "path",
-    "description": "This should appear as a method parameter, use value null, client-side validation should prvenet the call",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:2"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0"
-     ]
-    },
-    "name": "subscriptionId",
-    "in": "path",
-    "description": "The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:3"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2959,7 +1897,8 @@
      ],
      "name": "paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·parameters·0"
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-apiversion-method-string-none-query-local-2-0·get·parameters·0",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·parameters·0"
      ]
     },
     "name": "api-version",
@@ -2991,33 +1930,8 @@
     "in": "query",
     "description": "This should appear as a method parameter, use value null, this should result in no serialized parameter",
     "schema": {
-     "$ref": "#/components/schemas/schemas:4"
+     "$ref": "#/components/schemas/schemas:12"
     },
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-apiversion-swagger-string-none-query-local-2-0·get·parameters·0"
-     ]
-    },
-    "name": "api-version",
-    "in": "query",
-    "description": "The api version, which appears in the query, the value is always '2.0'",
-    "schema": {
-     "enum": [
-      "2.0"
-     ],
-     "type": "string"
-    },
-    "required": true,
     "x-ms-parameter-location": "method"
    },
    "parameters:7": {
@@ -3038,7 +1952,7 @@
     "description": "Unencoded path parameter with value 'path1/path2/path3'",
     "x-ms-skip-url-encoding": true,
     "schema": {
-     "$ref": "#/components/schemas/schemas:5"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -3087,7 +2001,7 @@
     "description": "Unencoded query parameter with value 'value1&q2=value2&q3=value3'",
     "allowReserved": true,
     "schema": {
-     "$ref": "#/components/schemas/schemas:6"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -3110,7 +2024,7 @@
     "description": "Unencoded query parameter with value null",
     "allowReserved": true,
     "schema": {
-     "$ref": "#/components/schemas/schemas:7"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "x-ms-parameter-location": "method"
    },
@@ -3157,7 +2071,7 @@
     "in": "query",
     "description": "The filter parameter with value '$filter=id gt 5 and name eq 'foo''.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:8"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -3201,7 +2115,7 @@
     "in": "query",
     "description": "The orderby parameter with value id.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:10"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -3216,7 +2130,8 @@
      ],
      "name": "paths·azurespecials-customnamedrequestid·post·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-customnamedrequestid·post·parameters·0"
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-customnamedrequestid·post·parameters·0",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-customnamedrequestidhead·head·parameters·0"
      ]
     },
     "name": "foo-client-request-id",
@@ -3224,7 +2139,7 @@
     "description": "The fooRequestId",
     "x-ms-client-request-id": true,
     "schema": {
-     "$ref": "#/components/schemas/schemas:11"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -3248,30 +2163,7 @@
     "x-ms-parameter-grouping": {},
     "x-ms-client-request-id": true,
     "schema": {
-     "$ref": "#/components/schemas/schemas:13"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidhead·head·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/parameters/paths·azurespecials-customnamedrequestidhead·head·parameters·0"
-     ]
-    },
-    "name": "foo-client-request-id",
-    "in": "header",
-    "description": "The fooRequestId",
-    "x-ms-client-request-id": true,
-    "schema": {
-     "$ref": "#/components/schemas/schemas:15"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -3293,7 +2185,7 @@
     "in": "path",
     "description": "The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'",
     "schema": {
-     "$ref": "#/components/schemas/schemas:17"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true
    },
@@ -3314,147 +2206,12 @@
     "in": "query",
     "description": "The api version, which appears in the query, the value is always '2015-07-01-preview'",
     "schema": {
-     "$ref": "#/components/schemas/schemas:18"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true
    }
   },
   "schemas": {
-   "schemas:0": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-apiversion-method-string-none-query-local-null·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-apiversion-method-string-none-query-local-null·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-query-valid·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-skipurlencoding-method-query-valid·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-skipurlencoding-method-query-null·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-skipurlencoding-method-query-null·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-odata-filter·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-odata-filter·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
    "schemas:9": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3471,36 +2228,6 @@
     "format": "int32",
     "type": "integer"
    },
-   "schemas:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-odata-filter·get·parameters·2·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-odata-filter·get·parameters·2·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestid·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestid·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
    "schemas:12": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3511,96 +2238,23 @@
      ],
      "name": "paths·azurespecials-customnamedrequestid·post·responses·200·headers·foo_request_id·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestid·post·responses·200·headers·foo_request_id·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidparamgrouping·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestidparamgrouping·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200·headers·foo_request_id·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200·headers·foo_request_id·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidhead·head·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestidhead·head·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidhead·head·responses·200·headers·foo_request_id·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestidhead·head·responses·200·headers·foo_request_id·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·globalsubscriptionid·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/components·parameters·globalsubscriptionid·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·globalapiversion·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestid·post·responses·200·headers·foo_request_id·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-apiversion-method-string-none-query-local-null·get·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-skipurlencoding-method-query-valid·get·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-skipurlencoding-method-query-null·get·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-odata-filter·get·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-odata-filter·get·parameters·2·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestid·post·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestidparamgrouping·post·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200·headers·foo_request_id·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestidhead·head·parameters·0·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/paths·azurespecials-customnamedrequestidhead·head·responses·200·headers·foo_request_id·schema",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/components·parameters·globalsubscriptionid·schema",
       "http://localhost:3000/swagger/azure-special-properties.json#/components/schemas/components·parameters·globalapiversion·schema"
      ]
     },
@@ -3705,47 +2359,13 @@
      ],
      "name": "paths·azurespecials-customnamedrequestid·post·responses·200·headers·foo_request_id",
      "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/headers/paths·azurespecials-customnamedrequestid·post·responses·200·headers·foo_request_id"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:12"
-    },
-    "description": "Gets the foo-request-id."
-   },
-   "headers:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200·headers·foo_request_id",
-     "originalLocations": [
-      "http://localhost:3000/swagger/azure-special-properties.json#/components/headers/paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200·headers·foo_request_id"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:14"
-    },
-    "description": "Gets the foo-request-id."
-   },
-   "headers:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-07-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·azurespecials-customnamedrequestidhead·head·responses·200·headers·foo_request_id",
-     "originalLocations": [
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/headers/paths·azurespecials-customnamedrequestid·post·responses·200·headers·foo_request_id",
+      "http://localhost:3000/swagger/azure-special-properties.json#/components/headers/paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200·headers·foo_request_id",
       "http://localhost:3000/swagger/azure-special-properties.json#/components/headers/paths·azurespecials-customnamedrequestidhead·head·responses·200·headers·foo_request_id"
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:16"
+     "$ref": "#/components/schemas/schemas:12"
     },
     "description": "Gets the foo-request-id."
    }

--- a/modelerfour/test/inputs/body-array/openapi-document.json
+++ b/modelerfour/test/inputs/body-array/openapi-document.json
@@ -106,7 +106,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -152,11 +152,11 @@
     "responses": {
      "200": {
       "description": "The empty array value []",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -196,7 +196,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -246,7 +246,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -282,11 +282,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -332,11 +332,11 @@
     "responses": {
      "200": {
       "description": "The array value [true, null, false]",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -382,11 +382,11 @@
     "responses": {
      "200": {
       "description": "The array value [true, 'boolean', false]",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -432,11 +432,11 @@
     "responses": {
      "200": {
       "description": "The array value [1, -1, 3, 300]",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -472,11 +472,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -522,11 +522,11 @@
     "responses": {
      "200": {
       "description": "The array value [1, null, 0]",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -572,11 +572,11 @@
     "responses": {
      "200": {
       "description": "The array value [1, 'integer', 0]",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -626,7 +626,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -662,11 +662,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -712,11 +712,11 @@
     "responses": {
      "200": {
       "description": "The array value [1, null, 0]",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:24"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -762,11 +762,11 @@
     "responses": {
      "200": {
       "description": "The array value [1, 'integer', 0]",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:24"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -816,7 +816,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -852,11 +852,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -902,11 +902,11 @@
     "responses": {
      "200": {
       "description": "The array value [0.0, null, -1.2e20]",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:32"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -952,11 +952,11 @@
     "responses": {
      "200": {
       "description": "The array value [1.0, 'number', 0.0]",
-      "$ref": "#/components/responses/responses:38"
+      "$ref": "#/components/responses/responses:32"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1006,7 +1006,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1042,11 +1042,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1092,11 +1092,11 @@
     "responses": {
      "200": {
       "description": "The array value [0.0, null, -1.2e20]",
-      "$ref": "#/components/responses/responses:44"
+      "$ref": "#/components/responses/responses:40"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1142,11 +1142,11 @@
     "responses": {
      "200": {
       "description": "The array value [1.0, 'number', 0.0]",
-      "$ref": "#/components/responses/responses:46"
+      "$ref": "#/components/responses/responses:40"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:47"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1196,7 +1196,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:49"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1232,11 +1232,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:50"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1286,7 +1286,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:53"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1322,11 +1322,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:54"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:55"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1376,7 +1376,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1412,11 +1412,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:58"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:59"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1462,11 +1462,11 @@
     "responses": {
      "200": {
       "description": "The array value ['foo', null, 'foo2']",
-      "$ref": "#/components/responses/responses:60"
+      "$ref": "#/components/responses/responses:48"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:61"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1512,11 +1512,11 @@
     "responses": {
      "200": {
       "description": "The array value ['foo', 123, 'foo2']",
-      "$ref": "#/components/responses/responses:62"
+      "$ref": "#/components/responses/responses:48"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:63"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1566,7 +1566,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:65"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1602,11 +1602,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:66"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:67"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1652,11 +1652,11 @@
     "responses": {
      "200": {
       "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']",
-      "$ref": "#/components/responses/responses:68"
+      "$ref": "#/components/responses/responses:64"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:69"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1706,7 +1706,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:71"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1742,11 +1742,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:72"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:73"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1792,11 +1792,11 @@
     "responses": {
      "200": {
       "description": "The array value ['2012-01-01', null, '1776-07-04']",
-      "$ref": "#/components/responses/responses:74"
+      "$ref": "#/components/responses/responses:70"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:75"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1842,11 +1842,11 @@
     "responses": {
      "200": {
       "description": "The array value ['2011-03-22', 'date']",
-      "$ref": "#/components/responses/responses:76"
+      "$ref": "#/components/responses/responses:70"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:77"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1896,7 +1896,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:79"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1932,11 +1932,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:80"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:81"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1982,11 +1982,11 @@
     "responses": {
      "200": {
       "description": "The array value ['2000-12-01t00:00:01z', null]",
-      "$ref": "#/components/responses/responses:82"
+      "$ref": "#/components/responses/responses:78"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:83"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2032,11 +2032,11 @@
     "responses": {
      "200": {
       "description": "The array value ['2000-12-01t00:00:01z', 'date-time']",
-      "$ref": "#/components/responses/responses:84"
+      "$ref": "#/components/responses/responses:78"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:85"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2086,7 +2086,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:87"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2122,11 +2122,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:88"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:89"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2176,7 +2176,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:91"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2212,11 +2212,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:92"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:93"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2266,7 +2266,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:95"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2302,11 +2302,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:96"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:97"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2352,11 +2352,11 @@
     "responses": {
      "200": {
       "description": "The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded",
-      "$ref": "#/components/responses/responses:98"
+      "$ref": "#/components/responses/responses:94"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:99"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2406,7 +2406,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:101"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2456,7 +2456,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:103"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2502,11 +2502,11 @@
     "responses": {
      "200": {
       "description": "Empty array of complex type []",
-      "$ref": "#/components/responses/responses:104"
+      "$ref": "#/components/responses/responses:102"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:105"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2552,11 +2552,11 @@
     "responses": {
      "200": {
       "description": "Array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]",
-      "$ref": "#/components/responses/responses:106"
+      "$ref": "#/components/responses/responses:102"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:107"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2602,11 +2602,11 @@
     "responses": {
      "200": {
       "description": "Array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]",
-      "$ref": "#/components/responses/responses:108"
+      "$ref": "#/components/responses/responses:102"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:109"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2652,11 +2652,11 @@
     "responses": {
      "200": {
       "description": "array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
-      "$ref": "#/components/responses/responses:110"
+      "$ref": "#/components/responses/responses:102"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:111"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2692,11 +2692,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:112"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:113"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2746,7 +2746,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:115"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2792,11 +2792,11 @@
     "responses": {
      "200": {
       "description": "An empty array []",
-      "$ref": "#/components/responses/responses:116"
+      "$ref": "#/components/responses/responses:114"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:117"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2842,11 +2842,11 @@
     "responses": {
      "200": {
       "description": "An array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]",
-      "$ref": "#/components/responses/responses:118"
+      "$ref": "#/components/responses/responses:114"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:119"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2892,11 +2892,11 @@
     "responses": {
      "200": {
       "description": "An array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]",
-      "$ref": "#/components/responses/responses:120"
+      "$ref": "#/components/responses/responses:114"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:121"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2942,11 +2942,11 @@
     "responses": {
      "200": {
       "description": "An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]",
-      "$ref": "#/components/responses/responses:122"
+      "$ref": "#/components/responses/responses:114"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:123"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2982,11 +2982,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:124"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:125"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3036,7 +3036,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:127"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3082,11 +3082,11 @@
     "responses": {
      "200": {
       "description": "An array of Dictionaries of type <string, string> with value []",
-      "$ref": "#/components/responses/responses:128"
+      "$ref": "#/components/responses/responses:126"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:129"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3132,11 +3132,11 @@
     "responses": {
      "200": {
       "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-      "$ref": "#/components/responses/responses:130"
+      "$ref": "#/components/responses/responses:126"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:131"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3182,11 +3182,11 @@
     "responses": {
      "200": {
       "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-      "$ref": "#/components/responses/responses:132"
+      "$ref": "#/components/responses/responses:126"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:133"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3232,11 +3232,11 @@
     "responses": {
      "200": {
       "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-      "$ref": "#/components/responses/responses:134"
+      "$ref": "#/components/responses/responses:126"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:135"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3272,11 +3272,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:136"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:137"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3317,7 +3317,75 @@
      ],
      "name": "paths·array-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-null·get·responses·default"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-null·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-invalid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-empty·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-tfft·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-tfft·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-true-null-false·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-true-boolean-false·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-_1-3-300·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-_1-3-300·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-null-zero·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-integer-0·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-_1-3-300·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-_1-3-300·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-null-zero·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-integer-0·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0_0-01_1-2e20·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0_0-01_1-2e20·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0-0_null_1-2e20·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-1-number-0·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0_0-01_1-2e20·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0_0-01_1-2e20·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0-0_null_1-2e20·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-1-number-0·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo1-foo2-foo3·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo1-foo2-foo3·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-enum-foo1-foo2-foo3·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-enum-foo1-foo2-foo3·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string_enum-foo1-foo2-foo3·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo-null-foo2·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo-123-foo2·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-invalidchars·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-invalidnull·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-invalidchars·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-invalidnull·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-invalidchars·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time_rfc1123-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time_rfc1123-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-duration-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-duration-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-invalidnull·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-base64url-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-null·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-itemnull·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-itemempty·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-null·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-itemnull·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-itemempty·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-null·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-itemnull·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-itemempty·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-valid·put·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -3339,7 +3407,11 @@
      ],
      "name": "paths·array-invalid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-invalid·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-invalid·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-_1-3-300·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-null-zero·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-integer-0·get·responses·200"
      ]
     },
     "description": "The invalid Array [1, 2, 3",
@@ -3348,73 +3420,6 @@
       "schema": {
        "description": "The invalid Array [1, 2, 3",
        "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-empty·get·responses·200"
-     ]
-    },
-    "description": "The empty array value []",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The empty array value []",
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -3429,32 +3434,27 @@
      ],
      "name": "paths·array-empty·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-empty·put·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-empty·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-tfft·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-_1-3-300·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-_1-3-300·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0_0-01_1-2e20·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0_0-01_1-2e20·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo1-foo2-foo3·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-enum-foo1-foo2-foo3·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string_enum-foo1-foo2-foo3·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time_rfc1123-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-duration-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-valid·put·responses·200"
      ]
     },
     "description": "Empty Response"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-empty·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-empty·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
    },
    "responses:8": {
     "x-ms-metadata": {
@@ -3466,7 +3466,9 @@
      ],
      "name": "paths·array-prim-boolean-tfft·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-tfft·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-tfft·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-true-null-false·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-true-boolean-false·get·responses·200"
      ]
     },
     "description": "The array value [true, false, false, true]",
@@ -3475,327 +3477,6 @@
       "schema": {
        "description": "The array value [true, false, false, true]",
        "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-tfft·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-tfft·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-tfft·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-tfft·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-tfft·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-tfft·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-true-null-false·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-true-null-false·get·responses·200"
-     ]
-    },
-    "description": "The array value [true, null, false]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [true, null, false]",
-       "$ref": "#/components/schemas/schemas:12"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-true-null-false·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-true-null-false·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-true-boolean-false·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-true-boolean-false·get·responses·200"
-     ]
-    },
-    "description": "The array value [true, 'boolean', false]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [true, 'boolean', false]",
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-true-boolean-false·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-boolean-true-boolean-false·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-_1-3-300·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-_1-3-300·get·responses·200"
-     ]
-    },
-    "description": "The array value [1, -1, 3, 300]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [1, -1, 3, 300]",
-       "$ref": "#/components/schemas/schemas:16"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-_1-3-300·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-_1-3-300·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-_1-3-300·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-_1-3-300·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-_1-3-300·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-_1-3-300·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-null-zero·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-null-zero·get·responses·200"
-     ]
-    },
-    "description": "The array value [1, null, 0]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [1, null, 0]",
-       "$ref": "#/components/schemas/schemas:20"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-null-zero·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-null-zero·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-integer-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-integer-0·get·responses·200"
-     ]
-    },
-    "description": "The array value [1, 'integer', 0]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [1, 'integer', 0]",
-       "$ref": "#/components/schemas/schemas:22"
-      }
-     }
-    }
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-integer-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-integer-1-integer-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -3810,7 +3491,9 @@
      ],
      "name": "paths·array-prim-long-1-_1-3-300·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-_1-3-300·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-_1-3-300·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-null-zero·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-integer-0·get·responses·200"
      ]
     },
     "description": "The array value [1, -1, 3, 300]",
@@ -3819,155 +3502,6 @@
       "schema": {
        "description": "The array value [1, -1, 3, 300]",
        "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-_1-3-300·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-_1-3-300·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-_1-3-300·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-_1-3-300·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-_1-3-300·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-_1-3-300·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-null-zero·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-null-zero·get·responses·200"
-     ]
-    },
-    "description": "The array value [1, null, 0]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [1, null, 0]",
-       "$ref": "#/components/schemas/schemas:28"
-      }
-     }
-    }
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-null-zero·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-null-zero·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-integer-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-integer-0·get·responses·200"
-     ]
-    },
-    "description": "The array value [1, 'integer', 0]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [1, 'integer', 0]",
-       "$ref": "#/components/schemas/schemas:30"
-      }
-     }
-    }
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-integer-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-long-1-integer-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -3982,7 +3516,9 @@
      ],
      "name": "paths·array-prim-float-0_0-01_1-2e20·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0_0-01_1-2e20·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0_0-01_1-2e20·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0-0_null_1-2e20·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-1-number-0·get·responses·200"
      ]
     },
     "description": "The array value [0, -0.01, 1.2e20]",
@@ -3991,155 +3527,6 @@
       "schema": {
        "description": "The array value [0, -0.01, 1.2e20]",
        "$ref": "#/components/schemas/schemas:32"
-      }
-     }
-    }
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0_0-01_1-2e20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0_0-01_1-2e20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0_0-01_1-2e20·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0_0-01_1-2e20·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0_0-01_1-2e20·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0_0-01_1-2e20·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0-0_null_1-2e20·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0-0_null_1-2e20·get·responses·200"
-     ]
-    },
-    "description": "The array value [0.0, null, -1.2e20]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [0.0, null, -1.2e20]",
-       "$ref": "#/components/schemas/schemas:36"
-      }
-     }
-    }
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0-0_null_1-2e20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-0-0_null_1-2e20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-1-number-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-1-number-0·get·responses·200"
-     ]
-    },
-    "description": "The array value [1.0, 'number', 0.0]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [1.0, 'number', 0.0]",
-       "$ref": "#/components/schemas/schemas:38"
-      }
-     }
-    }
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-1-number-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-float-1-number-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -4154,7 +3541,9 @@
      ],
      "name": "paths·array-prim-double-0_0-01_1-2e20·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0_0-01_1-2e20·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0_0-01_1-2e20·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0-0_null_1-2e20·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-1-number-0·get·responses·200"
      ]
     },
     "description": "The array value [0, -0.01, 1.2e20]",
@@ -4163,155 +3552,6 @@
       "schema": {
        "description": "The array value [0, -0.01, 1.2e20]",
        "$ref": "#/components/schemas/schemas:40"
-      }
-     }
-    }
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0_0-01_1-2e20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0_0-01_1-2e20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0_0-01_1-2e20·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0_0-01_1-2e20·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0_0-01_1-2e20·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0_0-01_1-2e20·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0-0_null_1-2e20·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0-0_null_1-2e20·get·responses·200"
-     ]
-    },
-    "description": "The array value [0.0, null, -1.2e20]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [0.0, null, -1.2e20]",
-       "$ref": "#/components/schemas/schemas:44"
-      }
-     }
-    }
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0-0_null_1-2e20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-0-0_null_1-2e20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-1-number-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-1-number-0·get·responses·200"
-     ]
-    },
-    "description": "The array value [1.0, 'number', 0.0]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value [1.0, 'number', 0.0]",
-       "$ref": "#/components/schemas/schemas:46"
-      }
-     }
-    }
-   },
-   "responses:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-1-number-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-double-1-number-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -4326,7 +3566,9 @@
      ],
      "name": "paths·array-prim-string-foo1-foo2-foo3·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo1-foo2-foo3·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo1-foo2-foo3·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo-null-foo2·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo-123-foo2·get·responses·200"
      ]
     },
     "description": "The array value ['foo1', 'foo2', 'foo3']",
@@ -4335,65 +3577,6 @@
       "schema": {
        "description": "The array value ['foo1', 'foo2', 'foo3']",
        "$ref": "#/components/schemas/schemas:48"
-      }
-     }
-    }
-   },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo1-foo2-foo3·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo1-foo2-foo3·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo1-foo2-foo3·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo1-foo2-foo3·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo1-foo2-foo3·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo1-foo2-foo3·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -4421,65 +3604,6 @@
      }
     }
    },
-   "responses:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-enum-foo1-foo2-foo3·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-enum-foo1-foo2-foo3·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-enum-foo1-foo2-foo3·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-enum-foo1-foo2-foo3·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-enum-foo1-foo2-foo3·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-enum-foo1-foo2-foo3·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
    "responses:56": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4503,155 +3627,6 @@
      }
     }
    },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string_enum-foo1-foo2-foo3·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string_enum-foo1-foo2-foo3·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string_enum-foo1-foo2-foo3·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string_enum-foo1-foo2-foo3·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo-null-foo2·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo-null-foo2·get·responses·200"
-     ]
-    },
-    "description": "The array value ['foo', null, 'foo2']",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value ['foo', null, 'foo2']",
-       "$ref": "#/components/schemas/schemas:60"
-      }
-     }
-    }
-   },
-   "responses:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo-null-foo2·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo-null-foo2·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo-123-foo2·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo-123-foo2·get·responses·200"
-     ]
-    },
-    "description": "The array value ['foo', 123, 'foo2']",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value ['foo', 123, 'foo2']",
-       "$ref": "#/components/schemas/schemas:62"
-      }
-     }
-    }
-   },
-   "responses:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo-123-foo2·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-string-foo-123-foo2·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
    "responses:64": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4662,7 +3637,8 @@
      ],
      "name": "paths·array-prim-uuid-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-invalidchars·get·responses·200"
      ]
     },
     "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']",
@@ -4671,110 +3647,6 @@
       "schema": {
        "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']",
        "$ref": "#/components/schemas/schemas:64"
-      }
-     }
-    }
-   },
-   "responses:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-uuid-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-uuid-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-uuid-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-uuid-invalidchars·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-invalidchars·get·responses·200"
-     ]
-    },
-    "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']",
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-uuid-invalidchars·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-uuid-invalidchars·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -4789,7 +3661,9 @@
      ],
      "name": "paths·array-prim-date-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-invalidnull·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-invalidchars·get·responses·200"
      ]
     },
     "description": "The array value ['2000-12-01', '1980-01-02', '1492-10-12']",
@@ -4798,155 +3672,6 @@
       "schema": {
        "description": "The array value ['2000-12-01', '1980-01-02', '1492-10-12']",
        "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-invalidnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-invalidnull·get·responses·200"
-     ]
-    },
-    "description": "The array value ['2012-01-01', null, '1776-07-04']",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value ['2012-01-01', null, '1776-07-04']",
-       "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:75": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-invalidnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-invalidnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-invalidchars·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-invalidchars·get·responses·200"
-     ]
-    },
-    "description": "The array value ['2011-03-22', 'date']",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value ['2011-03-22', 'date']",
-       "$ref": "#/components/schemas/schemas:76"
-      }
-     }
-    }
-   },
-   "responses:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-invalidchars·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date-invalidchars·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -4961,7 +3686,9 @@
      ],
      "name": "paths·array-prim-date_time-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-invalidnull·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-invalidchars·get·responses·200"
      ]
     },
     "description": "The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']",
@@ -4970,155 +3697,6 @@
       "schema": {
        "description": "The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']",
        "$ref": "#/components/schemas/schemas:78"
-      }
-     }
-    }
-   },
-   "responses:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:81": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:82": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-invalidnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-invalidnull·get·responses·200"
-     ]
-    },
-    "description": "The array value ['2000-12-01t00:00:01z', null]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value ['2000-12-01t00:00:01z', null]",
-       "$ref": "#/components/schemas/schemas:82"
-      }
-     }
-    }
-   },
-   "responses:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-invalidnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-invalidnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:84": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-invalidchars·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-invalidchars·get·responses·200"
-     ]
-    },
-    "description": "The array value ['2000-12-01t00:00:01z', 'date-time']",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The array value ['2000-12-01t00:00:01z', 'date-time']",
-       "$ref": "#/components/schemas/schemas:84"
-      }
-     }
-    }
-   },
-   "responses:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-invalidchars·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time-invalidchars·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -5146,65 +3724,6 @@
      }
     }
    },
-   "responses:87": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time_rfc1123-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time_rfc1123-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time_rfc1123-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time_rfc1123-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time_rfc1123-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-date_time_rfc1123-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
    "responses:90": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -5228,65 +3747,6 @@
      }
     }
    },
-   "responses:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-duration-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-duration-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:92": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-duration-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-duration-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-duration-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-duration-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
    "responses:94": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -5297,7 +3757,8 @@
      ],
      "name": "paths·array-prim-byte-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-invalidnull·get·responses·200"
      ]
     },
     "description": "The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64",
@@ -5306,110 +3767,6 @@
       "schema": {
        "description": "The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64",
        "$ref": "#/components/schemas/schemas:94"
-      }
-     }
-    }
-   },
-   "responses:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-byte-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-byte-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-byte-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-byte-invalidnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-invalidnull·get·responses·200"
-     ]
-    },
-    "description": "The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded",
-       "$ref": "#/components/schemas/schemas:98"
-      }
-     }
-    }
-   },
-   "responses:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-byte-invalidnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-byte-invalidnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -5437,28 +3794,6 @@
      }
     }
    },
-   "responses:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-base64url-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-prim-base64url-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
    "responses:102": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -5469,7 +3804,11 @@
      ],
      "name": "paths·array-complex-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-null·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-null·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-itemnull·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-itemempty·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-valid·get·responses·200"
      ]
     },
     "description": "array of complex type with null value",
@@ -5478,245 +3817,6 @@
       "schema": {
        "description": "array of complex type with null value",
        "$ref": "#/components/schemas/schemas:102"
-      }
-     }
-    }
-   },
-   "responses:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-empty·get·responses·200"
-     ]
-    },
-    "description": "Empty array of complex type []",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Empty array of complex type []",
-       "$ref": "#/components/schemas/schemas:103"
-      }
-     }
-    }
-   },
-   "responses:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-itemnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-itemnull·get·responses·200"
-     ]
-    },
-    "description": "Array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]",
-       "$ref": "#/components/schemas/schemas:104"
-      }
-     }
-    }
-   },
-   "responses:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-itemnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-itemnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:108": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-itemempty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-itemempty·get·responses·200"
-     ]
-    },
-    "description": "Array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]",
-       "$ref": "#/components/schemas/schemas:105"
-      }
-     }
-    }
-   },
-   "responses:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-itemempty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-itemempty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-valid·get·responses·200"
-     ]
-    },
-    "description": "array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
-       "$ref": "#/components/schemas/schemas:106"
-      }
-     }
-    }
-   },
-   "responses:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-complex-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -5731,7 +3831,11 @@
      ],
      "name": "paths·array-array-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-null·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-null·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-itemnull·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-itemempty·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-valid·get·responses·200"
      ]
     },
     "description": "null array",
@@ -5740,245 +3844,6 @@
       "schema": {
        "description": "a null array",
        "$ref": "#/components/schemas/schemas:108"
-      }
-     }
-    }
-   },
-   "responses:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-empty·get·responses·200"
-     ]
-    },
-    "description": "An empty array []",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An empty array []",
-       "$ref": "#/components/schemas/schemas:111"
-      }
-     }
-    }
-   },
-   "responses:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:118": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-itemnull·get·responses·200"
-     ]
-    },
-    "description": "An array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]",
-       "$ref": "#/components/schemas/schemas:114"
-      }
-     }
-    }
-   },
-   "responses:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-itemnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemempty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-itemempty·get·responses·200"
-     ]
-    },
-    "description": "An array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]",
-       "$ref": "#/components/schemas/schemas:117"
-      }
-     }
-    }
-   },
-   "responses:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemempty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-itemempty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-valid·get·responses·200"
-     ]
-    },
-    "description": "An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]",
-       "$ref": "#/components/schemas/schemas:120"
-      }
-     }
-    }
-   },
-   "responses:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-array-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -5993,7 +3858,11 @@
      ],
      "name": "paths·array-dictionary-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-null·get·responses·200"
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-null·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-itemnull·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-itemempty·get·responses·200",
+      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-valid·get·responses·200"
      ]
     },
     "description": "An array of Dictionaries with value null",
@@ -6002,245 +3871,6 @@
       "schema": {
        "description": "An array of Dictionaries with value null",
        "$ref": "#/components/schemas/schemas:126"
-      }
-     }
-    }
-   },
-   "responses:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:128": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-empty·get·responses·200"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value []",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of Dictionaries of type <string, string> with value []",
-       "$ref": "#/components/schemas/schemas:129"
-      }
-     }
-    }
-   },
-   "responses:129": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:130": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-itemnull·get·responses·200"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-       "$ref": "#/components/schemas/schemas:132"
-      }
-     }
-    }
-   },
-   "responses:131": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-itemnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:132": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemempty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-itemempty·get·responses·200"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-       "$ref": "#/components/schemas/schemas:135"
-      }
-     }
-    }
-   },
-   "responses:133": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemempty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-itemempty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:134": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-valid·get·responses·200"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:135": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
-      }
-     }
-    }
-   },
-   "responses:136": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:137": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/responses/paths·array-dictionary-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:146"
       }
      }
     }
@@ -6291,7 +3921,12 @@
      ],
      "name": "paths·array-invalid·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-invalid·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-invalid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-null-zero·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-integer-0·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The invalid Array [1, 2, 3",
@@ -6310,41 +3945,12 @@
      ],
      "name": "paths·array-invalid·get·responses·200·content·application-json·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-invalid·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The empty array value []",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:5"
-    }
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-empty·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-empty·get·responses·200·content·application-json·schema·items"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-invalid·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-empty·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-null-zero·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-integer-0·get·responses·200·content·application-json·schema·items"
      ]
     },
     "type": "integer"
@@ -6393,7 +3999,10 @@
      ],
      "name": "paths·array-prim-boolean-tfft·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-tfft·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-tfft·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-tfft·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-true-null-false·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The array value [true, false, false, true]",
@@ -6412,248 +4021,13 @@
      ],
      "name": "paths·array-prim-boolean-tfft·get·responses·200·content·application-json·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-tfft·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-tfft·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-tfft·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [true, false, false, true]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:11"
-    }
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-tfft·put·requestbody·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-tfft·put·requestbody·content·application-json·schema·items"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-true-null-false·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-true-null-false·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [true, null, false]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:13"
-    }
-   },
-   "schemas:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-true-null-false·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-true-null-false·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [true, 'boolean', false]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:15"
-    }
-   },
-   "schemas:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-tfft·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-tfft·put·requestbody·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-true-null-false·get·responses·200·content·application-json·schema·items",
       "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema·items"
      ]
     },
     "type": "boolean"
-   },
-   "schemas:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1, -1, 3, 300]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:17"
-    }
-   },
-   "schemas:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1, -1, 3, 300]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:19"
-    }
-   },
-   "schemas:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema·items"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-null-zero·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-null-zero·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1, null, 0]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:21"
-    }
-   },
-   "schemas:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-null-zero·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-null-zero·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-integer-0·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-integer-0·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1, 'integer', 0]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:23"
-    }
-   },
-   "schemas:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-integer-1-integer-0·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-integer-1-integer-0·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "integer"
    },
    "schemas:24": {
     "x-ms-metadata": {
@@ -6665,7 +4039,10 @@
      ],
      "name": "paths·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-null-zero·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-integer-0·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The array value [1, -1, 3, 300]",
@@ -6684,111 +4061,9 @@
      ],
      "name": "paths·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1, -1, 3, 300]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:27"
-    }
-   },
-   "schemas:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema·items"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-null-zero·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-null-zero·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1, null, 0]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:29"
-    }
-   },
-   "schemas:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-null-zero·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-null-zero·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-integer-0·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-integer-0·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1, 'integer', 0]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:31"
-    }
-   },
-   "schemas:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-long-1-integer-0·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-null-zero·get·responses·200·content·application-json·schema·items",
       "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-long-1-integer-0·get·responses·200·content·application-json·schema·items"
      ]
     },
@@ -6805,7 +4080,10 @@
      ],
      "name": "paths·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-1-number-0·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The array value [0, -0.01, 1.2e20]",
@@ -6824,111 +4102,9 @@
      ],
      "name": "paths·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [0, -0.01, 1.2e20]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:35"
-    }
-   },
-   "schemas:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema·items"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [0.0, null, -1.2e20]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:37"
-    }
-   },
-   "schemas:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-1-number-0·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-1-number-0·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1.0, 'number', 0.0]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:39"
-    }
-   },
-   "schemas:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-float-1-number-0·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema·items",
       "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-float-1-number-0·get·responses·200·content·application-json·schema·items"
      ]
     },
@@ -6945,7 +4121,10 @@
      ],
      "name": "paths·array-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-1-number-0·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The array value [0, -0.01, 1.2e20]",
@@ -6964,111 +4143,9 @@
      ],
      "name": "paths·array-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [0, -0.01, 1.2e20]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:43"
-    }
-   },
-   "schemas:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema·items"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [0.0, null, -1.2e20]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:45"
-    }
-   },
-   "schemas:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-1-number-0·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-1-number-0·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [1.0, 'number', 0.0]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:47"
-    }
-   },
-   "schemas:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-double-1-number-0·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema·items",
       "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-double-1-number-0·get·responses·200·content·application-json·schema·items"
      ]
     },
@@ -7085,7 +4162,15 @@
      ],
      "name": "paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-null·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-empty·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemnull·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemempty·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-valid·get·responses·200·content·application-json·schema·items"
      ]
     },
     "description": "The array value ['foo1', 'foo2', 'foo3']",
@@ -7104,41 +4189,21 @@
      ],
      "name": "paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['foo1', 'foo2', 'foo3']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:51"
-    }
-   },
-   "schemas:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-null·get·responses·200·content·application-json·schema·items·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-empty·get·responses·200·content·application-json·schema·items·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemnull·get·responses·200·content·application-json·schema·items·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemempty·get·responses·200·content·application-json·schema·items·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-valid·get·responses·200·content·application-json·schema·items·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-null·get·responses·200·content·application-json·schema·items·additionalproperties",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items·additionalproperties",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items·additionalproperties",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items·additionalproperties",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items·additionalproperties",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items·additionalproperties"
      ]
     },
     "type": "string"
@@ -7153,25 +4218,7 @@
      ],
      "name": "paths·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['foo1', 'foo2', 'foo3']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/FooEnum"
-    }
-   },
-   "schemas:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema"
      ]
     },
@@ -7191,7 +4238,8 @@
      ],
      "name": "paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema"
      ]
     },
     "description": "The array value ['foo1', 'foo2', 'foo3']",
@@ -7199,93 +4247,6 @@
     "items": {
      "$ref": "#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items"
     }
-   },
-   "schemas:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['foo1', 'foo2', 'foo3']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items"
-    }
-   },
-   "schemas:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['foo', null, 'foo2']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:61"
-    }
-   },
-   "schemas:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['foo', 123, 'foo2']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:63"
-    }
-   },
-   "schemas:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "string"
    },
    "schemas:64": {
     "x-ms-metadata": {
@@ -7297,7 +4258,9 @@
      ],
      "name": "paths·array-prim-uuid-valid·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-uuid-valid·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-uuid-valid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-uuid-valid·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-uuid-invalidchars·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']",
@@ -7324,44 +4287,6 @@
     "type": "string",
     "format": "uuid"
    },
-   "schemas:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-uuid-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-uuid-valid·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:65"
-    }
-   },
-   "schemas:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-uuid-invalidchars·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-uuid-invalidchars·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:65"
-    }
-   },
    "schemas:70": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -7372,7 +4297,10 @@
      ],
      "name": "paths·array-prim-date-valid·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date-valid·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date-valid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date-valid·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date-invalidnull·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date-invalidchars·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The array value ['2000-12-01', '1980-01-02', '1492-10-12']",
@@ -7400,63 +4328,6 @@
     "type": "string",
     "format": "date"
    },
-   "schemas:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date-valid·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['2000-12-01', '1980-01-02', '1492-10-12']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:71"
-    }
-   },
-   "schemas:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-invalidnull·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date-invalidnull·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['2012-01-01', null, '1776-07-04']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:71"
-    }
-   },
-   "schemas:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date-invalidchars·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date-invalidchars·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['2011-03-22', 'date']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:71"
-    }
-   },
    "schemas:78": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -7467,7 +4338,10 @@
      ],
      "name": "paths·array-prim-date_time-valid·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time-valid·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time-valid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time-valid·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time-invalidnull·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time-invalidchars·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']",
@@ -7495,63 +4369,6 @@
     "type": "string",
     "format": "date-time"
    },
-   "schemas:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time-valid·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:79"
-    }
-   },
-   "schemas:82": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-invalidnull·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time-invalidnull·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['2000-12-01t00:00:01z', null]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:79"
-    }
-   },
-   "schemas:84": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time-invalidchars·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time-invalidchars·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['2000-12-01t00:00:01z', 'date-time']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:79"
-    }
-   },
    "schemas:86": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -7562,7 +4379,8 @@
      ],
      "name": "paths·array-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time_rfc1123-valid·put·requestbody·content·application-json·schema"
      ]
     },
     "description": "The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']",
@@ -7588,25 +4406,6 @@
     "type": "string",
     "format": "date-time-rfc1123"
    },
-   "schemas:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-date_time_rfc1123-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-date_time_rfc1123-valid·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:87"
-    }
-   },
    "schemas:90": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -7617,7 +4416,8 @@
      ],
      "name": "paths·array-prim-duration-valid·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-duration-valid·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-duration-valid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-duration-valid·put·requestbody·content·application-json·schema"
      ]
     },
     "description": "The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']",
@@ -7643,25 +4443,6 @@
     "type": "string",
     "format": "duration"
    },
-   "schemas:92": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-duration-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-duration-valid·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:91"
-    }
-   },
    "schemas:94": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -7672,7 +4453,9 @@
      ],
      "name": "paths·array-prim-byte-valid·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-byte-valid·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-byte-valid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-byte-valid·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-byte-invalidnull·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64",
@@ -7698,44 +4481,6 @@
     },
     "type": "string",
     "format": "byte"
-   },
-   "schemas:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-byte-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-byte-valid·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:95"
-    }
-   },
-   "schemas:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-byte-invalidnull·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-byte-invalidnull·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:95"
-    }
    },
    "schemas:100": {
     "x-ms-metadata": {
@@ -7782,105 +4527,15 @@
      ],
      "name": "paths·array-complex-null·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-null·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "array of complex type with null value",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:144"
-    }
-   },
-   "schemas:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Empty array of complex type []",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:144"
-    }
-   },
-   "schemas:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-itemnull·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-itemnull·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:144"
-    }
-   },
-   "schemas:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-itemempty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-itemempty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:144"
-    }
-   },
-   "schemas:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-valid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-valid·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:144"
-    }
-   },
-   "schemas:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-complex-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-null·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-itemnull·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-itemempty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-valid·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-complex-valid·put·requestbody·content·application-json·schema"
      ]
     },
-    "description": "array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
+    "description": "array of complex type with null value",
     "type": "array",
     "items": {
      "$ref": "#/components/schemas/schemas:144"
@@ -7896,255 +4551,18 @@
      ],
      "name": "paths·array-array-null·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-null·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-null·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemnull·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemempty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-valid·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "a null array",
     "type": "array",
     "items": {
-     "$ref": "#/components/schemas/schemas:109"
+     "$ref": "#/components/schemas/schemas:48"
     }
-   },
-   "schemas:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-null·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-null·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:110"
-    }
-   },
-   "schemas:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-null·get·responses·200·content·application-json·schema·items·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-null·get·responses·200·content·application-json·schema·items·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An empty array []",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:112"
-    }
-   },
-   "schemas:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-empty·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-empty·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:113"
-    }
-   },
-   "schemas:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-empty·get·responses·200·content·application-json·schema·items·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-empty·get·responses·200·content·application-json·schema·items·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemnull·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemnull·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:115"
-    }
-   },
-   "schemas:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemnull·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemnull·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:116"
-    }
-   },
-   "schemas:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemnull·get·responses·200·content·application-json·schema·items·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemnull·get·responses·200·content·application-json·schema·items·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemempty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemempty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:118"
-    }
-   },
-   "schemas:118": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemempty·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemempty·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:119"
-    }
-   },
-   "schemas:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-itemempty·get·responses·200·content·application-json·schema·items·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-itemempty·get·responses·200·content·application-json·schema·items·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-valid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-valid·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:121"
-    }
-   },
-   "schemas:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-valid·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-valid·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:122"
-    }
-   },
-   "schemas:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-array-valid·get·responses·200·content·application-json·schema·items·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-array-valid·get·responses·200·content·application-json·schema·items·items"
-     ]
-    },
-    "type": "string"
    },
    "schemas:123": {
     "x-ms-metadata": {
@@ -8208,7 +4626,12 @@
      ],
      "name": "paths·array-dictionary-null·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-null·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-null·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·put·requestbody·content·application-json·schema"
      ]
     },
     "description": "An array of Dictionaries with value null",
@@ -8227,288 +4650,18 @@
      ],
      "name": "paths·array-dictionary-null·get·responses·200·content·application-json·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-null·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:128"
-    }
-   },
-   "schemas:128": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-null·get·responses·200·content·application-json·schema·items·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-null·get·responses·200·content·application-json·schema·items·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:129": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value []",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:130"
-    }
-   },
-   "schemas:130": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:131"
-    }
-   },
-   "schemas:131": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:132": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:133"
-    }
-   },
-   "schemas:133": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:134"
-    }
-   },
-   "schemas:134": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:135": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:136"
-    }
-   },
-   "schemas:136": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:137"
-    }
-   },
-   "schemas:137": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:138": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:139"
-    }
-   },
-   "schemas:139": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:140"
-    }
-   },
-   "schemas:140": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:141": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:142"
-    }
-   },
-   "schemas:142": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-null·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items",
       "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items"
      ]
     },
     "type": "object",
     "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:143"
+     "$ref": "#/components/schemas/schemas:49"
     }
-   },
-   "schemas:143": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items·additionalproperties"
-     ]
-    },
-    "type": "string"
    },
    "schemas:144": {
     "x-ms-metadata": {
@@ -8597,19 +4750,20 @@
      ],
      "name": "FooEnum",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items"
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items",
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items"
      ]
-    },
-    "x-ms-enum": {
-     "name": "FooEnum",
-     "modelAsString": false
     },
     "type": "string",
     "enum": [
      "foo1",
      "foo2",
      "foo3"
-    ]
+    ],
+    "x-ms-enum": {
+     "name": "FooEnum",
+     "modelAsString": false
+    }
    },
    "paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items": {
     "x-ms-metadata": {
@@ -8621,26 +4775,7 @@
      ],
      "name": "paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items"
-     ]
-    },
-    "type": "string",
-    "enum": [
-     "foo1",
-     "foo2",
-     "foo3"
-    ]
-   },
-   "paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items",
       "http://localhost:3000/swagger/body-array.json#/components/schemas/paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items"
      ]
     },
@@ -8694,7 +4829,7 @@
      "application/json": {
       "schema": {
        "description": "The array value [true, false, false, true]",
-       "$ref": "#/components/schemas/schemas:10"
+       "$ref": "#/components/schemas/schemas:8"
       }
      }
     },
@@ -8718,7 +4853,7 @@
      "application/json": {
       "schema": {
        "description": "The array value [1, -1, 3, 300]",
-       "$ref": "#/components/schemas/schemas:18"
+       "$ref": "#/components/schemas/schemas:2"
       }
      }
     },
@@ -8742,7 +4877,7 @@
      "application/json": {
       "schema": {
        "description": "The array value [1, -1, 3, 300]",
-       "$ref": "#/components/schemas/schemas:26"
+       "$ref": "#/components/schemas/schemas:24"
       }
      }
     },
@@ -8766,7 +4901,7 @@
      "application/json": {
       "schema": {
        "description": "The array value [0, -0.01, 1.2e20]",
-       "$ref": "#/components/schemas/schemas:34"
+       "$ref": "#/components/schemas/schemas:32"
       }
      }
     },
@@ -8790,7 +4925,7 @@
      "application/json": {
       "schema": {
        "description": "The array value [0, -0.01, 1.2e20]",
-       "$ref": "#/components/schemas/schemas:42"
+       "$ref": "#/components/schemas/schemas:40"
       }
      }
     },
@@ -8814,7 +4949,7 @@
      "application/json": {
       "schema": {
        "description": "The array value ['foo1', 'foo2', 'foo3']",
-       "$ref": "#/components/schemas/schemas:50"
+       "$ref": "#/components/schemas/schemas:48"
       }
      }
     },
@@ -8838,7 +4973,7 @@
      "application/json": {
       "schema": {
        "description": "The array value ['foo1', 'foo2', 'foo3']",
-       "$ref": "#/components/schemas/schemas:54"
+       "$ref": "#/components/schemas/schemas:52"
       }
      }
     },
@@ -8862,7 +4997,7 @@
      "application/json": {
       "schema": {
        "description": "The array value ['foo1', 'foo2', 'foo3']",
-       "$ref": "#/components/schemas/schemas:58"
+       "$ref": "#/components/schemas/schemas:56"
       }
      }
     },
@@ -8886,7 +5021,7 @@
      "application/json": {
       "schema": {
        "description": "The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']",
-       "$ref": "#/components/schemas/schemas:66"
+       "$ref": "#/components/schemas/schemas:64"
       }
      }
     },
@@ -8910,7 +5045,7 @@
      "application/json": {
       "schema": {
        "description": "The array value ['2000-12-01', '1980-01-02', '1492-10-12']",
-       "$ref": "#/components/schemas/schemas:72"
+       "$ref": "#/components/schemas/schemas:70"
       }
      }
     },
@@ -8934,7 +5069,7 @@
      "application/json": {
       "schema": {
        "description": "The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']",
-       "$ref": "#/components/schemas/schemas:80"
+       "$ref": "#/components/schemas/schemas:78"
       }
      }
     },
@@ -8958,7 +5093,7 @@
      "application/json": {
       "schema": {
        "description": "The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']",
-       "$ref": "#/components/schemas/schemas:88"
+       "$ref": "#/components/schemas/schemas:86"
       }
      }
     },
@@ -8982,7 +5117,7 @@
      "application/json": {
       "schema": {
        "description": "The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']",
-       "$ref": "#/components/schemas/schemas:92"
+       "$ref": "#/components/schemas/schemas:90"
       }
      }
     },
@@ -9006,7 +5141,7 @@
      "application/json": {
       "schema": {
        "description": "The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64",
-       "$ref": "#/components/schemas/schemas:96"
+       "$ref": "#/components/schemas/schemas:94"
       }
      }
     },
@@ -9030,7 +5165,7 @@
      "application/json": {
       "schema": {
        "description": "array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
-       "$ref": "#/components/schemas/schemas:107"
+       "$ref": "#/components/schemas/schemas:102"
       }
      }
     },
@@ -9078,7 +5213,7 @@
      "application/json": {
       "schema": {
        "description": "An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]",
-       "$ref": "#/components/schemas/schemas:141"
+       "$ref": "#/components/schemas/schemas:126"
       }
      }
     },

--- a/modelerfour/test/inputs/body-boolean.quirks/openapi-document.json
+++ b/modelerfour/test/inputs/body-boolean.quirks/openapi-document.json
@@ -96,7 +96,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -142,11 +142,11 @@
     "responses": {
      "200": {
       "description": "The false Boolean value",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -173,7 +173,7 @@
     "operationId": "bool_putFalse",
     "description": "Set Boolean value false",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:1"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "tags": [
@@ -182,11 +182,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -232,11 +232,11 @@
     "responses": {
      "200": {
       "description": "The null Boolean value",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -282,11 +282,11 @@
     "responses": {
      "200": {
       "description": "The invalid Boolean value",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -304,7 +304,10 @@
      ],
      "name": "paths·bool-true·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-true·get·responses·200"
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-true·get·responses·200",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-false·get·responses·200",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-null·get·responses·200",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-invalid·get·responses·200"
      ]
     },
     "description": "The true Boolean value",
@@ -326,7 +329,12 @@
      ],
      "name": "paths·bool-true·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-true·get·responses·default"
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-true·get·responses·default",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-true·put·responses·default",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-false·get·responses·default",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-false·put·responses·default",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-null·get·responses·default",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-invalid·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -348,201 +356,11 @@
      ],
      "name": "paths·bool-true·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-true·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-true·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-true·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-false·get·responses·200"
-     ]
-    },
-    "description": "The false Boolean value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-false·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·put·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-true·put·responses·200",
       "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-false·put·responses·200"
      ]
     },
     "description": "Empty Response"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-false·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-null·get·responses·200"
-     ]
-    },
-    "description": "The null Boolean value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-invalid·get·responses·200"
-     ]
-    },
-    "description": "The invalid Boolean value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/responses/paths·bool-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
    }
   },
   "schemas": {
@@ -556,81 +374,11 @@
      ],
      "name": "paths·bool-true·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-true·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-true·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-true·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-false·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-false·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-null·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-null·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-invalid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-true·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-true·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-false·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-false·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-null·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-boolean.quirks.json#/components/schemas/paths·bool-invalid·get·responses·200·content·application-json·schema"
      ]
     },
@@ -687,36 +435,14 @@
      ],
      "name": "paths·bool-true·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/requestBodies/paths·bool-true·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:1"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "boolBody"
-   },
-   "requestBodies:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-boolean.quirks.json#/components/requestBodies/paths·bool-true·put·requestbody",
       "http://localhost:3000/swagger/body-boolean.quirks.json#/components/requestBodies/paths·bool-false·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:3"
+       "$ref": "#/components/schemas/schemas:0"
       }
      }
     },

--- a/modelerfour/test/inputs/body-boolean/openapi-document.json
+++ b/modelerfour/test/inputs/body-boolean/openapi-document.json
@@ -96,7 +96,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -146,7 +146,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -182,11 +182,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -236,7 +236,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -282,11 +282,11 @@
     "responses": {
      "200": {
       "description": "The invalid Boolean value",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -326,7 +326,12 @@
      ],
      "name": "paths·bool-true·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-true·get·responses·default"
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-true·get·responses·default",
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-true·put·responses·default",
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-false·get·responses·default",
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-false·put·responses·default",
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-null·get·responses·default",
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-invalid·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -348,32 +353,11 @@
      ],
      "name": "paths·bool-true·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-true·put·responses·200"
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-true·put·responses·200",
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-false·put·responses·200"
      ]
     },
     "description": "Empty Response"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-true·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-true·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
    },
    "responses:4": {
     "x-ms-metadata": {
@@ -397,65 +381,6 @@
      }
     }
    },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-false·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-false·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-false·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
    "responses:8": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -466,7 +391,8 @@
      ],
      "name": "paths·bool-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-null·get·responses·200"
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-null·get·responses·200",
+      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-invalid·get·responses·200"
      ]
     },
     "description": "The null Boolean value",
@@ -474,72 +400,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-invalid·get·responses·200"
-     ]
-    },
-    "description": "The invalid Boolean value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/responses/paths·bool-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
       }
      }
     }
@@ -556,21 +416,7 @@
      ],
      "name": "paths·bool-null·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-null·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-invalid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-null·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-invalid·get·responses·200·content·application-json·schema"
      ]
     },
@@ -625,24 +471,7 @@
      ],
      "name": "paths·bool-true·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-true·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·bool-true·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-true·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-true·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-true·put·requestbody·content·application-json·schema"
      ]
     },
@@ -661,24 +490,7 @@
      ],
      "name": "paths·bool-false·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-false·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "boolean",
-    "enum": [
-     false
-    ]
-   },
-   "paths·bool-false·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·bool-false·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-false·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-boolean.json#/components/schemas/paths·bool-false·put·requestbody·content·application-json·schema"
      ]
     },
@@ -705,7 +517,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·bool-true·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·bool-true·get·responses·200·content·application-json·schema"
       }
      }
     },
@@ -728,7 +540,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·bool-false·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·bool-false·get·responses·200·content·application-json·schema"
       }
      }
     },

--- a/modelerfour/test/inputs/body-byte/openapi-document.json
+++ b/modelerfour/test/inputs/body-byte/openapi-document.json
@@ -106,7 +106,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -156,7 +156,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -197,7 +197,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -243,11 +243,11 @@
     "responses": {
      "200": {
       "description": "The invalid byte value '::::SWAGGER::::'",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -288,7 +288,11 @@
      ],
      "name": "paths·byte-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-null·get·responses·default"
+      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-null·get·responses·default",
+      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-nonascii·get·responses·default",
+      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-nonascii·put·responses·default",
+      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-invalid·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -323,28 +327,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·byte-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    }
-   },
    "responses:4": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -355,7 +337,8 @@
      ],
      "name": "paths·byte-nonascii·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-nonascii·get·responses·200"
+      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-nonascii·get·responses·200",
+      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-invalid·get·responses·200"
      ]
     },
     "description": "Non-ascii base-64 encoded byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)",
@@ -364,28 +347,6 @@
       "schema": {
        "description": "Non-ascii base-64 encoded byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)",
        "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·byte-nonascii·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-nonascii·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
       }
      }
     }
@@ -404,73 +365,6 @@
      ]
     },
     "description": "Empty Response"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·byte-nonascii·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-nonascii·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·byte-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-invalid·get·responses·200"
-     ]
-    },
-    "description": "The invalid byte value '::::SWAGGER::::'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The invalid byte value '::::SWAGGER::::'",
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·byte-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-byte.json#/components/responses/paths·byte-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    }
    }
   },
   "schemas": {

--- a/modelerfour/test/inputs/body-complex/openapi-document.json
+++ b/modelerfour/test/inputs/body-complex/openapi-document.json
@@ -96,7 +96,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -139,11 +139,11 @@
     "responses": {
      "200": {
       "description": "Get complex types with basic property",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -186,11 +186,11 @@
     "responses": {
      "200": {
       "description": "Get complex types with basic property",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -233,11 +233,11 @@
     "responses": {
      "200": {
       "description": "Get complex types with basic property",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -280,11 +280,11 @@
     "responses": {
      "200": {
       "description": "Get complex types with basic property",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -331,7 +331,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -365,11 +365,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -416,7 +416,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -450,11 +450,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -501,7 +501,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -535,11 +535,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -586,7 +586,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -620,11 +620,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -671,7 +671,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -705,11 +705,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -756,7 +756,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -790,11 +790,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -841,7 +841,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -875,11 +875,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:38"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -926,7 +926,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -960,11 +960,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1011,7 +1011,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1045,11 +1045,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:46"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:47"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1096,7 +1096,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:49"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1130,11 +1130,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:50"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1181,7 +1181,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:53"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1215,11 +1215,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:54"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:55"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1266,7 +1266,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1300,11 +1300,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:58"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:59"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1347,11 +1347,11 @@
     "responses": {
      "200": {
       "description": "Complex object with array property",
-      "$ref": "#/components/responses/responses:60"
+      "$ref": "#/components/responses/responses:56"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:61"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1379,17 +1379,17 @@
     "description": "Put complex types with array property which is empty",
     "requestBody": {
      "description": "Please put an empty array",
-     "$ref": "#/components/requestBodies/requestBodies:13"
+     "$ref": "#/components/requestBodies/requestBodies:12"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:62"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:63"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1432,11 +1432,11 @@
     "responses": {
      "200": {
       "description": "Complex object with array property",
-      "$ref": "#/components/responses/responses:64"
+      "$ref": "#/components/responses/responses:56"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:65"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1483,7 +1483,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:67"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1517,11 +1517,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:68"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:69"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1564,11 +1564,11 @@
     "responses": {
      "200": {
       "description": "Complex object with dictionary property",
-      "$ref": "#/components/responses/responses:70"
+      "$ref": "#/components/responses/responses:66"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:71"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1596,17 +1596,17 @@
     "description": "Put complex types with dictionary property which is empty",
     "requestBody": {
      "description": "Please put an empty dictionary",
-     "$ref": "#/components/requestBodies/requestBodies:15"
+     "$ref": "#/components/requestBodies/requestBodies:14"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:72"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:73"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1649,11 +1649,11 @@
     "responses": {
      "200": {
       "description": "Complex object with dictionary property",
-      "$ref": "#/components/responses/responses:74"
+      "$ref": "#/components/responses/responses:66"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:75"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1696,11 +1696,11 @@
     "responses": {
      "200": {
       "description": "Complex object with dictionary property",
-      "$ref": "#/components/responses/responses:76"
+      "$ref": "#/components/responses/responses:66"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:77"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1747,7 +1747,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:79"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1781,11 +1781,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:80"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:81"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1832,7 +1832,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:83"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1866,11 +1866,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:84"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:85"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1917,7 +1917,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:87"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1964,7 +1964,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:89"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2007,11 +2007,11 @@
     "responses": {
      "200": {
       "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects without discriminator specified",
-      "$ref": "#/components/responses/responses:90"
+      "$ref": "#/components/responses/responses:88"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:91"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2058,7 +2058,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:93"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2091,11 +2091,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:94"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:95"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2136,17 +2136,17 @@
     "operationId": "polymorphism_putMissingDiscriminator",
     "description": "Put complex types that are polymorphic, omitting the discriminator",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:19"
+     "$ref": "#/components/requestBodies/requestBodies:18"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Returns a salmon",
-      "$ref": "#/components/responses/responses:96"
+      "$ref": "#/components/responses/responses:92"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:97"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2188,17 +2188,17 @@
     "description": "Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client",
     "requestBody": {
      "description": "Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:\n{\n    \"fishtype\": \"sawshark\",\n    \"species\": \"snaggle toothed\",\n    \"length\": 18.5,\n    \"age\": 2,\n    \"birthday\": \"2013-06-01T01:00:00Z\",\n    \"location\": \"alaska\",\n    \"picture\": base64(FF FF FF FF FE),\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"birthday\": \"2012-01-05T01:00:00Z\",\n            \"length\": 20,\n            \"age\": 6\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"picture\": base64(FF FF FF FF FE),\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}",
-     "$ref": "#/components/requestBodies/requestBodies:20"
+     "$ref": "#/components/requestBodies/requestBodies:17"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:98"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:99"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2241,11 +2241,11 @@
     "responses": {
      "200": {
       "description": "Complex object that extends cat and pet, returns a Salmon like this:\n{\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'species':'predator',\n            'length':20,\n            'siblings':[\n                {\n                    'fishtype':'Salmon',\n                    'location':'atlantic',\n                    'iswild':true,\n                    'species':'coho',\n                    'length':2,\n                    'siblings':[\n                      {\n                        'fishtype':'Shark',\n                        'age':6,\n                        'birthday': '2012-01-05T01:00:00Z',\n                        'species':'predator',\n                        'length':20\n                      },\n                      {\n                        'fishtype':'Sawshark',\n                        'age':105,\n                        'birthday': '1900-01-05T01:00:00Z',\n                        'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n                        'species':'dangerous',\n                        'length':10\n                      }\n                    ]\n                },\n                {\n                    'fishtype':'Sawshark',\n                    'age':105,\n                    'birthday': '1900-01-05T01:00:00Z',\n                    'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n                    'species':'dangerous',\n                    'length':10,\n                    'siblings':[]\n                }\n            ]\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n            'length':10,'siblings':[]\n          }\n        ]\n    };",
-      "$ref": "#/components/responses/responses:100"
+      "$ref": "#/components/responses/responses:82"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:101"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2273,17 +2273,17 @@
     "description": "Put complex types that are polymorphic and have recursive references",
     "requestBody": {
      "description": "Please put a salmon that looks like this:\n{\n    \"fishtype\": \"salmon\",\n    \"species\": \"king\",\n    \"length\": 1,\n    \"age\": 1,\n    \"location\": \"alaska\",\n    \"iswild\": true,\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"length\": 20,\n            \"age\": 6,\n            \"siblings\": [\n                {\n                    \"fishtype\": \"salmon\",\n                    \"species\": \"coho\",\n                    \"length\": 2,\n                    \"age\": 2,\n                    \"location\": \"atlantic\",\n                    \"iswild\": true,\n                    \"siblings\": [\n                        {\n                            \"fishtype\": \"shark\",\n                            \"species\": \"predator\",\n                            \"length\": 20,\n                            \"age\": 6\n                        },\n                        {\n                            \"fishtype\": \"sawshark\",\n                            \"species\": \"dangerous\",\n                            \"length\": 10,\n                            \"age\": 105\n                        }\n                    ]\n                },\n                {\n                    \"fishtype\": \"sawshark\",\n                    \"species\": \"dangerous\",\n                    \"length\": 10,\n                    \"age\": 105\n                }\n            ]\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}",
-     "$ref": "#/components/requestBodies/requestBodies:21"
+     "$ref": "#/components/requestBodies/requestBodies:17"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:102"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:103"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2330,7 +2330,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:105"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2363,11 +2363,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:106"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:107"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2427,7 +2427,11 @@
      ],
      "name": "paths·complex-basic-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-invalid·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-null·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-notprovided·get·responses·200"
      ]
     },
     "description": "Get complex type {id: 2, name: 'abc', color: 'YELLOW'}",
@@ -2449,7 +2453,60 @@
      ],
      "name": "paths·complex-basic-valid·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-valid·get·responses·default"
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-invalid·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-null·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-notprovided·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-integer·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-integer·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-long·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-long·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-float·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-float·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-double·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-double·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-bool·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-bool·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-string·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-string·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-date·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-date·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetime·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetime·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetimerfc1123·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetimerfc1123·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-duration·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-duration·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-byte·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-byte·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-empty·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-notprovided·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-empty·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-null·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-notprovided·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-inheritance-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-inheritance-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-dotsyntax·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-composedwithdiscriminator·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-composedwithoutdiscriminator·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-complicated·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-complicated·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-missingdiscriminator·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-missingrequired-invalid·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphicrecursive-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphicrecursive-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-readonlyproperty-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-readonlyproperty-valid·put·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -2471,208 +2528,31 @@
      ],
      "name": "paths·complex-basic-valid·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-valid·put·responses·200"
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-integer·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-long·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-float·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-double·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-bool·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-string·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-date·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetime·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetimerfc1123·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-duration·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-byte·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-empty·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-empty·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-inheritance-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-complicated·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-missingrequired-invalid·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphicrecursive-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-readonlyproperty-valid·put·responses·200"
      ]
     },
     "description": "Empty Response"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-invalid·get·responses·200"
-     ]
-    },
-    "description": "Get complex types with basic property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-empty·get·responses·200"
-     ]
-    },
-    "description": "Get complex types with basic property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-null·get·responses·200"
-     ]
-    },
-    "description": "Get complex types with basic property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-notprovided·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-notprovided·get·responses·200"
-     ]
-    },
-    "description": "Get complex types with basic property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-basic-notprovided·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-basic-notprovided·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
    },
    "responses:12": {
     "x-ms-metadata": {
@@ -2692,65 +2572,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:38"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-integer·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-integer·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-integer·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-integer·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-integer·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-integer·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -2777,65 +2598,6 @@
      }
     }
    },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-long·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-long·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-long·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-long·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-long·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-long·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:20": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -2854,65 +2616,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:40"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-float·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-float·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-float·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-float·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-float·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-float·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -2939,65 +2642,6 @@
      }
     }
    },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-double·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-double·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-double·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-double·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-double·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-double·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:28": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3016,65 +2660,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:42"
-      }
-     }
-    }
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-bool·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-bool·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-bool·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-bool·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-bool·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-bool·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -3101,65 +2686,6 @@
      }
     }
    },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-string·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-string·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-string·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-string·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-string·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-string·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:36": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3178,65 +2704,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:47"
-      }
-     }
-    }
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-date·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-date·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-date·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-date·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-date·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-date·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -3263,65 +2730,6 @@
      }
     }
    },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-datetime·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetime·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-datetime·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetime·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-datetime·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetime·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:44": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3340,65 +2748,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:53"
-      }
-     }
-    }
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-datetimerfc1123·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetimerfc1123·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-datetimerfc1123·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetimerfc1123·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-datetimerfc1123·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-datetimerfc1123·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -3425,65 +2774,6 @@
      }
     }
    },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-duration·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-duration·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-duration·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-duration·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-duration·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-duration·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:52": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3506,65 +2796,6 @@
      }
     }
    },
-   "responses:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-byte·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-byte·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-byte·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-byte·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-primitive-byte·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-primitive-byte·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:56": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3575,168 +2806,8 @@
      ],
      "name": "paths·complex-array-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-valid·get·responses·200"
-     ]
-    },
-    "description": "Complex object with array property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:60"
-      }
-     }
-    }
-   },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-empty·get·responses·200"
-     ]
-    },
-    "description": "Complex object with array property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:60"
-      }
-     }
-    }
-   },
-   "responses:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-empty·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-empty·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-empty·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-empty·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-notprovided·get·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-empty·get·responses·200",
       "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-notprovided·get·responses·200"
      ]
     },
@@ -3745,28 +2816,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:60"
-      }
-     }
-    }
-   },
-   "responses:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-notprovided·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-array-notprovided·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -3781,212 +2830,9 @@
      ],
      "name": "paths·complex-dictionary-typed-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-valid·get·responses·200"
-     ]
-    },
-    "description": "Complex object with dictionary property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:63"
-      }
-     }
-    }
-   },
-   "responses:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:70": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-empty·get·responses·200"
-     ]
-    },
-    "description": "Complex object with dictionary property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:63"
-      }
-     }
-    }
-   },
-   "responses:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-empty·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-empty·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-empty·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-empty·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-null·get·responses·200"
-     ]
-    },
-    "description": "Complex object with dictionary property",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:63"
-      }
-     }
-    }
-   },
-   "responses:75": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-notprovided·get·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-null·get·responses·200",
       "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-notprovided·get·responses·200"
      ]
     },
@@ -3995,28 +2841,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:63"
-      }
-     }
-    }
-   },
-   "responses:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-notprovided·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-dictionary-typed-notprovided·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -4043,65 +2867,6 @@
      }
     }
    },
-   "responses:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-inheritance-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-inheritance-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-inheritance-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-inheritance-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:81": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-inheritance-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-inheritance-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:82": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4112,7 +2877,8 @@
      ],
      "name": "paths·complex-polymorphism-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphicrecursive-valid·get·responses·200"
      ]
     },
     "description": "Returns an object like this: {\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1.0,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'length':20.0,\n            'species':'predator',\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'length':10.0,\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n          },\n          {\n            'fishtype': 'goblin',\n            'age': 1,\n            'birthday': '2015-08-08T00:00:00Z',\n            'length': 30.0,\n            'species': 'scary',\n            'jawsize': 5\n          }\n        ]\n      };",
@@ -4120,65 +2886,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:22"
-      }
-     }
-    }
-   },
-   "responses:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:84": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -4205,28 +2912,6 @@
      }
     }
    },
-   "responses:87": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-dotsyntax·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-dotsyntax·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
    "responses:88": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4237,7 +2922,8 @@
      ],
      "name": "paths·complex-polymorphism-composedwithdiscriminator·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-composedwithdiscriminator·get·responses·200"
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-composedwithdiscriminator·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-composedwithoutdiscriminator·get·responses·200"
      ]
     },
     "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects with discriminator specified",
@@ -4245,72 +2931,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-composedwithdiscriminator·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-composedwithdiscriminator·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:90": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-composedwithoutdiscriminator·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-composedwithoutdiscriminator·get·responses·200"
-     ]
-    },
-    "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects without discriminator specified",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-composedwithoutdiscriminator·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-composedwithoutdiscriminator·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -4325,7 +2945,8 @@
      ],
      "name": "paths·complex-polymorphism-complicated·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-complicated·get·responses·200"
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-complicated·get·responses·200",
+      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-missingdiscriminator·put·responses·200"
      ]
     },
     "description": "OK",
@@ -4333,227 +2954,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:26"
-      }
-     }
-    }
-   },
-   "responses:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-complicated·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-complicated·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:94": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-complicated·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-complicated·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-complicated·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-complicated·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-missingdiscriminator·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-missingdiscriminator·put·responses·200"
-     ]
-    },
-    "description": "Returns a salmon",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:26"
-      }
-     }
-    }
-   },
-   "responses:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-missingdiscriminator·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-missingdiscriminator·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-missingrequired-invalid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-missingrequired-invalid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-missingrequired-invalid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphism-missingrequired-invalid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:100": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphicrecursive-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphicrecursive-valid·get·responses·200"
-     ]
-    },
-    "description": "Complex object that extends cat and pet, returns a Salmon like this:\n{\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'species':'predator',\n            'length':20,\n            'siblings':[\n                {\n                    'fishtype':'Salmon',\n                    'location':'atlantic',\n                    'iswild':true,\n                    'species':'coho',\n                    'length':2,\n                    'siblings':[\n                      {\n                        'fishtype':'Shark',\n                        'age':6,\n                        'birthday': '2012-01-05T01:00:00Z',\n                        'species':'predator',\n                        'length':20\n                      },\n                      {\n                        'fishtype':'Sawshark',\n                        'age':105,\n                        'birthday': '1900-01-05T01:00:00Z',\n                        'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n                        'species':'dangerous',\n                        'length':10\n                      }\n                    ]\n                },\n                {\n                    'fishtype':'Sawshark',\n                    'age':105,\n                    'birthday': '1900-01-05T01:00:00Z',\n                    'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n                    'species':'dangerous',\n                    'length':10,\n                    'siblings':[]\n                }\n            ]\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n            'length':10,'siblings':[]\n          }\n        ]\n    };",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:22"
-      }
-     }
-    }
-   },
-   "responses:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphicrecursive-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphicrecursive-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:102": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphicrecursive-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphicrecursive-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphicrecursive-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-polymorphicrecursive-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -4576,65 +2976,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-readonlyproperty-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-readonlyproperty-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-readonlyproperty-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-readonlyproperty-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-readonlyproperty-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/responses/paths·complex-readonlyproperty-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -5275,8 +3616,7 @@
       "http://localhost:3000/swagger/body-complex.json#/components/schemas/components·schemas·smart_salmon·additionalproperties"
      ]
     },
-    "type": "object",
-    "x-format": "any"
+    "type": "object"
    },
    "schemas:31": {
     "x-ms-metadata": {
@@ -6497,7 +4837,8 @@
      ],
      "name": "paths·complex-array-valid·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-array-valid·put·requestbody"
+      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-array-valid·put·requestbody",
+      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-array-empty·put·requestbody"
      ]
     },
     "content": {
@@ -6511,30 +4852,6 @@
     "description": "Please put an array with 4 items: \"1, 2, 3, 4\", \"\", null, \"&S#$(*Y\", \"The quick brown fox jumps over the lazy dog\"",
     "x-ms-requestBody-name": "complexBody"
    },
-   "requestBodies:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-array-empty·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-array-empty·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:60"
-      }
-     }
-    },
-    "required": true,
-    "description": "Please put an empty array",
-    "x-ms-requestBody-name": "complexBody"
-   },
    "requestBodies:14": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -6545,30 +4862,7 @@
      ],
      "name": "paths·complex-dictionary-typed-valid·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-dictionary-typed-valid·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:63"
-      }
-     }
-    },
-    "required": true,
-    "description": "Please put a dictionary with 5 key-value pairs: \"txt\":\"notepad\", \"bmp\":\"mspaint\", \"xls\":\"excel\", \"exe\":\"\", \"\":null",
-    "x-ms-requestBody-name": "complexBody"
-   },
-   "requestBodies:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-dictionary-typed-empty·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-dictionary-typed-valid·put·requestbody",
       "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-dictionary-typed-empty·put·requestbody"
      ]
     },
@@ -6580,7 +4874,7 @@
      }
     },
     "required": true,
-    "description": "Please put an empty dictionary",
+    "description": "Please put a dictionary with 5 key-value pairs: \"txt\":\"notepad\", \"bmp\":\"mspaint\", \"xls\":\"excel\", \"exe\":\"\", \"\":null",
     "x-ms-requestBody-name": "complexBody"
    },
    "requestBodies:16": {
@@ -6617,7 +4911,9 @@
      ],
      "name": "paths·complex-polymorphism-valid·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphism-valid·put·requestbody"
+      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphism-valid·put·requestbody",
+      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphism-missingrequired-invalid·put·requestbody",
+      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphicrecursive-valid·put·requestbody"
      ]
     },
     "content": {
@@ -6641,29 +4937,7 @@
      ],
      "name": "paths·complex-polymorphism-complicated·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphism-complicated·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:26"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "complexBody"
-   },
-   "requestBodies:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-missingdiscriminator·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphism-complicated·put·requestbody",
       "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphism-missingdiscriminator·put·requestbody"
      ]
     },
@@ -6675,54 +4949,6 @@
      }
     },
     "required": true,
-    "x-ms-requestBody-name": "complexBody"
-   },
-   "requestBodies:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphism-missingrequired-invalid·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphism-missingrequired-invalid·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:22"
-      }
-     }
-    },
-    "required": true,
-    "description": "Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:\n{\n    \"fishtype\": \"sawshark\",\n    \"species\": \"snaggle toothed\",\n    \"length\": 18.5,\n    \"age\": 2,\n    \"birthday\": \"2013-06-01T01:00:00Z\",\n    \"location\": \"alaska\",\n    \"picture\": base64(FF FF FF FF FE),\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"birthday\": \"2012-01-05T01:00:00Z\",\n            \"length\": 20,\n            \"age\": 6\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"picture\": base64(FF FF FF FF FE),\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}",
-    "x-ms-requestBody-name": "complexBody"
-   },
-   "requestBodies:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-02-29"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·complex-polymorphicrecursive-valid·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-complex.json#/components/requestBodies/paths·complex-polymorphicrecursive-valid·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:22"
-      }
-     }
-    },
-    "required": true,
-    "description": "Please put a salmon that looks like this:\n{\n    \"fishtype\": \"salmon\",\n    \"species\": \"king\",\n    \"length\": 1,\n    \"age\": 1,\n    \"location\": \"alaska\",\n    \"iswild\": true,\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"length\": 20,\n            \"age\": 6,\n            \"siblings\": [\n                {\n                    \"fishtype\": \"salmon\",\n                    \"species\": \"coho\",\n                    \"length\": 2,\n                    \"age\": 2,\n                    \"location\": \"atlantic\",\n                    \"iswild\": true,\n                    \"siblings\": [\n                        {\n                            \"fishtype\": \"shark\",\n                            \"species\": \"predator\",\n                            \"length\": 20,\n                            \"age\": 6\n                        },\n                        {\n                            \"fishtype\": \"sawshark\",\n                            \"species\": \"dangerous\",\n                            \"length\": 10,\n                            \"age\": 105\n                        }\n                    ]\n                },\n                {\n                    \"fishtype\": \"sawshark\",\n                    \"species\": \"dangerous\",\n                    \"length\": 10,\n                    \"age\": 105\n                }\n            ]\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}",
     "x-ms-requestBody-name": "complexBody"
    },
    "requestBodies:22": {

--- a/modelerfour/test/inputs/body-date/openapi-document.json
+++ b/modelerfour/test/inputs/body-date/openapi-document.json
@@ -96,11 +96,11 @@
     "responses": {
      "200": {
       "description": "The invalid date value",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -143,11 +143,11 @@
     "responses": {
      "200": {
       "description": "The overflow date value",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -190,11 +190,11 @@
     "responses": {
      "200": {
       "description": "The underflow date value",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -245,7 +245,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -274,11 +274,11 @@
     "responses": {
      "200": {
       "description": "The max date value",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -319,17 +319,17 @@
     "operationId": "date_putMinDate",
     "description": "Put min date value 0000-01-01",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:1"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The min date value",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -362,7 +362,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -380,7 +380,11 @@
      ],
      "name": "paths·date-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-null·get·responses·200"
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-null·get·responses·200",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-invaliddate·get·responses·200",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-overflowdate·get·responses·200",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-underflowdate·get·responses·200",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-max·get·responses·200"
      ]
     },
     "description": "The null date value",
@@ -402,139 +406,14 @@
      ],
      "name": "paths·date-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-invaliddate·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-invaliddate·get·responses·200"
-     ]
-    },
-    "description": "The invalid date value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-invaliddate·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-invaliddate·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-overflowdate·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-overflowdate·get·responses·200"
-     ]
-    },
-    "description": "The overflow date value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-overflowdate·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-overflowdate·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-underflowdate·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-underflowdate·get·responses·200"
-     ]
-    },
-    "description": "The underflow date value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-underflowdate·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-underflowdate·get·responses·default"
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-null·get·responses·default",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-invaliddate·get·responses·default",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-overflowdate·get·responses·default",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-underflowdate·get·responses·default",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-max·put·responses·default",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-max·get·responses·default",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-min·put·responses·default",
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-min·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -556,113 +435,11 @@
      ],
      "name": "paths·date-max·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-max·put·responses·200"
-     ]
-    },
-    "description": "The max date value"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-max·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-max·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-max·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-max·get·responses·200"
-     ]
-    },
-    "description": "The max date value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-max·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-max·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-min·put·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-max·put·responses·200",
       "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-min·put·responses·200"
      ]
     },
-    "description": "The min date value"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-min·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-min·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
+    "description": "The max date value"
    },
    "responses:14": {
     "x-ms-metadata": {
@@ -682,28 +459,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·date-min·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-min·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/responses/paths·date-min·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
       }
      }
     }
@@ -802,29 +557,7 @@
      ],
      "name": "paths·date-max·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-date.json#/components/requestBodies/paths·date-max·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "dateBody"
-   },
-   "requestBodies:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·date-min·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-date.json#/components/requestBodies/paths·date-max·put·requestbody",
       "http://localhost:3000/swagger/body-date.json#/components/requestBodies/paths·date-min·put·requestbody"
      ]
     },

--- a/modelerfour/test/inputs/body-datetime-rfc1123/openapi-document.json
+++ b/modelerfour/test/inputs/body-datetime-rfc1123/openapi-document.json
@@ -96,11 +96,11 @@
     "responses": {
      "200": {
       "description": "The invalid datetime value",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -143,11 +143,11 @@
     "responses": {
      "200": {
       "description": "The overflow datetime value",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -190,11 +190,11 @@
     "responses": {
      "200": {
       "description": "The underflow datetime value",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -245,7 +245,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -288,11 +288,11 @@
     "responses": {
      "200": {
       "description": "The max datetime value fri, 31 dec 9999 23:59:59 gmt",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -335,11 +335,11 @@
     "responses": {
      "200": {
       "description": "The max datetime value FRI, 31 DEC 9999 23:59:59 GMT",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -380,17 +380,17 @@
     "operationId": "datetimerfc1123_putUtcMinDateTime",
     "description": "Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:1"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The min datetime value Mon, 1 Jan 0001 00:00:00 GMT",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -423,7 +423,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -441,7 +441,12 @@
      ],
      "name": "paths·datetimerfc1123-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-null·get·responses·200"
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-null·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-invalid·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-overflow·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-underflow·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max-lowercase·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max-uppercase·get·responses·200"
      ]
     },
     "description": "The null datetime value",
@@ -463,139 +468,15 @@
      ],
      "name": "paths·datetimerfc1123-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-invalid·get·responses·200"
-     ]
-    },
-    "description": "The invalid datetime value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-overflow·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-overflow·get·responses·200"
-     ]
-    },
-    "description": "The overflow datetime value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-overflow·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-overflow·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-underflow·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-underflow·get·responses·200"
-     ]
-    },
-    "description": "The underflow datetime value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-underflow·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-underflow·get·responses·default"
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-null·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-invalid·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-overflow·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-underflow·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max·put·responses·default",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max-lowercase·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max-uppercase·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-min·put·responses·default",
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-min·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -617,157 +498,11 @@
      ],
      "name": "paths·datetimerfc1123-max·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max·put·responses·200"
-     ]
-    },
-    "description": "The max datetime value Fri, 31 Dec 9999 23:59:59 GMT"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-max·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-max-lowercase·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max-lowercase·get·responses·200"
-     ]
-    },
-    "description": "The max datetime value fri, 31 dec 9999 23:59:59 gmt",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-max-lowercase·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max-lowercase·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-max-uppercase·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max-uppercase·get·responses·200"
-     ]
-    },
-    "description": "The max datetime value FRI, 31 DEC 9999 23:59:59 GMT",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-max-uppercase·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max-uppercase·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-min·put·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-max·put·responses·200",
       "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-min·put·responses·200"
      ]
     },
-    "description": "The min datetime value Mon, 1 Jan 0001 00:00:00 GMT"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-min·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-min·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    }
+    "description": "The max datetime value Fri, 31 Dec 9999 23:59:59 GMT"
    },
    "responses:16": {
     "x-ms-metadata": {
@@ -787,28 +522,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·datetimerfc1123-min·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-min·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/responses/paths·datetimerfc1123-min·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
       }
      }
     }
@@ -908,29 +621,7 @@
      ],
      "name": "paths·datetimerfc1123-max·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/requestBodies/paths·datetimerfc1123-max·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "datetimeBody"
-   },
-   "requestBodies:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetimerfc1123-min·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/requestBodies/paths·datetimerfc1123-max·put·requestbody",
       "http://localhost:3000/swagger/body-datetime-rfc1123.json#/components/requestBodies/paths·datetimerfc1123-min·put·requestbody"
      ]
     },

--- a/modelerfour/test/inputs/body-datetime/openapi-document.json
+++ b/modelerfour/test/inputs/body-datetime/openapi-document.json
@@ -96,11 +96,11 @@
     "responses": {
      "200": {
       "description": "The invalid datetime value",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -143,11 +143,11 @@
     "responses": {
      "200": {
       "description": "The overflow datetime value",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -190,11 +190,11 @@
     "responses": {
      "200": {
       "description": "The underflow datetime value",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -245,7 +245,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -288,11 +288,11 @@
     "responses": {
      "200": {
       "description": "The max datetime value 9999-12-31t23:59:59.9999999z",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -335,11 +335,11 @@
     "responses": {
      "200": {
       "description": "The max datetime value 9999-12-31T23:59:59.9999999Z",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -380,17 +380,17 @@
     "operationId": "datetime_putLocalPositiveOffsetMaxDateTime",
     "description": "Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:1"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -433,11 +433,11 @@
     "responses": {
      "200": {
       "description": "The max datetime value 9999-12-31t23:59:59.9999999+14:00",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -480,11 +480,11 @@
     "responses": {
      "200": {
       "description": "The max datetime value 9999-12-31T23:59:59.9999999+14:00",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -525,17 +525,17 @@
     "operationId": "datetime_putLocalNegativeOffsetMaxDateTime",
     "description": "Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:2"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -578,11 +578,11 @@
     "responses": {
      "200": {
       "description": "The max datetime value 9999-12-31T23:59:59.9999999-14:00",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -625,11 +625,11 @@
     "responses": {
      "200": {
       "description": "The max datetime value 9999-12-31t23:59:59.9999999-14:00",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -670,17 +670,17 @@
     "operationId": "datetime_putUtcMinDateTime",
     "description": "Put min datetime value 0001-01-01T00:00:00Z",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:3"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The min datetime value 0001-01-01T00:00:00Z",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -713,7 +713,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -754,17 +754,17 @@
     "operationId": "datetime_putLocalPositiveOffsetMinDateTime",
     "description": "Put min datetime value 0001-01-01T00:00:00+14:00",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:4"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The min datetime value 0001-01-01T00:00:00+14:00",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -797,7 +797,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -838,17 +838,17 @@
     "operationId": "datetime_putLocalNegativeOffsetMinDateTime",
     "description": "Put min datetime value 0001-01-01T00:00:00-14:00",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:5"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The min datetime value 0001-01-01T00:00:00+14:00",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -877,11 +877,11 @@
     "responses": {
      "200": {
       "description": "The min datetime value 0001-01-01T00:00:00+14:00",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:32"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -899,7 +899,16 @@
      ],
      "name": "paths·datetime-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-null·get·responses·200"
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-null·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-invalid·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-overflow·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-underflow·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc-lowercase·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc-uppercase·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset-lowercase·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset-uppercase·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset-uppercase·get·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset-lowercase·get·responses·200"
      ]
     },
     "description": "The null datetime value",
@@ -921,139 +930,25 @@
      ],
      "name": "paths·datetime-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-invalid·get·responses·200"
-     ]
-    },
-    "description": "The invalid datetime value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-overflow·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-overflow·get·responses·200"
-     ]
-    },
-    "description": "The overflow datetime value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-overflow·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-overflow·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-underflow·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-underflow·get·responses·200"
-     ]
-    },
-    "description": "The underflow datetime value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-underflow·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-underflow·get·responses·default"
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-null·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-invalid·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-overflow·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-underflow·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc·put·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc-lowercase·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc-uppercase·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset·put·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset-lowercase·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset-uppercase·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset·put·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset-uppercase·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset-lowercase·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-utc·put·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-utc·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localpositiveoffset·put·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localpositiveoffset·get·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localnegativeoffset·put·responses·default",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localnegativeoffset·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -1075,407 +970,15 @@
      ],
      "name": "paths·datetime-max-utc·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc·put·responses·200"
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc·put·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset·put·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset·put·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-utc·put·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localpositiveoffset·put·responses·200",
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localnegativeoffset·put·responses·200"
      ]
     },
     "description": "The max datetime value 9999-12-31T23:59:59.9999999Z"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-utc·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-utc-lowercase·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc-lowercase·get·responses·200"
-     ]
-    },
-    "description": "The max datetime value 9999-12-31t23:59:59.9999999z",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-utc-lowercase·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc-lowercase·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-utc-uppercase·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc-uppercase·get·responses·200"
-     ]
-    },
-    "description": "The max datetime value 9999-12-31T23:59:59.9999999Z",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-utc-uppercase·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-utc-uppercase·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localpositiveoffset·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset·put·responses·200"
-     ]
-    },
-    "description": "The max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localpositiveoffset·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localpositiveoffset-lowercase·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset-lowercase·get·responses·200"
-     ]
-    },
-    "description": "The max datetime value 9999-12-31t23:59:59.9999999+14:00",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localpositiveoffset-lowercase·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset-lowercase·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localpositiveoffset-uppercase·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset-uppercase·get·responses·200"
-     ]
-    },
-    "description": "The max datetime value 9999-12-31T23:59:59.9999999+14:00",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localpositiveoffset-uppercase·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localpositiveoffset-uppercase·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localnegativeoffset·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset·put·responses·200"
-     ]
-    },
-    "description": "The max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00"
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localnegativeoffset·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localnegativeoffset-uppercase·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset-uppercase·get·responses·200"
-     ]
-    },
-    "description": "The max datetime value 9999-12-31T23:59:59.9999999-14:00",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localnegativeoffset-uppercase·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset-uppercase·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localnegativeoffset-lowercase·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset-lowercase·get·responses·200"
-     ]
-    },
-    "description": "The max datetime value 9999-12-31t23:59:59.9999999-14:00",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localnegativeoffset-lowercase·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-max-localnegativeoffset-lowercase·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-utc·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-utc·put·responses·200"
-     ]
-    },
-    "description": "The min datetime value 0001-01-01T00:00:00Z"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-utc·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-utc·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
    },
    "responses:28": {
     "x-ms-metadata": {
@@ -1499,65 +1002,6 @@
      }
     }
    },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-utc·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-utc·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localpositiveoffset·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localpositiveoffset·put·responses·200"
-     ]
-    },
-    "description": "The min datetime value 0001-01-01T00:00:00+14:00"
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localpositiveoffset·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localpositiveoffset·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
    "responses:32": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1568,87 +1012,7 @@
      ],
      "name": "paths·datetime-min-localpositiveoffset·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localpositiveoffset·get·responses·200"
-     ]
-    },
-    "description": "The min datetime value 0001-01-01T00:00:00+14:00",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/paths·datetime-min-localpositiveoffset·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localpositiveoffset·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localpositiveoffset·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localnegativeoffset·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localnegativeoffset·put·responses·200"
-     ]
-    },
-    "description": "The min datetime value 0001-01-01T00:00:00+14:00"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localnegativeoffset·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localnegativeoffset·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localnegativeoffset·get·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localpositiveoffset·get·responses·200",
       "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localnegativeoffset·get·responses·200"
      ]
     },
@@ -1657,28 +1021,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·datetime-min-localpositiveoffset·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localnegativeoffset·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/responses/paths·datetime-min-localnegativeoffset·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
       }
      }
     }
@@ -1806,121 +1148,11 @@
      ],
      "name": "paths·datetime-max-utc·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-max-utc·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "datetimeBody"
-   },
-   "requestBodies:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localpositiveoffset·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-max-localpositiveoffset·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "datetimeBody"
-   },
-   "requestBodies:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-max-localnegativeoffset·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-max-localnegativeoffset·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "datetimeBody"
-   },
-   "requestBodies:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-utc·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-min-utc·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "datetimeBody"
-   },
-   "requestBodies:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localpositiveoffset·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-min-localpositiveoffset·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "datetimeBody"
-   },
-   "requestBodies:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·datetime-min-localnegativeoffset·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-max-utc·put·requestbody",
+      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-max-localpositiveoffset·put·requestbody",
+      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-max-localnegativeoffset·put·requestbody",
+      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-min-utc·put·requestbody",
+      "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-min-localpositiveoffset·put·requestbody",
       "http://localhost:3000/swagger/body-datetime.json#/components/requestBodies/paths·datetime-min-localnegativeoffset·put·requestbody"
      ]
     },

--- a/modelerfour/test/inputs/body-dictionary/openapi-document.json
+++ b/modelerfour/test/inputs/body-dictionary/openapi-document.json
@@ -102,11 +102,11 @@
     "responses": {
      "200": {
       "description": "The empty dictionary value {}",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -146,7 +146,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -193,7 +193,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -236,11 +236,11 @@
     "responses": {
      "200": {
       "description": "The Dictionary with null key",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -283,11 +283,11 @@
     "responses": {
      "200": {
       "description": "The Dictionary with key as empty string",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -330,11 +330,11 @@
     "responses": {
      "200": {
       "description": "The invalid Dictionary value",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -384,7 +384,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -420,11 +420,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -470,11 +470,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": true, \"1\": null, \"2\": false }",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:14"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -520,11 +520,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value '{\"0\": true, \"1\": \"boolean\", \"2\": false}'",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:14"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -570,11 +570,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -610,11 +610,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -660,11 +660,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 1, \"1\": null, \"2\": 0}",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -710,11 +710,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 1, \"1\": \"integer\", \"2\": 0}",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -764,7 +764,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -800,11 +800,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -850,11 +850,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 1, \"1\": null, \"2\": 0}",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:30"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -900,11 +900,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 1, \"1\": \"integer\", \"2\": 0}",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:30"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -954,7 +954,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -990,11 +990,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1040,11 +1040,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 0.0, \"1\": null, \"2\": 1.2e20}",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:38"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1090,11 +1090,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 1.0, \"1\": \"number\", \"2\": 0.0}",
-      "$ref": "#/components/responses/responses:44"
+      "$ref": "#/components/responses/responses:38"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1144,7 +1144,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:47"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1180,11 +1180,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:48"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:49"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1230,11 +1230,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 0.0, \"1\": null, \"2\": 1.2e20}",
-      "$ref": "#/components/responses/responses:50"
+      "$ref": "#/components/responses/responses:46"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1280,11 +1280,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": 1.0, \"1\": \"number\", \"2\": 0.0}",
-      "$ref": "#/components/responses/responses:52"
+      "$ref": "#/components/responses/responses:46"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:53"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1330,11 +1330,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": \"foo1\", \"1\": \"foo2\", \"2\": \"foo3\"}",
-      "$ref": "#/components/responses/responses:54"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:55"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1361,7 +1361,7 @@
     "operationId": "dictionary_putStringValid",
     "description": "Set dictionary value {\"0\": \"foo1\", \"1\": \"foo2\", \"2\": \"foo3\"}",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:6"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "tags": [
@@ -1370,11 +1370,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:56"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1420,11 +1420,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": \"foo\", \"1\": null, \"2\": \"foo2\"}",
-      "$ref": "#/components/responses/responses:58"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:59"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1470,11 +1470,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": \"foo\", \"1\": 123, \"2\": \"foo2\"}",
-      "$ref": "#/components/responses/responses:60"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:61"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1524,7 +1524,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:63"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1560,11 +1560,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:64"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:65"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1610,11 +1610,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": \"2012-01-01\", \"1\": null, \"2\": \"1776-07-04\"}",
-      "$ref": "#/components/responses/responses:66"
+      "$ref": "#/components/responses/responses:62"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:67"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1660,11 +1660,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": \"2011-03-22\", \"1\": \"date\"}",
-      "$ref": "#/components/responses/responses:68"
+      "$ref": "#/components/responses/responses:62"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:69"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1714,7 +1714,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:71"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1750,11 +1750,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:72"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:73"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1800,11 +1800,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": \"2000-12-01t00:00:01z\", \"1\": null}",
-      "$ref": "#/components/responses/responses:74"
+      "$ref": "#/components/responses/responses:70"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:75"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1850,11 +1850,11 @@
     "responses": {
      "200": {
       "description": "The dictionary value {\"0\": \"2000-12-01t00:00:01z\", \"1\": \"date-time\"}",
-      "$ref": "#/components/responses/responses:76"
+      "$ref": "#/components/responses/responses:70"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:77"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1904,7 +1904,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:79"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1940,11 +1940,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:80"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:81"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1994,7 +1994,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:83"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2030,11 +2030,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:84"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:85"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2084,7 +2084,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:87"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2120,11 +2120,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:88"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:89"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2170,11 +2170,11 @@
     "responses": {
      "200": {
       "description": "The byte dictionary value {\"0\": hex(FF FF FF FA), \"1\": null} with the first item base64 encoded",
-      "$ref": "#/components/responses/responses:90"
+      "$ref": "#/components/responses/responses:86"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:91"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2224,7 +2224,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:93"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2274,7 +2274,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:95"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2320,11 +2320,11 @@
     "responses": {
      "200": {
       "description": "Empty dictionary of complex type {}",
-      "$ref": "#/components/responses/responses:96"
+      "$ref": "#/components/responses/responses:94"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:97"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2370,11 +2370,11 @@
     "responses": {
      "200": {
       "description": "Dictionary of complex type with null item {\"0\": {\"integer\": 1, \"string\": \"2\"}, \"1\": null, \"2\": {\"integer\": 5, \"string\": \"6\"}}",
-      "$ref": "#/components/responses/responses:98"
+      "$ref": "#/components/responses/responses:94"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:99"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2420,11 +2420,11 @@
     "responses": {
      "200": {
       "description": "Dictionary of complex type with empty item {\"0\": {\"integer\": 1, \"string\": \"2\"}, \"1:\" {}, \"2\": {\"integer\": 5, \"string\": \"6\"}}",
-      "$ref": "#/components/responses/responses:100"
+      "$ref": "#/components/responses/responses:94"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:101"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2470,11 +2470,11 @@
     "responses": {
      "200": {
       "description": "Dictionary of complex type with {\"0\": {\"integer\": 1, \"string\": \"2\"}, \"1\": {\"integer\": 3, \"string\": \"4\"}, \"2\": {\"integer\": 5, \"string\": \"6\"}}",
-      "$ref": "#/components/responses/responses:102"
+      "$ref": "#/components/responses/responses:94"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:103"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2510,11 +2510,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:104"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:105"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2564,7 +2564,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:107"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2614,7 +2614,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:109"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2660,11 +2660,11 @@
     "responses": {
      "200": {
       "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": null, \"2\": [\"7\", \"8\", \"9\"]}",
-      "$ref": "#/components/responses/responses:110"
+      "$ref": "#/components/responses/responses:108"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:111"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2710,11 +2710,11 @@
     "responses": {
      "200": {
       "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": [], \"2\": [\"7\", \"8\", \"9\"]}",
-      "$ref": "#/components/responses/responses:112"
+      "$ref": "#/components/responses/responses:108"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:113"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2760,11 +2760,11 @@
     "responses": {
      "200": {
       "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": [\"4\", \"5\", \"6\"], \"2\": [\"7\", \"8\", \"9\"]}",
-      "$ref": "#/components/responses/responses:114"
+      "$ref": "#/components/responses/responses:108"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:115"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2800,11 +2800,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:116"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:117"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2854,7 +2854,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:119"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2900,11 +2900,11 @@
     "responses": {
      "200": {
       "description": "An dictionaries of dictionaries of type <string, string> with value {}",
-      "$ref": "#/components/responses/responses:120"
+      "$ref": "#/components/responses/responses:118"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:121"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2950,11 +2950,11 @@
     "responses": {
      "200": {
       "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": null, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-      "$ref": "#/components/responses/responses:122"
+      "$ref": "#/components/responses/responses:118"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:123"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3000,11 +3000,11 @@
     "responses": {
      "200": {
       "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-      "$ref": "#/components/responses/responses:124"
+      "$ref": "#/components/responses/responses:118"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:125"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3050,11 +3050,11 @@
     "responses": {
      "200": {
       "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {\"4\": \"four\", \"5\": \"five\", \"6\": \"six\"}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-      "$ref": "#/components/responses/responses:126"
+      "$ref": "#/components/responses/responses:118"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:127"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3090,11 +3090,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:128"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:129"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3112,7 +3112,11 @@
      ],
      "name": "paths·dictionary-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-null·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-null·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-_1-3-300·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-null-zero·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-integer-0·get·responses·200"
      ]
     },
     "description": "The null dictionary value",
@@ -3135,52 +3139,71 @@
      ],
      "name": "paths·dictionary-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-empty·get·responses·200"
-     ]
-    },
-    "description": "The empty dictionary value {}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The empty dictionary value {}",
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-empty·get·responses·default"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-null·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-empty·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-nullvalue·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-nullkey·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-keyemptystring·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-invalid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-tfft·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-tfft·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-true-null-false·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-true-boolean-false·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-_1-3-300·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-_1-3-300·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-null-zero·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-integer-0·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-_1-3-300·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-_1-3-300·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-null-zero·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-integer-0·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0_0-01_1-2e20·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-1-number-0·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0_0-01_1-2e20·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-1-number-0·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo1-foo2-foo3·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo-null-foo2·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo-123-foo2·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-invalidnull·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-invalidchars·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-invalidnull·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-invalidchars·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time_rfc1123-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time_rfc1123-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-duration-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-duration-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-invalidnull·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-base64url-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-null·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-itemnull·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-itemempty·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-null·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-itemnull·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-itemempty·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-valid·put·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-null·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-itemnull·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-itemempty·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-valid·get·responses·default",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-valid·put·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -3202,32 +3225,24 @@
      ],
      "name": "paths·dictionary-empty·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-empty·put·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-empty·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-tfft·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-_1-3-300·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-_1-3-300·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0_0-01_1-2e20·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0_0-01_1-2e20·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo1-foo2-foo3·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time_rfc1123-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-duration-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-valid·put·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-valid·put·responses·200"
      ]
     },
     "description": "Empty Response"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-empty·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-empty·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
    },
    "responses:6": {
     "x-ms-metadata": {
@@ -3239,7 +3254,13 @@
      ],
      "name": "paths·dictionary-nullvalue·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-nullvalue·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-nullvalue·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-nullkey·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-keyemptystring·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-invalid·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo-null-foo2·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo-123-foo2·get·responses·200"
      ]
     },
     "description": "The Dictionary with null value",
@@ -3247,160 +3268,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-nullvalue·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-nullvalue·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-nullkey·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-nullkey·get·responses·200"
-     ]
-    },
-    "description": "The Dictionary with null key",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-nullkey·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-nullkey·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-keyemptystring·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-keyemptystring·get·responses·200"
-     ]
-    },
-    "description": "The Dictionary with key as empty string",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:10"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-keyemptystring·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-keyemptystring·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-invalid·get·responses·200"
-     ]
-    },
-    "description": "The invalid Dictionary value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:12"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -3415,7 +3282,9 @@
      ],
      "name": "paths·dictionary-prim-boolean-tfft·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-tfft·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-tfft·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-true-null-false·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-true-boolean-false·get·responses·200"
      ]
     },
     "description": "The dictionary value {\"0\": true, \"1\": false, \"2\": false, \"3\": true }",
@@ -3424,327 +3293,6 @@
       "schema": {
        "description": "The dictionary value {\"0\": true, \"1\": false, \"2\": false, \"3\": true }",
        "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-tfft·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-tfft·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-tfft·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-tfft·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-tfft·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-tfft·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-true-null-false·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-true-null-false·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": true, \"1\": null, \"2\": false }",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": true, \"1\": null, \"2\": false }",
-       "$ref": "#/components/schemas/schemas:18"
-      }
-     }
-    }
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-true-null-false·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-true-null-false·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-true-boolean-false·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-true-boolean-false·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value '{\"0\": true, \"1\": \"boolean\", \"2\": false}'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value [true, 'boolean', false]",
-       "$ref": "#/components/schemas/schemas:20"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-true-boolean-false·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-boolean-true-boolean-false·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-_1-3-300·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-_1-3-300·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
-       "$ref": "#/components/schemas/schemas:22"
-      }
-     }
-    }
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-_1-3-300·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-_1-3-300·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-_1-3-300·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-_1-3-300·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-_1-3-300·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-_1-3-300·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-null-zero·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-null-zero·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": null, \"2\": 0}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 1, \"1\": null, \"2\": 0}",
-       "$ref": "#/components/schemas/schemas:26"
-      }
-     }
-    }
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-null-zero·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-null-zero·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-integer-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-integer-0·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": \"integer\", \"2\": 0}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 1, \"1\": \"integer\", \"2\": 0}",
-       "$ref": "#/components/schemas/schemas:28"
-      }
-     }
-    }
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-integer-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-integer-1-integer-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -3759,7 +3307,9 @@
      ],
      "name": "paths·dictionary-prim-long-1-_1-3-300·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-_1-3-300·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-_1-3-300·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-null-zero·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-integer-0·get·responses·200"
      ]
     },
     "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
@@ -3768,155 +3318,6 @@
       "schema": {
        "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
        "$ref": "#/components/schemas/schemas:30"
-      }
-     }
-    }
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-_1-3-300·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-_1-3-300·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-_1-3-300·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-_1-3-300·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-_1-3-300·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-_1-3-300·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-null-zero·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-null-zero·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": null, \"2\": 0}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 1, \"1\": null, \"2\": 0}",
-       "$ref": "#/components/schemas/schemas:34"
-      }
-     }
-    }
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-null-zero·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-null-zero·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-integer-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-integer-0·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": \"integer\", \"2\": 0}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 1, \"1\": \"integer\", \"2\": 0}",
-       "$ref": "#/components/schemas/schemas:36"
-      }
-     }
-    }
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-integer-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-long-1-integer-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -3931,7 +3332,9 @@
      ],
      "name": "paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-1-number-0·get·responses·200"
      ]
     },
     "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
@@ -3940,155 +3343,6 @@
       "schema": {
        "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
        "$ref": "#/components/schemas/schemas:38"
-      }
-     }
-    }
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0_0-01_1-2e20·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0_0-01_1-2e20·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0_0-01_1-2e20·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0_0-01_1-2e20·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 0.0, \"1\": null, \"2\": 1.2e20}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 0.0, \"1\": null, \"2\": 1.2e20}",
-       "$ref": "#/components/schemas/schemas:42"
-      }
-     }
-    }
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-1-number-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-1-number-0·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1.0, \"1\": \"number\", \"2\": 0.0}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 1.0, \"1\": \"number\", \"2\": 0.0}",
-       "$ref": "#/components/schemas/schemas:44"
-      }
-     }
-    }
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-1-number-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-float-1-number-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -4103,7 +3357,9 @@
      ],
      "name": "paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-1-number-0·get·responses·200"
      ]
     },
     "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
@@ -4112,327 +3368,6 @@
       "schema": {
        "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
        "$ref": "#/components/schemas/schemas:46"
-      }
-     }
-    }
-   },
-   "responses:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0_0-01_1-2e20·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0_0-01_1-2e20·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0_0-01_1-2e20·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0_0-01_1-2e20·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 0.0, \"1\": null, \"2\": 1.2e20}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 0.0, \"1\": null, \"2\": 1.2e20}",
-       "$ref": "#/components/schemas/schemas:50"
-      }
-     }
-    }
-   },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-1-number-0·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-1-number-0·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1.0, \"1\": \"number\", \"2\": 0.0}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": 1.0, \"1\": \"number\", \"2\": 0.0}",
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-1-number-0·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-double-1-number-0·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"foo1\", \"1\": \"foo2\", \"2\": \"foo3\"}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": \"foo1\", \"1\": \"foo2\", \"2\": \"foo3\"}",
-       "$ref": "#/components/schemas/schemas:54"
-      }
-     }
-    }
-   },
-   "responses:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo1-foo2-foo3·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo1-foo2-foo3·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo-null-foo2·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo-null-foo2·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"foo\", \"1\": null, \"2\": \"foo2\"}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": \"foo\", \"1\": null, \"2\": \"foo2\"}",
-       "$ref": "#/components/schemas/schemas:58"
-      }
-     }
-    }
-   },
-   "responses:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo-null-foo2·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo-null-foo2·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo-123-foo2·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo-123-foo2·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"foo\", \"1\": 123, \"2\": \"foo2\"}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": \"foo\", \"1\": 123, \"2\": \"foo2\"}",
-       "$ref": "#/components/schemas/schemas:60"
-      }
-     }
-    }
-   },
-   "responses:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo-123-foo2·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-string-foo-123-foo2·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -4447,7 +3382,9 @@
      ],
      "name": "paths·dictionary-prim-date-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-invalidnull·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-invalidchars·get·responses·200"
      ]
     },
     "description": "The dictionary value {\"0\": \"2000-12-01\", \"1\": \"1980-01-02\", \"2\": \"1492-10-12\"}",
@@ -4456,155 +3393,6 @@
       "schema": {
        "description": "The dictionary value {\"0\": \"2000-12-01\", \"1\": \"1980-01-02\", \"2\": \"1492-10-12\"}",
        "$ref": "#/components/schemas/schemas:62"
-      }
-     }
-    }
-   },
-   "responses:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date-invalidnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-invalidnull·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"2012-01-01\", \"1\": null, \"2\": \"1776-07-04\"}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": \"2012-01-01\", \"1\": null, \"2\": \"1776-07-04\"}",
-       "$ref": "#/components/schemas/schemas:62"
-      }
-     }
-    }
-   },
-   "responses:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date-invalidnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-invalidnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date-invalidchars·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-invalidchars·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"2011-03-22\", \"1\": \"date\"}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": \"2011-03-22\", \"1\": \"date\"}",
-       "$ref": "#/components/schemas/schemas:62"
-      }
-     }
-    }
-   },
-   "responses:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date-invalidchars·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date-invalidchars·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -4619,7 +3407,9 @@
      ],
      "name": "paths·dictionary-prim-date_time-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-invalidnull·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-invalidchars·get·responses·200"
      ]
     },
     "description": "The dictionary value {\"0\": \"2000-12-01t00:00:01z\", \"1\": \"1980-01-02T00:11:35+01:00\", \"2\": \"1492-10-12T10:15:01-08:00\"}",
@@ -4628,155 +3418,6 @@
       "schema": {
        "description": "The dictionary value {\"0\": \"2000-12-01t00:00:01z\", \"1\": \"1980-01-02T00:11:35+01:00\", \"2\": \"1492-10-12T10:15:01-08:00\"}",
        "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time-invalidnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-invalidnull·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"2000-12-01t00:00:01z\", \"1\": null}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": \"2000-12-01t00:00:01z\", \"1\": null}",
-       "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:75": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time-invalidnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-invalidnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time-invalidchars·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-invalidchars·get·responses·200"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"2000-12-01t00:00:01z\", \"1\": \"date-time\"}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": \"2000-12-01t00:00:01z\", \"1\": \"date-time\"}",
-       "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time-invalidchars·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time-invalidchars·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -4804,65 +3445,6 @@
      }
     }
    },
-   "responses:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time_rfc1123-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time_rfc1123-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time_rfc1123-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time_rfc1123-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:81": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-date_time_rfc1123-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-date_time_rfc1123-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
    "responses:82": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4886,65 +3468,6 @@
      }
     }
    },
-   "responses:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-duration-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-duration-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:84": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-duration-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-duration-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-duration-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-duration-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
    "responses:86": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4955,7 +3478,8 @@
      ],
      "name": "paths·dictionary-prim-byte-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-valid·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-valid·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-invalidnull·get·responses·200"
      ]
     },
     "description": "The dictionary value {\"0\": hex(FF FF FF FA), \"1\": hex(01 02 03), \"2\": hex (25, 29, 43)} with each elementencoded in base 64",
@@ -4964,110 +3488,6 @@
       "schema": {
        "description": "The dictionary value {\"0\": hex(FF FF FF FA), \"1\": hex(01 02 03), \"2\": hex (25, 29, 43)} with each elementencoded in base 64",
        "$ref": "#/components/schemas/schemas:86"
-      }
-     }
-    }
-   },
-   "responses:87": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-byte-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-byte-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-byte-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:90": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-byte-invalidnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-invalidnull·get·responses·200"
-     ]
-    },
-    "description": "The byte dictionary value {\"0\": hex(FF FF FF FA), \"1\": null} with the first item base64 encoded",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The byte dictionary value {\"0\": hex(FF FF FF FA), \"1\": null} with the first item base64 encoded",
-       "$ref": "#/components/schemas/schemas:86"
-      }
-     }
-    }
-   },
-   "responses:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-byte-invalidnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-byte-invalidnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -5095,28 +3515,6 @@
      }
     }
    },
-   "responses:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-base64url-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-prim-base64url-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
    "responses:94": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -5127,7 +3525,11 @@
      ],
      "name": "paths·dictionary-complex-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-null·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-null·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-itemnull·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-itemempty·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-valid·get·responses·200"
      ]
     },
     "description": "Dictionary of complex type with null value",
@@ -5136,245 +3538,6 @@
       "schema": {
        "description": "Dictionary of complex type with null value",
        "$ref": "#/components/schemas/schemas:94"
-      }
-     }
-    }
-   },
-   "responses:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-empty·get·responses·200"
-     ]
-    },
-    "description": "Empty dictionary of complex type {}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Empty dictionary of complex type {}",
-       "$ref": "#/components/schemas/schemas:94"
-      }
-     }
-    }
-   },
-   "responses:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-itemnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-itemnull·get·responses·200"
-     ]
-    },
-    "description": "Dictionary of complex type with null item {\"0\": {\"integer\": 1, \"string\": \"2\"}, \"1\": null, \"2\": {\"integer\": 5, \"string\": \"6\"}}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Dictionary of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]",
-       "$ref": "#/components/schemas/schemas:94"
-      }
-     }
-    }
-   },
-   "responses:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-itemnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-itemnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:100": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-itemempty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-itemempty·get·responses·200"
-     ]
-    },
-    "description": "Dictionary of complex type with empty item {\"0\": {\"integer\": 1, \"string\": \"2\"}, \"1:\" {}, \"2\": {\"integer\": 5, \"string\": \"6\"}}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Dictionary of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]",
-       "$ref": "#/components/schemas/schemas:94"
-      }
-     }
-    }
-   },
-   "responses:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-itemempty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-itemempty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:102": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-valid·get·responses·200"
-     ]
-    },
-    "description": "Dictionary of complex type with {\"0\": {\"integer\": 1, \"string\": \"2\"}, \"1\": {\"integer\": 3, \"string\": \"4\"}, \"2\": {\"integer\": 5, \"string\": \"6\"}}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Dictionary of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
-       "$ref": "#/components/schemas/schemas:94"
-      }
-     }
-    }
-   },
-   "responses:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-complex-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-complex-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -5402,28 +3565,6 @@
      }
     }
    },
-   "responses:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
    "responses:108": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -5434,7 +3575,10 @@
      ],
      "name": "paths·dictionary-array-empty·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-empty·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-itemnull·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-itemempty·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-valid·get·responses·200"
      ]
     },
     "description": "An empty dictionary {}",
@@ -5443,200 +3587,6 @@
       "schema": {
        "description": "An empty dictionary {}",
        "$ref": "#/components/schemas/schemas:103"
-      }
-     }
-    }
-   },
-   "responses:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-itemnull·get·responses·200"
-     ]
-    },
-    "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": null, \"2\": [\"7\", \"8\", \"9\"]}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": null, \"2\": [\"7\", \"8\", \"9\"]}",
-       "$ref": "#/components/schemas/schemas:106"
-      }
-     }
-    }
-   },
-   "responses:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-itemnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemempty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-itemempty·get·responses·200"
-     ]
-    },
-    "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": [], \"2\": [\"7\", \"8\", \"9\"]}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": [], \"2\": [\"7\", \"8\", \"9\"]}",
-       "$ref": "#/components/schemas/schemas:109"
-      }
-     }
-    }
-   },
-   "responses:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemempty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-itemempty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-valid·get·responses·200"
-     ]
-    },
-    "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": [\"4\", \"5\", \"6\"], \"2\": [\"7\", \"8\", \"9\"]}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": [\"4\", \"5\", \"6\"], \"2\": [\"7\", \"8\", \"9\"]}",
-       "$ref": "#/components/schemas/schemas:112"
-      }
-     }
-    }
-   },
-   "responses:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-array-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -5651,7 +3601,11 @@
      ],
      "name": "paths·dictionary-dictionary-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-null·get·responses·200"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-null·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-empty·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-itemnull·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-itemempty·get·responses·200",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-valid·get·responses·200"
      ]
     },
     "description": "An dictionaries of dictionaries with value null",
@@ -5660,245 +3614,6 @@
       "schema": {
        "description": "An dictionaries of dictionaries with value null",
        "$ref": "#/components/schemas/schemas:118"
-      }
-     }
-    }
-   },
-   "responses:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-empty·get·responses·200"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An dictionaries of dictionaries of type <string, string> with value {}",
-       "$ref": "#/components/schemas/schemas:121"
-      }
-     }
-    }
-   },
-   "responses:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemnull·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-itemnull·get·responses·200"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": null, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": null, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-       "$ref": "#/components/schemas/schemas:124"
-      }
-     }
-    }
-   },
-   "responses:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemnull·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-itemnull·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemempty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-itemempty·get·responses·200"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-       "$ref": "#/components/schemas/schemas:127"
-      }
-     }
-    }
-   },
-   "responses:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemempty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-itemempty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:126": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-valid·get·responses·200"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {\"4\": \"four\", \"5\": \"five\", \"6\": \"six\"}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {\"4\": \"four\", \"5\": \"five\", \"6\": \"six\"}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-       "$ref": "#/components/schemas/schemas:130"
-      }
-     }
-    }
-   },
-   "responses:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
-      }
-     }
-    }
-   },
-   "responses:128": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-valid·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:129": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/responses/paths·dictionary-dictionary-valid·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:138"
       }
      }
     }
@@ -5915,7 +3630,12 @@
      ],
      "name": "paths·dictionary-null·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-null·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-null·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-null-zero·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-integer-0·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The null dictionary value",
@@ -5934,78 +3654,15 @@
      ],
      "name": "paths·dictionary-null·get·responses·200·content·application-json·schema·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-null·get·responses·200·content·application-json·schema·additionalproperties"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-null·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-null-zero·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-integer-0·get·responses·200·content·application-json·schema·additionalproperties"
      ]
     },
     "type": "integer"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The empty dictionary value {}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:3"
-    }
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-empty·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-empty·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The empty dictionary value {}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:5"
-    }
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-empty·put·requestbody·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-empty·put·requestbody·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "string"
    },
    "schemas:6": {
     "x-ms-metadata": {
@@ -6017,7 +3674,21 @@
      ],
      "name": "paths·dictionary-nullvalue·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-nullvalue·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-nullvalue·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-empty·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-nullkey·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-invalid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema·additionalproperties"
      ]
     },
     "type": "object",
@@ -6035,106 +3706,25 @@
      ],
      "name": "paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-nullkey·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-nullkey·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:9"
-    }
-   },
-   "schemas:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-nullkey·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-nullkey·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:11"
-    }
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-invalid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-invalid·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:13"
-    }
-   },
-   "schemas:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-invalid·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-invalid·get·responses·200·content·application-json·schema·additionalproperties"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-empty·put·requestbody·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-nullkey·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-invalid·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties·items",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties·items",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties·items",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties·items",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema·additionalproperties·additionalproperties"
      ]
     },
     "type": "string"
@@ -6149,7 +3739,10 @@
      ],
      "name": "paths·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-tfft·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-true-null-false·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The dictionary value {\"0\": true, \"1\": false, \"2\": false, \"3\": true }",
@@ -6168,248 +3761,13 @@
      ],
      "name": "paths·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-tfft·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-tfft·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": true, \"1\": false, \"2\": false, \"3\": true }",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:17"
-    }
-   },
-   "schemas:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-tfft·put·requestbody·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-tfft·put·requestbody·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-true-null-false·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-true-null-false·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": true, \"1\": null, \"2\": false }",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:19"
-    }
-   },
-   "schemas:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-true-null-false·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-true-null-false·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value [true, 'boolean', false]",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:21"
-    }
-   },
-   "schemas:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-tfft·put·requestbody·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-true-null-false·get·responses·200·content·application-json·schema·additionalproperties",
       "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema·additionalproperties"
      ]
     },
     "type": "boolean"
-   },
-   "schemas:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:23"
-    }
-   },
-   "schemas:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:25"
-    }
-   },
-   "schemas:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-null-zero·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-null-zero·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": null, \"2\": 0}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:27"
-    }
-   },
-   "schemas:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-null-zero·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-null-zero·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-integer-0·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-integer-0·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": \"integer\", \"2\": 0}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:29"
-    }
-   },
-   "schemas:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-integer-1-integer-0·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-integer-1-integer-0·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "integer"
    },
    "schemas:30": {
     "x-ms-metadata": {
@@ -6421,7 +3779,10 @@
      ],
      "name": "paths·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-null-zero·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-integer-0·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
@@ -6440,111 +3801,9 @@
      ],
      "name": "paths·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:33"
-    }
-   },
-   "schemas:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-null-zero·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-null-zero·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": null, \"2\": 0}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:35"
-    }
-   },
-   "schemas:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-null-zero·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-null-zero·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-integer-0·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-integer-0·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1, \"1\": \"integer\", \"2\": 0}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:37"
-    }
-   },
-   "schemas:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-long-1-integer-0·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-null-zero·get·responses·200·content·application-json·schema·additionalproperties",
       "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-long-1-integer-0·get·responses·200·content·application-json·schema·additionalproperties"
      ]
     },
@@ -6561,7 +3820,10 @@
      ],
      "name": "paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-1-number-0·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
@@ -6580,111 +3842,9 @@
      ],
      "name": "paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:41"
-    }
-   },
-   "schemas:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 0.0, \"1\": null, \"2\": 1.2e20}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:43"
-    }
-   },
-   "schemas:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-1-number-0·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-1-number-0·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1.0, \"1\": \"number\", \"2\": 0.0}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:45"
-    }
-   },
-   "schemas:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-float-1-number-0·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema·additionalproperties",
       "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-float-1-number-0·get·responses·200·content·application-json·schema·additionalproperties"
      ]
     },
@@ -6701,7 +3861,10 @@
      ],
      "name": "paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-1-number-0·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
@@ -6720,252 +3883,14 @@
      ],
      "name": "paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:49"
-    }
-   },
-   "schemas:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 0.0, \"1\": null, \"2\": 1.2e20}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:51"
-    }
-   },
-   "schemas:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-1-number-0·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-1-number-0·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": 1.0, \"1\": \"number\", \"2\": 0.0}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:53"
-    }
-   },
-   "schemas:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-double-1-number-0·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema·additionalproperties",
       "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-double-1-number-0·get·responses·200·content·application-json·schema·additionalproperties"
      ]
     },
     "type": "number",
     "format": "double"
-   },
-   "schemas:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"foo1\", \"1\": \"foo2\", \"2\": \"foo3\"}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:55"
-    }
-   },
-   "schemas:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"foo1\", \"1\": \"foo2\", \"2\": \"foo3\"}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:57"
-    }
-   },
-   "schemas:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"foo\", \"1\": null, \"2\": \"foo2\"}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:59"
-    }
-   },
-   "schemas:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "The dictionary value {\"0\": \"foo\", \"1\": 123, \"2\": \"foo2\"}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:61"
-    }
-   },
-   "schemas:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "string"
    },
    "schemas:62": {
     "x-ms-metadata": {
@@ -7283,7 +4208,10 @@
      ],
      "name": "paths·dictionary-array-empty·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-empty·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-valid·get·responses·200·content·application-json·schema"
      ]
     },
     "description": "An empty dictionary {}",
@@ -7302,184 +4230,16 @@
      ],
      "name": "paths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:105"
-    }
-   },
-   "schemas:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": null, \"2\": [\"7\", \"8\", \"9\"]}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:107"
-    }
-   },
-   "schemas:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:108"
-    }
-   },
-   "schemas:108": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": [], \"2\": [\"7\", \"8\", \"9\"]}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:110"
-    }
-   },
-   "schemas:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:111"
-    }
-   },
-   "schemas:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-valid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-valid·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An array of array of strings {\"0\": [\"1\", \"2\", \"3\"], \"1\": [\"4\", \"5\", \"6\"], \"2\": [\"7\", \"8\", \"9\"]}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:113"
-    }
-   },
-   "schemas:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties",
       "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties"
      ]
     },
     "type": "array",
     "items": {
-     "$ref": "#/components/schemas/schemas:114"
+     "$ref": "#/components/schemas/schemas:7"
     }
-   },
-   "schemas:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties·items"
-     ]
-    },
-    "type": "string"
    },
    "schemas:115": {
     "x-ms-metadata": {
@@ -7543,307 +4303,19 @@
      ],
      "name": "paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema"
      ]
     },
     "description": "An dictionaries of dictionaries with value null",
     "type": "object",
     "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:119"
+     "$ref": "#/components/schemas/schemas:6"
     }
-   },
-   "schemas:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:120"
-    }
-   },
-   "schemas:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:122"
-    }
-   },
-   "schemas:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:123"
-    }
-   },
-   "schemas:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": null, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:125"
-    }
-   },
-   "schemas:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:126"
-    }
-   },
-   "schemas:126": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:128"
-    }
-   },
-   "schemas:128": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:129"
-    }
-   },
-   "schemas:129": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:130": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {\"4\": \"four\", \"5\": \"five\", \"6\": \"six\"}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:131"
-    }
-   },
-   "schemas:131": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:132"
-    }
-   },
-   "schemas:132": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:133": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {\"4\": \"four\", \"5\": \"five\", \"6\": \"six\"}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:134"
-    }
-   },
-   "schemas:134": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema·additionalproperties"
-     ]
-    },
-    "type": "object",
-    "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:135"
-    }
-   },
-   "schemas:135": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema·additionalproperties·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/schemas/paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema·additionalproperties·additionalproperties"
-     ]
-    },
-    "type": "string"
    },
    "schemas:136": {
     "x-ms-metadata": {
@@ -7934,14 +4406,15 @@
      ],
      "name": "paths·dictionary-empty·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/requestBodies/paths·dictionary-empty·put·requestbody"
+      "http://localhost:3000/swagger/body-dictionary.json#/components/requestBodies/paths·dictionary-empty·put·requestbody",
+      "http://localhost:3000/swagger/body-dictionary.json#/components/requestBodies/paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
        "description": "The empty dictionary value {}",
-       "$ref": "#/components/schemas/schemas:4"
+       "$ref": "#/components/schemas/schemas:6"
       }
      }
     },
@@ -7965,7 +4438,7 @@
      "application/json": {
       "schema": {
        "description": "The dictionary value {\"0\": true, \"1\": false, \"2\": false, \"3\": true }",
-       "$ref": "#/components/schemas/schemas:16"
+       "$ref": "#/components/schemas/schemas:14"
       }
      }
     },
@@ -7989,7 +4462,7 @@
      "application/json": {
       "schema": {
        "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
-       "$ref": "#/components/schemas/schemas:24"
+       "$ref": "#/components/schemas/schemas:0"
       }
      }
     },
@@ -8013,7 +4486,7 @@
      "application/json": {
       "schema": {
        "description": "The dictionary value {\"0\": 1, \"1\": -1, \"2\": 3, \"3\": 300}",
-       "$ref": "#/components/schemas/schemas:32"
+       "$ref": "#/components/schemas/schemas:30"
       }
      }
     },
@@ -8037,7 +4510,7 @@
      "application/json": {
       "schema": {
        "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
-       "$ref": "#/components/schemas/schemas:40"
+       "$ref": "#/components/schemas/schemas:38"
       }
      }
     },
@@ -8061,31 +4534,7 @@
      "application/json": {
       "schema": {
        "description": "The dictionary value {\"0\": 0, \"1\": -0.01, \"2\": 1.2e20}",
-       "$ref": "#/components/schemas/schemas:48"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "arrayBody"
-   },
-   "requestBodies:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-dictionary.json#/components/requestBodies/paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "The dictionary value {\"0\": \"foo1\", \"1\": \"foo2\", \"2\": \"foo3\"}",
-       "$ref": "#/components/schemas/schemas:56"
+       "$ref": "#/components/schemas/schemas:46"
       }
      }
     },
@@ -8277,7 +4726,7 @@
      "application/json": {
       "schema": {
        "description": "An dictionaries of dictionaries of type <string, string> with value {\"0\": {\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, \"1\": {\"4\": \"four\", \"5\": \"five\", \"6\": \"six\"}, \"2\": {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}}",
-       "$ref": "#/components/schemas/schemas:133"
+       "$ref": "#/components/schemas/schemas:118"
       }
      }
     },

--- a/modelerfour/test/inputs/body-duration/openapi-document.json
+++ b/modelerfour/test/inputs/body-duration/openapi-document.json
@@ -104,7 +104,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -133,11 +133,11 @@
     "responses": {
      "200": {
       "description": "The positive duration value",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -180,11 +180,11 @@
     "responses": {
      "200": {
       "description": "The invalid duration value",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -202,7 +202,9 @@
      ],
      "name": "paths·duration-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-null·get·responses·200"
+      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-null·get·responses·200",
+      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-positiveduration·get·responses·200",
+      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-invalid·get·responses·200"
      ]
     },
     "description": "The null duration value",
@@ -224,7 +226,10 @@
      ],
      "name": "paths·duration-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-null·get·responses·default"
+      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-null·get·responses·default",
+      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-positiveduration·put·responses·default",
+      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-positiveduration·get·responses·default",
+      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-invalid·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -250,116 +255,6 @@
      ]
     },
     "description": "A positive duration value"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·duration-positiveduration·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-positiveduration·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·duration-positiveduration·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-positiveduration·get·responses·200"
-     ]
-    },
-    "description": "The positive duration value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·duration-positiveduration·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-positiveduration·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·duration-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-invalid·get·responses·200"
-     ]
-    },
-    "description": "The invalid duration value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·duration-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-duration.json#/components/responses/paths·duration-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
    }
   },
   "schemas": {

--- a/modelerfour/test/inputs/body-file/openapi-document.json
+++ b/modelerfour/test/inputs/body-file/openapi-document.json
@@ -102,11 +102,11 @@
     "responses": {
      "200": {
       "description": "The large file",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -152,11 +152,11 @@
     "responses": {
      "200": {
       "description": "The empty file stream",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -174,7 +174,9 @@
      ],
      "name": "paths·files-stream-nonempty·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-nonempty·get·responses·200"
+      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-nonempty·get·responses·200",
+      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-verylarge·get·responses·200",
+      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-empty·get·responses·200"
      ]
     },
     "description": "The PNG file",
@@ -186,7 +188,7 @@
      },
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:1"
+       "$ref": "#/components/schemas/schemas:0"
       }
      }
     }
@@ -201,114 +203,8 @@
      ],
      "name": "paths·files-stream-nonempty·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-nonempty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "image/png": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     },
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-verylarge·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-verylarge·get·responses·200"
-     ]
-    },
-    "description": "The large file",
-    "content": {
-     "image/png": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     },
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-verylarge·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-verylarge·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "image/png": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     },
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-empty·get·responses·200"
-     ]
-    },
-    "description": "The empty file stream",
-    "content": {
-     "image/png": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     },
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-empty·get·responses·default",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-nonempty·get·responses·default",
+      "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-verylarge·get·responses·default",
       "http://localhost:3000/swagger/body-file.json#/components/responses/paths·files-stream-empty·get·responses·default"
      ]
     },
@@ -338,81 +234,11 @@
      ],
      "name": "paths·files-stream-nonempty·get·responses·200·content·image-png·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-nonempty·get·responses·200·content·image-png·schema"
-     ]
-    },
-    "type": "file"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-nonempty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-nonempty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "file"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-verylarge·get·responses·200·content·image-png·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-verylarge·get·responses·200·content·image-png·schema"
-     ]
-    },
-    "type": "file"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-verylarge·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-verylarge·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "file"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-empty·get·responses·200·content·image-png·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-empty·get·responses·200·content·image-png·schema"
-     ]
-    },
-    "type": "file"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·files-stream-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-nonempty·get·responses·200·content·image-png·schema",
+      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-nonempty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-verylarge·get·responses·200·content·image-png·schema",
+      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-verylarge·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-empty·get·responses·200·content·image-png·schema",
       "http://localhost:3000/swagger/body-file.json#/components/schemas/paths·files-stream-empty·get·responses·200·content·application-json·schema"
      ]
     },

--- a/modelerfour/test/inputs/body-formdata-urlencoded/openapi-document.json
+++ b/modelerfour/test/inputs/body-formdata-urlencoded/openapi-document.json
@@ -63,7 +63,7 @@
      },
      "405": {
       "description": "Invalid input",
-      "$ref": "#/components/responses/responses:1"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -203,25 +203,11 @@
      ],
      "name": "paths·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-formdata-urlencoded.json#/components/responses/paths·get·responses·200"
-     ]
-    },
-    "description": "Pet updated."
-   },
-   "responses:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·get·responses·405",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-formdata-urlencoded.json#/components/responses/paths·get·responses·200",
       "http://localhost:3000/swagger/body-formdata-urlencoded.json#/components/responses/paths·get·responses·405"
      ]
     },
-    "description": "Invalid input"
+    "description": "Pet updated."
    }
   }
  },

--- a/modelerfour/test/inputs/body-formdata/openapi-document.json
+++ b/modelerfour/test/inputs/body-formdata/openapi-document.json
@@ -97,11 +97,11 @@
     "responses": {
      "200": {
       "description": "Serialized file stream",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -228,22 +228,10 @@
      ],
      "name": "paths·formdata-stream-uploadfile·post·responses·200·content·application-octet_stream·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-formdata.json#/components/schemas/paths·formdata-stream-uploadfile·post·responses·200·content·application-octet_stream·schema"
-     ]
-    },
-    "type": "file"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·formdata-stream-uploadfile·post·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-formdata.json#/components/schemas/paths·formdata-stream-uploadfile·post·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-formdata.json#/components/schemas/paths·formdata-stream-uploadfile·post·responses·200·content·application-octet_stream·schema",
+      "http://localhost:3000/swagger/body-formdata.json#/components/schemas/paths·formdata-stream-uploadfile·post·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-formdata.json#/components/schemas/paths·formdata-stream-uploadfile·put·responses·200·content·application-octet_stream·schema",
+      "http://localhost:3000/swagger/body-formdata.json#/components/schemas/paths·formdata-stream-uploadfile·put·responses·200·content·application-json·schema"
      ]
     },
     "type": "file"
@@ -263,36 +251,6 @@
     },
     "type": "object",
     "format": "file"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·formdata-stream-uploadfile·put·responses·200·content·application-octet_stream·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-formdata.json#/components/schemas/paths·formdata-stream-uploadfile·put·responses·200·content·application-octet_stream·schema"
-     ]
-    },
-    "type": "file"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·formdata-stream-uploadfile·put·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-formdata.json#/components/schemas/paths·formdata-stream-uploadfile·put·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "file"
    },
    "schemas:8": {
     "x-ms-metadata": {
@@ -345,7 +303,8 @@
      ],
      "name": "paths·formdata-stream-uploadfile·post·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-formdata.json#/components/responses/paths·formdata-stream-uploadfile·post·responses·200"
+      "http://localhost:3000/swagger/body-formdata.json#/components/responses/paths·formdata-stream-uploadfile·post·responses·200",
+      "http://localhost:3000/swagger/body-formdata.json#/components/responses/paths·formdata-stream-uploadfile·put·responses·200"
      ]
     },
     "description": "Serialized file stream",
@@ -357,7 +316,7 @@
      },
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:4"
+       "$ref": "#/components/schemas/schemas:3"
       }
      }
     }
@@ -372,60 +331,7 @@
      ],
      "name": "paths·formdata-stream-uploadfile·post·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-formdata.json#/components/responses/paths·formdata-stream-uploadfile·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/octet-stream": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     },
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·formdata-stream-uploadfile·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-formdata.json#/components/responses/paths·formdata-stream-uploadfile·put·responses·200"
-     ]
-    },
-    "description": "Serialized file stream",
-    "content": {
-     "application/octet-stream": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     },
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·formdata-stream-uploadfile·put·responses·default",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-formdata.json#/components/responses/paths·formdata-stream-uploadfile·post·responses·default",
       "http://localhost:3000/swagger/body-formdata.json#/components/responses/paths·formdata-stream-uploadfile·put·responses·default"
      ]
     },

--- a/modelerfour/test/inputs/body-integer/openapi-document.json
+++ b/modelerfour/test/inputs/body-integer/openapi-document.json
@@ -96,11 +96,11 @@
     "responses": {
      "200": {
       "description": "The invalid int value",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -147,7 +147,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -190,11 +190,11 @@
     "responses": {
      "200": {
       "description": "The underflow Int32 value",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -241,7 +241,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -284,11 +284,11 @@
     "responses": {
      "200": {
       "description": "The underflow Int64 value",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -339,7 +339,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -386,11 +386,11 @@
     "responses": {
      "200": {
       "description": "The max int64 value",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:12"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -431,17 +431,17 @@
     "operationId": "int_putMin32",
     "description": "Put min int32 value",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:2"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The min int32 value",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:12"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -482,17 +482,17 @@
     "operationId": "int_putMin64",
     "description": "Put min int64 value",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:3"
+     "$ref": "#/components/requestBodies/requestBodies:1"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The min int64 value",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:12"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -539,7 +539,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -572,11 +572,11 @@
     "responses": {
      "200": {
       "description": "The datetime value encoded as Unix time",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:12"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -619,11 +619,11 @@
     "responses": {
      "200": {
       "description": "The invalid Unix time value",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:20"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -666,11 +666,11 @@
     "responses": {
      "200": {
       "description": "The null Unix time value",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:20"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -688,7 +688,8 @@
      ],
      "name": "paths·int-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-null·get·responses·200"
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-null·get·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-invalid·get·responses·200"
      ]
     },
     "description": "The null int value",
@@ -710,51 +711,20 @@
      ],
      "name": "paths·int-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-invalid·get·responses·200"
-     ]
-    },
-    "description": "The invalid int value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:1"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-invalid·get·responses·default"
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-null·get·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-invalid·get·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-overflowint32·get·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-underflowint32·get·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-overflowint64·get·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-underflowint64·get·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-max-32·put·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-max-64·put·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-min-32·put·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-min-64·put·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-unixtime·get·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-unixtime·put·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-invalidunixtime·get·responses·default",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-nullunixtime·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -776,7 +746,8 @@
      ],
      "name": "paths·int-overflowint32·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-overflowint32·get·responses·200"
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-overflowint32·get·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-underflowint32·get·responses·200"
      ]
     },
     "description": "The overflow Int32 value",
@@ -784,72 +755,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-overflowint32·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-overflowint32·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-underflowint32·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-underflowint32·get·responses·200"
-     ]
-    },
-    "description": "The underflow Int32 value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-underflowint32·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-underflowint32·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
       }
      }
     }
@@ -864,7 +769,8 @@
      ],
      "name": "paths·int-overflowint64·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-overflowint64·get·responses·200"
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-overflowint64·get·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-underflowint64·get·responses·200"
      ]
     },
     "description": "The overflow Int64 value",
@@ -872,72 +778,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-overflowint64·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-overflowint64·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-underflowint64·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-underflowint64·get·responses·200"
-     ]
-    },
-    "description": "The underflow Int64 value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-underflowint64·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-underflowint64·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
       }
      }
     }
@@ -952,143 +792,14 @@
      ],
      "name": "paths·int-max-32·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-max-32·put·responses·200"
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-max-32·put·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-max-64·put·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-min-32·put·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-min-64·put·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-unixtime·put·responses·200"
      ]
     },
     "description": "The max int32 value"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-max-32·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-max-32·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-max-64·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-max-64·put·responses·200"
-     ]
-    },
-    "description": "The max int64 value"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-max-64·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-max-64·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-min-32·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-min-32·put·responses·200"
-     ]
-    },
-    "description": "The min int32 value"
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-min-32·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-min-32·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-min-64·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-min-64·put·responses·200"
-     ]
-    },
-    "description": "The min int64 value"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-min-64·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-min-64·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
    },
    "responses:20": {
     "x-ms-metadata": {
@@ -1100,7 +811,9 @@
      ],
      "name": "paths·int-unixtime·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-unixtime·get·responses·200"
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-unixtime·get·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-invalidunixtime·get·responses·200",
+      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-nullunixtime·get·responses·200"
      ]
     },
     "description": "The date value encoded as Unix time",
@@ -1108,153 +821,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:10"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-unixtime·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-unixtime·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-unixtime·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-unixtime·put·responses·200"
-     ]
-    },
-    "description": "The datetime value encoded as Unix time"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-unixtime·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-unixtime·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-invalidunixtime·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-invalidunixtime·get·responses·200"
-     ]
-    },
-    "description": "The invalid Unix time value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:12"
-      }
-     }
-    }
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-invalidunixtime·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-invalidunixtime·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-nullunixtime·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-nullunixtime·get·responses·200"
-     ]
-    },
-    "description": "The null Unix time value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:13"
-      }
-     }
-    }
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-nullunixtime·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/responses/paths·int-nullunixtime·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:14"
       }
      }
     }
@@ -1271,21 +837,7 @@
      ],
      "name": "paths·int-null·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-null·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-invalid·get·responses·200·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-null·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-invalid·get·responses·200·content·application-json·schema"
      ]
     },
@@ -1301,23 +853,10 @@
      ],
      "name": "paths·int-overflowint32·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-overflowint32·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "int32"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-underflowint32·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-underflowint32·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-overflowint32·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-underflowint32·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-max-32·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-min-32·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "integer",
@@ -1333,86 +872,9 @@
      ],
      "name": "paths·int-overflowint64·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-overflowint64·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-underflowint64·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-underflowint64·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-max-32·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-max-32·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "int32"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-max-64·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-max-64·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "int64"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-min-32·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-min-32·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "int32"
-   },
-   "schemas:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-min-64·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-overflowint64·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-underflowint64·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-max-64·put·requestbody·content·application-json·schema",
       "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-min-64·put·requestbody·content·application-json·schema"
      ]
     },
@@ -1429,54 +891,9 @@
      ],
      "name": "paths·int-unixtime·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-unixtime·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "unixtime"
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-unixtime·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-unixtime·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "unixtime"
-   },
-   "schemas:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-invalidunixtime·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-invalidunixtime·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "integer",
-    "format": "unixtime"
-   },
-   "schemas:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-nullunixtime·get·responses·200·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-unixtime·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-unixtime·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-invalidunixtime·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-integer.json#/components/schemas/paths·int-nullunixtime·get·responses·200·content·application-json·schema"
      ]
     },
@@ -1534,13 +951,14 @@
      ],
      "name": "paths·int-max-32·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/requestBodies/paths·int-max-32·put·requestbody"
+      "http://localhost:3000/swagger/body-integer.json#/components/requestBodies/paths·int-max-32·put·requestbody",
+      "http://localhost:3000/swagger/body-integer.json#/components/requestBodies/paths·int-min-32·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:6"
+       "$ref": "#/components/schemas/schemas:2"
       }
      }
     },
@@ -1557,59 +975,14 @@
      ],
      "name": "paths·int-max-64·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/requestBodies/paths·int-max-64·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "intBody"
-   },
-   "requestBodies:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-min-32·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-integer.json#/components/requestBodies/paths·int-min-32·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "intBody"
-   },
-   "requestBodies:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·int-min-64·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-integer.json#/components/requestBodies/paths·int-max-64·put·requestbody",
       "http://localhost:3000/swagger/body-integer.json#/components/requestBodies/paths·int-min-64·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:9"
+       "$ref": "#/components/schemas/schemas:4"
       }
      }
     },
@@ -1632,7 +1005,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:11"
+       "$ref": "#/components/schemas/schemas:10"
       }
      }
     },

--- a/modelerfour/test/inputs/body-number.quirks/openapi-document.json
+++ b/modelerfour/test/inputs/body-number.quirks/openapi-document.json
@@ -100,7 +100,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -147,7 +147,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -198,7 +198,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -231,7 +231,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -278,11 +278,11 @@
     "responses": {
      "200": {
       "description": "The big double value",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -315,7 +315,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -356,17 +356,17 @@
     "operationId": "number_putBigDoublePositiveDecimal",
     "description": "Put big double value 99999999.99",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:2"
+     "$ref": "#/components/requestBodies/requestBodies:1"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The big double value",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -399,7 +399,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -440,17 +440,17 @@
     "operationId": "number_putBigDoubleNegativeDecimal",
     "description": "Put big double value -99999999.99",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:3"
+     "$ref": "#/components/requestBodies/requestBodies:1"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The big double value",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -483,7 +483,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -530,11 +530,11 @@
     "responses": {
      "200": {
       "description": "The big decimal value",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -567,7 +567,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -608,17 +608,17 @@
     "operationId": "number_putBigDecimalPositiveDecimal",
     "description": "Put big decimal value 99999999.99",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:5"
+     "$ref": "#/components/requestBodies/requestBodies:4"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The big decimal value",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -651,7 +651,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -692,17 +692,17 @@
     "operationId": "number_putBigDecimalNegativeDecimal",
     "description": "Put big decimal value -99999999.99",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:6"
+     "$ref": "#/components/requestBodies/requestBodies:4"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The big decimal value",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -735,7 +735,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -776,17 +776,17 @@
     "operationId": "number_putSmallFloat",
     "description": "Put small float value 3.402823e-20",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:7"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The small float value",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -819,7 +819,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -860,17 +860,17 @@
     "operationId": "number_putSmallDouble",
     "description": "Put small double value 2.5976931e-101",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:8"
+     "$ref": "#/components/requestBodies/requestBodies:1"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The small double value",
-      "$ref": "#/components/responses/responses:38"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -903,7 +903,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -944,17 +944,17 @@
     "operationId": "number_putSmallDecimal",
     "description": "Put small decimal value 2.5976931e-101",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:9"
+     "$ref": "#/components/requestBodies/requestBodies:4"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The small decimal value",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:6"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -987,7 +987,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1027,7 +1027,29 @@
      ],
      "name": "paths·number-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-null·get·responses·default"
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-null·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-invalidfloat·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-invaliddouble·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-float-3-402823e-20·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-float-3-402823e-20·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-2-5976931e-101·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-2-5976931e-101·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-99999999-99·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-99999999-99·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-_99999999-99·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-_99999999-99·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-2-5976931e-101·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-2-5976931e-101·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-99999999-99·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-99999999-99·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-_99999999-99·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-_99999999-99·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-float-3-402823e_20·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-float-3-402823e_20·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-double-2-5976931e_101·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-double-2-5976931e_101·get·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-decimal-2-5976931e_101·put·responses·default",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-decimal-2-5976931e_101·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -1061,28 +1083,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-invalidfloat·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-invalidfloat·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
    "responses:4": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1105,28 +1105,6 @@
      }
     }
    },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-invaliddouble·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-invaliddouble·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
    "responses:6": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1137,32 +1115,19 @@
      ],
      "name": "paths·number-big-float-3-402823e-20·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-float-3-402823e-20·put·responses·200"
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-float-3-402823e-20·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-2-5976931e-101·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-99999999-99·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-_99999999-99·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-2-5976931e-101·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-99999999-99·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-_99999999-99·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-float-3-402823e_20·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-double-2-5976931e_101·put·responses·200",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-decimal-2-5976931e_101·put·responses·200"
      ]
     },
     "description": "The big float value"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-float-3-402823e-20·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-float-3-402823e-20·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
    },
    "responses:8": {
     "x-ms-metadata": {
@@ -1182,65 +1147,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-float-3-402823e-20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-float-3-402823e-20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-2-5976931e-101·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-2-5976931e-101·put·responses·200"
-     ]
-    },
-    "description": "The big double value"
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-2-5976931e-101·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-2-5976931e-101·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
       }
      }
     }
@@ -1267,65 +1173,6 @@
      }
     }
    },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-2-5976931e-101·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-2-5976931e-101·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-99999999-99·put·responses·200"
-     ]
-    },
-    "description": "The big double value"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-99999999-99·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
    "responses:16": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1344,65 +1191,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-99999999-99·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-_99999999-99·put·responses·200"
-     ]
-    },
-    "description": "The big double value"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-_99999999-99·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
       }
      }
     }
@@ -1429,65 +1217,6 @@
      }
     }
    },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-double-_99999999-99·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-2-5976931e-101·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-2-5976931e-101·put·responses·200"
-     ]
-    },
-    "description": "The big decimal value"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-2-5976931e-101·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-2-5976931e-101·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
    "responses:24": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1506,65 +1235,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-2-5976931e-101·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-2-5976931e-101·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-99999999-99·put·responses·200"
-     ]
-    },
-    "description": "The big decimal value"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-99999999-99·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
       }
      }
     }
@@ -1591,65 +1261,6 @@
      }
     }
    },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-99999999-99·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-_99999999-99·put·responses·200"
-     ]
-    },
-    "description": "The big decimal value"
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-_99999999-99·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
    "responses:32": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1668,65 +1279,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-big-decimal-_99999999-99·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-float-3-402823e_20·put·responses·200"
-     ]
-    },
-    "description": "The small float value"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-float-3-402823e_20·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
       }
      }
     }
@@ -1753,65 +1305,6 @@
      }
     }
    },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-float-3-402823e_20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-double-2-5976931e_101·put·responses·200"
-     ]
-    },
-    "description": "The small double value"
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-double-2-5976931e_101·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
    "responses:40": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1834,65 +1327,6 @@
      }
     }
    },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-double-2-5976931e_101·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-decimal-2-5976931e_101·put·responses·200"
-     ]
-    },
-    "description": "The small decimal value"
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-decimal-2-5976931e_101·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
    "responses:44": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1911,28 +1345,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-small-decimal-2-5976931e_101·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/responses/paths·number-small-decimal-2-5976931e_101·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
       }
      }
     }
@@ -1964,7 +1376,9 @@
      ],
      "name": "paths·number-invalidfloat·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-invalidfloat·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-invalidfloat·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-float-3-402823e-20·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-small-float-3-402823e_20·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "number",
@@ -1980,71 +1394,11 @@
      ],
      "name": "paths·number-invaliddouble·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-invaliddouble·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-float-3-402823e-20·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-float-3-402823e-20·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-2-5976931e-101·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-double-2-5976931e-101·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema"
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-invaliddouble·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-double-2-5976931e-101·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-small-double-2-5976931e_101·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "number",
@@ -2060,86 +1414,9 @@
      ],
      "name": "paths·number-big-decimal-2-5976931e-101·put·requestbody·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-decimal-2-5976931e-101·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "decimal"
-   },
-   "schemas:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "decimal"
-   },
-   "schemas:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "decimal"
-   },
-   "schemas:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-small-float-3-402823e_20·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-small-double-2-5976931e_101·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-decimal-2-5976931e-101·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema",
       "http://localhost:3000/swagger/body-number.quirks.json#/components/schemas/paths·number-small-decimal-2-5976931e_101·put·requestbody·content·application-json·schema"
      ]
     },
@@ -2387,13 +1664,14 @@
      ],
      "name": "paths·number-big-float-3-402823e-20·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-float-3-402823e-20·put·requestbody"
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-float-3-402823e-20·put·requestbody",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-small-float-3-402823e_20·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:3"
+       "$ref": "#/components/schemas/schemas:1"
       }
      }
     },
@@ -2410,59 +1688,16 @@
      ],
      "name": "paths·number-big-double-2-5976931e-101·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-double-2-5976931e-101·put·requestbody"
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-double-2-5976931e-101·put·requestbody",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-double-99999999-99·put·requestbody",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-double-_99999999-99·put·requestbody",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-small-double-2-5976931e_101·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-double-99999999-99·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-double-_99999999-99·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
+       "$ref": "#/components/schemas/schemas:2"
       }
      }
     },
@@ -2479,128 +1714,16 @@
      ],
      "name": "paths·number-big-decimal-2-5976931e-101·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-decimal-2-5976931e-101·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:11"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-decimal-99999999-99·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:13"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-decimal-_99999999-99·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-small-float-3-402823e_20·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:17"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-small-double-2-5976931e_101·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:19"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-decimal-2-5976931e-101·put·requestbody",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-decimal-99999999-99·put·requestbody",
+      "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-big-decimal-_99999999-99·put·requestbody",
       "http://localhost:3000/swagger/body-number.quirks.json#/components/requestBodies/paths·number-small-decimal-2-5976931e_101·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:21"
+       "$ref": "#/components/schemas/schemas:11"
       }
      }
     },

--- a/modelerfour/test/inputs/body-number/openapi-document.json
+++ b/modelerfour/test/inputs/body-number/openapi-document.json
@@ -100,7 +100,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -147,7 +147,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -194,7 +194,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -245,7 +245,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -278,7 +278,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -325,11 +325,11 @@
     "responses": {
      "200": {
       "description": "The big double value",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -362,7 +362,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -409,11 +409,11 @@
     "responses": {
      "200": {
       "description": "The big double value",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -446,7 +446,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -493,11 +493,11 @@
     "responses": {
      "200": {
       "description": "The big double value",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -530,7 +530,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -577,11 +577,11 @@
     "responses": {
      "200": {
       "description": "The big decimal value",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -614,7 +614,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -661,11 +661,11 @@
     "responses": {
      "200": {
       "description": "The big decimal value",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -698,7 +698,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -745,11 +745,11 @@
     "responses": {
      "200": {
       "description": "The big decimal value",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -782,7 +782,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -823,17 +823,17 @@
     "operationId": "number_putSmallFloat",
     "description": "Put small float value 3.402823e-20",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:7"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The small float value",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -866,7 +866,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -907,17 +907,17 @@
     "operationId": "number_putSmallDouble",
     "description": "Put small double value 2.5976931e-101",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:8"
+     "$ref": "#/components/requestBodies/requestBodies:1"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The small double value",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -950,7 +950,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -991,17 +991,17 @@
     "operationId": "number_putSmallDecimal",
     "description": "Put small decimal value 2.5976931e-101",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:9"
+     "$ref": "#/components/requestBodies/requestBodies:4"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "The small decimal value",
-      "$ref": "#/components/responses/responses:44"
+      "$ref": "#/components/responses/responses:8"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1034,7 +1034,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:47"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1074,7 +1074,30 @@
      ],
      "name": "paths·number-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-null·get·responses·default"
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-null·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-invalidfloat·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-invaliddouble·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-invaliddecimal·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-float-3-402823e-20·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-float-3-402823e-20·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-2-5976931e-101·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-2-5976931e-101·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-99999999-99·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-99999999-99·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-_99999999-99·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-_99999999-99·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-2-5976931e-101·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-2-5976931e-101·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-99999999-99·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-99999999-99·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-_99999999-99·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-_99999999-99·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-float-3-402823e_20·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-float-3-402823e_20·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-double-2-5976931e_101·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-double-2-5976931e_101·get·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-decimal-2-5976931e_101·put·responses·default",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-decimal-2-5976931e_101·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -1108,28 +1131,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-invalidfloat·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-invalidfloat·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
    "responses:4": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1148,28 +1149,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-invaliddouble·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-invaliddouble·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
       }
      }
     }
@@ -1196,28 +1175,6 @@
      }
     }
    },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-invaliddecimal·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-invaliddecimal·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
    "responses:8": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1228,32 +1185,19 @@
      ],
      "name": "paths·number-big-float-3-402823e-20·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-float-3-402823e-20·put·responses·200"
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-float-3-402823e-20·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-2-5976931e-101·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-99999999-99·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-_99999999-99·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-2-5976931e-101·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-99999999-99·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-_99999999-99·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-float-3-402823e_20·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-double-2-5976931e_101·put·responses·200",
+      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-decimal-2-5976931e_101·put·responses·200"
      ]
     },
     "description": "The big float value"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-float-3-402823e-20·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-float-3-402823e-20·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
    },
    "responses:10": {
     "x-ms-metadata": {
@@ -1273,65 +1217,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-float-3-402823e-20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-float-3-402823e-20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-2-5976931e-101·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-2-5976931e-101·put·responses·200"
-     ]
-    },
-    "description": "The big double value"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-2-5976931e-101·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-2-5976931e-101·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
       }
      }
     }
@@ -1358,65 +1243,6 @@
      }
     }
    },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-2-5976931e-101·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-2-5976931e-101·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-99999999-99·put·responses·200"
-     ]
-    },
-    "description": "The big double value"
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-99999999-99·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
    "responses:18": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1435,65 +1261,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-99999999-99·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-_99999999-99·put·responses·200"
-     ]
-    },
-    "description": "The big double value"
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-_99999999-99·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
       }
      }
     }
@@ -1520,65 +1287,6 @@
      }
     }
    },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-double-_99999999-99·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-2-5976931e-101·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-2-5976931e-101·put·responses·200"
-     ]
-    },
-    "description": "The big decimal value"
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-2-5976931e-101·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-2-5976931e-101·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
    "responses:26": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1597,65 +1305,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-2-5976931e-101·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-2-5976931e-101·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-99999999-99·put·responses·200"
-     ]
-    },
-    "description": "The big decimal value"
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-99999999-99·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
       }
      }
     }
@@ -1682,65 +1331,6 @@
      }
     }
    },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-99999999-99·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-_99999999-99·put·responses·200"
-     ]
-    },
-    "description": "The big decimal value"
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-_99999999-99·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
    "responses:34": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1759,65 +1349,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-big-decimal-_99999999-99·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-float-3-402823e_20·put·responses·200"
-     ]
-    },
-    "description": "The small float value"
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-float-3-402823e_20·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
       }
      }
     }
@@ -1844,65 +1375,6 @@
      }
     }
    },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-float-3-402823e_20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-double-2-5976931e_101·put·responses·200"
-     ]
-    },
-    "description": "The small double value"
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-double-2-5976931e_101·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
    "responses:42": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1925,65 +1397,6 @@
      }
     }
    },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-double-2-5976931e_101·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
-   "responses:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-decimal-2-5976931e_101·put·responses·200"
-     ]
-    },
-    "description": "The small decimal value"
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-decimal-2-5976931e_101·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
-      }
-     }
-    }
-   },
    "responses:46": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -2002,28 +1415,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·number-small-decimal-2-5976931e_101·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/responses/paths·number-small-decimal-2-5976931e_101·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:24"
       }
      }
     }
@@ -2055,7 +1446,9 @@
      ],
      "name": "paths·number-invalidfloat·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-invalidfloat·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-invalidfloat·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-float-3-402823e-20·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-small-float-3-402823e_20·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "number",
@@ -2071,7 +1464,9 @@
      ],
      "name": "paths·number-invaliddouble·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-invaliddouble·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-invaliddouble·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-2-5976931e-101·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-small-double-2-5976931e_101·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "number",
@@ -2087,102 +1482,8 @@
      ],
      "name": "paths·number-invaliddecimal·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-invaliddecimal·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "decimal"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-float-3-402823e-20·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-float-3-402823e-20·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-2-5976931e-101·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-2-5976931e-101·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-2-5976931e-101·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-2-5976931e-101·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "decimal"
-   },
-   "schemas:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-small-float-3-402823e_20·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "float"
-   },
-   "schemas:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-small-double-2-5976931e_101·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "double"
-   },
-   "schemas:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-invaliddecimal·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-2-5976931e-101·put·requestbody·content·application-json·schema",
       "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-small-decimal-2-5976931e_101·put·requestbody·content·application-json·schema"
      ]
     },
@@ -2266,25 +1567,6 @@
      2.5976931e+101
     ]
    },
-   "paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "double",
-    "enum": [
-     99999999.99
-    ]
-   },
    "paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -2295,32 +1577,14 @@
      ],
      "name": "paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "number",
     "format": "double",
     "enum": [
      99999999.99
-    ]
-   },
-   "paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "double",
-    "enum": [
-     -99999999.99
     ]
    },
    "paths·number-big-double-_99999999-99·get·responses·200·content·application-json·schema": {
@@ -2333,7 +1597,8 @@
      ],
      "name": "paths·number-big-double-_99999999-99·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-_99999999-99·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-_99999999-99·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "number",
@@ -2361,25 +1626,6 @@
      2.5976931e+101
     ]
    },
-   "paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "decimal",
-    "enum": [
-     99999999.99
-    ]
-   },
    "paths·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -2390,32 +1636,14 @@
      ],
      "name": "paths·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "number",
     "format": "decimal",
     "enum": [
      99999999.99
-    ]
-   },
-   "paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "number",
-    "format": "decimal",
-    "enum": [
-     -99999999.99
     ]
    },
    "paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema": {
@@ -2428,7 +1656,8 @@
      ],
      "name": "paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-number.json#/components/schemas/paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "number",
@@ -2506,13 +1735,14 @@
      ],
      "name": "paths·number-big-float-3-402823e-20·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-big-float-3-402823e-20·put·requestbody"
+      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-big-float-3-402823e-20·put·requestbody",
+      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-small-float-3-402823e_20·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:4"
+       "$ref": "#/components/schemas/schemas:1"
       }
      }
     },
@@ -2529,13 +1759,14 @@
      ],
      "name": "paths·number-big-double-2-5976931e-101·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-big-double-2-5976931e-101·put·requestbody"
+      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-big-double-2-5976931e-101·put·requestbody",
+      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-small-double-2-5976931e_101·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:6"
+       "$ref": "#/components/schemas/schemas:2"
       }
      }
     },
@@ -2558,7 +1789,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema"
       }
      }
     },
@@ -2581,7 +1812,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·number-big-double-_99999999-99·get·responses·200·content·application-json·schema"
       }
      }
     },
@@ -2598,13 +1829,14 @@
      ],
      "name": "paths·number-big-decimal-2-5976931e-101·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-big-decimal-2-5976931e-101·put·requestbody"
+      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-big-decimal-2-5976931e-101·put·requestbody",
+      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-small-decimal-2-5976931e_101·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:12"
+       "$ref": "#/components/schemas/schemas:3"
       }
      }
     },
@@ -2627,7 +1859,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema"
       }
      }
     },
@@ -2650,76 +1882,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-float-3-402823e_20·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-small-float-3-402823e_20·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:18"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-double-2-5976931e_101·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-small-double-2-5976931e_101·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:20"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "numberBody"
-   },
-   "requestBodies:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·number-small-decimal-2-5976931e_101·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-number.json#/components/requestBodies/paths·number-small-decimal-2-5976931e_101·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:22"
+       "$ref": "#/components/schemas/paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema"
       }
      }
     },

--- a/modelerfour/test/inputs/body-string.quirks/openapi-document.json
+++ b/modelerfour/test/inputs/body-string.quirks/openapi-document.json
@@ -96,7 +96,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -146,7 +146,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -182,11 +182,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -236,7 +236,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -263,7 +263,7 @@
     "operationId": "string_putMbcs",
     "description": "Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:2"
+     "$ref": "#/components/requestBodies/requestBodies:1"
     },
     "x-ms-requestBody-index": 0,
     "tags": [
@@ -272,11 +272,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -326,7 +326,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -353,7 +353,7 @@
     "operationId": "string_putWhitespace",
     "description": "Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:3"
+     "$ref": "#/components/requestBodies/requestBodies:1"
     },
     "x-ms-requestBody-index": 0,
     "tags": [
@@ -362,11 +362,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -416,7 +416,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -452,11 +452,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -502,11 +502,11 @@
     "responses": {
      "200": {
       "description": "The String value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:16"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -542,11 +542,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -596,7 +596,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -632,11 +632,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -686,7 +686,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -736,7 +736,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -782,11 +782,11 @@
     "responses": {
      "200": {
       "description": "The base64url encoded string value",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:30"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -822,11 +822,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -872,11 +872,11 @@
     "responses": {
      "200": {
       "description": "The null value",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:30"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -916,7 +916,25 @@
      ],
      "name": "paths·string-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-null·get·responses·default"
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-null·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-null·put·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-empty·put·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-mbcs·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-mbcs·put·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-whitespace·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-whitespace·put·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-notexpandable·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-notexpandable·put·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referenced·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referenced·put·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referencedconstant·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referencedconstant·put·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-notprovided·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64encoding·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64urlencoding·get·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64urlencoding·put·responses·default",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-nullbase64urlencoding·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -938,32 +956,17 @@
      ],
      "name": "paths·string-null·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-null·put·responses·200"
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-null·put·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-empty·put·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-mbcs·put·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-whitespace·put·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-notexpandable·put·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referenced·put·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referencedconstant·put·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64urlencoding·put·responses·200"
      ]
     },
     "description": "Empty Response"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-null·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-null·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
    },
    "responses:4": {
     "x-ms-metadata": {
@@ -983,65 +986,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·string-empty·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-empty·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-empty·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-empty·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-empty·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
       }
      }
     }
@@ -1068,65 +1012,6 @@
      }
     }
    },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-mbcs·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-mbcs·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-mbcs·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
    "responses:12": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1149,65 +1034,6 @@
      }
     }
    },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-whitespace·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-whitespace·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-whitespace·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
    "responses:16": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1218,87 +1044,7 @@
      ],
      "name": "paths·string-enum-notexpandable·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-notexpandable·get·responses·200"
-     ]
-    },
-    "description": "The String value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/Colors"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-notexpandable·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-notexpandable·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-notexpandable·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-notexpandable·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-notexpandable·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-notexpandable·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referenced·get·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-notexpandable·get·responses·200",
       "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referenced·get·responses·200"
      ]
     },
@@ -1307,65 +1053,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/Colors"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referenced·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referenced·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referenced·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referenced·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referenced·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referenced·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
       }
      }
     }
@@ -1392,65 +1079,6 @@
      }
     }
    },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referencedconstant·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referencedconstant·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referencedconstant·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referencedconstant·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referencedconstant·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-enum-referencedconstant·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
    "responses:28": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1473,28 +1101,6 @@
      }
     }
    },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-notprovided·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-notprovided·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
    "responses:30": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1505,7 +1111,9 @@
      ],
      "name": "paths·string-base64encoding·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64encoding·get·responses·200"
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64encoding·get·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64urlencoding·get·responses·200",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-nullbase64urlencoding·get·responses·200"
      ]
     },
     "description": "The base64 encoded string value",
@@ -1516,216 +1124,9 @@
       }
      }
     }
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64encoding·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64encoding·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64urlencoding·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64urlencoding·get·responses·200"
-     ]
-    },
-    "description": "The base64url encoded string value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:11"
-      }
-     }
-    }
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64urlencoding·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64urlencoding·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64urlencoding·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64urlencoding·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64urlencoding·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-base64urlencoding·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-nullbase64urlencoding·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-nullbase64urlencoding·get·responses·200"
-     ]
-    },
-    "description": "The null value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:11"
-      }
-     }
-    }
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-nullbase64urlencoding·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/responses/paths·string-nullbase64urlencoding·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
    }
   },
   "schemas": {
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-null·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-null·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-empty·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-empty·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-mbcs·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-whitespace·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "string"
-   },
    "schemas:10": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1736,7 +1137,11 @@
      ],
      "name": "paths·string-notprovided·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-notprovided·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-notprovided·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-null·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-empty·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-mbcs·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-whitespace·put·requestbody·content·application-json·schema"
      ]
     },
     "type": "string"
@@ -1925,7 +1330,9 @@
      ],
      "name": "Colors",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-enum-notexpandable·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-enum-notexpandable·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/paths·string-enum-notexpandable·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/schemas/RefColors"
      ]
     },
     "x-ms-enum": {
@@ -1980,7 +1387,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:1"
+       "$ref": "#/components/schemas/schemas:10"
       }
      }
     },
@@ -1996,59 +1403,15 @@
      ],
      "name": "paths·string-empty·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/requestBodies/paths·string-empty·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "stringBody"
-   },
-   "requestBodies:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.quirks.json#/components/requestBodies/paths·string-mbcs·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "stringBody"
-   },
-   "requestBodies:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/requestBodies/paths·string-empty·put·requestbody",
+      "http://localhost:3000/swagger/body-string.quirks.json#/components/requestBodies/paths·string-mbcs·put·requestbody",
       "http://localhost:3000/swagger/body-string.quirks.json#/components/requestBodies/paths·string-whitespace·put·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:7"
+       "$ref": "#/components/schemas/schemas:10"
       }
      }
     },

--- a/modelerfour/test/inputs/body-string/openapi-document.json
+++ b/modelerfour/test/inputs/body-string/openapi-document.json
@@ -96,7 +96,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -146,7 +146,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -182,11 +182,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -236,7 +236,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -272,11 +272,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -326,7 +326,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -362,11 +362,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -416,7 +416,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -452,11 +452,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -502,11 +502,11 @@
     "responses": {
      "200": {
       "description": "The String value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:16"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -542,11 +542,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -596,7 +596,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -632,11 +632,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -686,7 +686,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -736,7 +736,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -782,11 +782,11 @@
     "responses": {
      "200": {
       "description": "The base64url encoded string value",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:30"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -822,11 +822,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:2"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -872,11 +872,11 @@
     "responses": {
      "200": {
       "description": "The null value",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:30"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -916,7 +916,25 @@
      ],
      "name": "paths·string-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-null·get·responses·default"
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-null·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-null·put·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-empty·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-empty·put·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-mbcs·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-mbcs·put·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-whitespace·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-whitespace·put·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-notexpandable·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-notexpandable·put·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referenced·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referenced·put·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referencedconstant·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referencedconstant·put·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-notprovided·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64encoding·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64urlencoding·get·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64urlencoding·put·responses·default",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-nullbase64urlencoding·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -938,32 +956,17 @@
      ],
      "name": "paths·string-null·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-null·put·responses·200"
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-null·put·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-empty·put·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-mbcs·put·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-whitespace·put·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-notexpandable·put·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referenced·put·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referencedconstant·put·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64urlencoding·put·responses·200"
      ]
     },
     "description": "Empty Response"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-null·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-null·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
    },
    "responses:4": {
     "x-ms-metadata": {
@@ -983,65 +986,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/paths·string-empty·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-empty·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-empty·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-empty·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-empty·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
       }
      }
     }
@@ -1068,65 +1012,6 @@
      }
     }
    },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-mbcs·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-mbcs·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-mbcs·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
    "responses:12": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1149,65 +1034,6 @@
      }
     }
    },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-whitespace·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-whitespace·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-whitespace·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
    "responses:16": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1218,87 +1044,7 @@
      ],
      "name": "paths·string-enum-notexpandable·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-notexpandable·get·responses·200"
-     ]
-    },
-    "description": "The String value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/Colors"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-notexpandable·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-notexpandable·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-notexpandable·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-notexpandable·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-notexpandable·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-notexpandable·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referenced·get·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-notexpandable·get·responses·200",
       "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referenced·get·responses·200"
      ]
     },
@@ -1307,65 +1053,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/Colors"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referenced·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referenced·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referenced·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referenced·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referenced·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referenced·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
       }
      }
     }
@@ -1392,65 +1079,6 @@
      }
     }
    },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referencedconstant·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referencedconstant·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referencedconstant·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referencedconstant·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-enum-referencedconstant·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-enum-referencedconstant·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
    "responses:28": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1473,28 +1101,6 @@
      }
     }
    },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-notprovided·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-notprovided·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
    "responses:30": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1505,7 +1111,9 @@
      ],
      "name": "paths·string-base64encoding·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64encoding·get·responses·200"
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64encoding·get·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64urlencoding·get·responses·200",
+      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-nullbase64urlencoding·get·responses·200"
      ]
     },
     "description": "The base64 encoded string value",
@@ -1513,153 +1121,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:11"
-      }
-     }
-    }
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64encoding·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64encoding·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64urlencoding·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64urlencoding·get·responses·200"
-     ]
-    },
-    "description": "The base64url encoded string value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:11"
-      }
-     }
-    }
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64urlencoding·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64urlencoding·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64urlencoding·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64urlencoding·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-base64urlencoding·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-base64urlencoding·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-nullbase64urlencoding·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-nullbase64urlencoding·get·responses·200"
-     ]
-    },
-    "description": "The null value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:11"
-      }
-     }
-    }
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-nullbase64urlencoding·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/responses/paths·string-nullbase64urlencoding·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
       }
      }
     }
@@ -1793,24 +1254,7 @@
      ],
      "name": "paths·string-null·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-null·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "string",
-    "enum": [
-     null
-    ]
-   },
-   "paths·string-null·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-null·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-null·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-null·put·requestbody·content·application-json·schema"
      ]
     },
@@ -1829,24 +1273,7 @@
      ],
      "name": "paths·string-empty·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "string",
-    "enum": [
-     ""
-    ]
-   },
-   "paths·string-empty·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-empty·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-empty·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-empty·put·requestbody·content·application-json·schema"
      ]
     },
@@ -1865,24 +1292,7 @@
      ],
      "name": "paths·string-mbcs·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-mbcs·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "string",
-    "enum": [
-     "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€"
-    ]
-   },
-   "paths·string-mbcs·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-mbcs·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-mbcs·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-mbcs·put·requestbody·content·application-json·schema"
      ]
     },
@@ -1901,24 +1311,7 @@
      ],
      "name": "paths·string-whitespace·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-whitespace·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "type": "string",
-    "enum": [
-     "    Now is the time for all good men to come to the aid of their country    "
-    ]
-   },
-   "paths·string-whitespace·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·string-whitespace·put·requestbody·content·application-json·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-whitespace·get·responses·200·content·application-json·schema",
       "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-whitespace·put·requestbody·content·application-json·schema"
      ]
     },
@@ -1937,7 +1330,9 @@
      ],
      "name": "Colors",
      "originalLocations": [
-      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-enum-notexpandable·get·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-enum-notexpandable·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/body-string.json#/components/schemas/paths·string-enum-notexpandable·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/body-string.json#/components/schemas/RefColors"
      ]
     },
     "x-ms-enum": {
@@ -1992,7 +1387,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·string-null·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·string-null·get·responses·200·content·application-json·schema"
       }
      }
     },
@@ -2014,7 +1409,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·string-empty·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·string-empty·get·responses·200·content·application-json·schema"
       }
      }
     },
@@ -2037,7 +1432,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·string-mbcs·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·string-mbcs·get·responses·200·content·application-json·schema"
       }
      }
     },
@@ -2060,7 +1455,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/paths·string-whitespace·put·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·string-whitespace·get·responses·200·content·application-json·schema"
       }
      }
     },

--- a/modelerfour/test/inputs/complex-model/openapi-document.json
+++ b/modelerfour/test/inputs/complex-model/openapi-document.json
@@ -102,7 +102,7 @@
       "description": "Subscription ID."
      },
      {
-      "$ref": "#/components/parameters/parameters:2",
+      "$ref": "#/components/parameters/parameters:0",
       "description": "Resource Group ID."
      },
      {
@@ -124,7 +124,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -153,11 +153,11 @@
     "description": "Resets products.",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:3",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "Subscription ID."
      },
      {
-      "$ref": "#/components/parameters/parameters:4",
+      "$ref": "#/components/parameters/parameters:0",
       "description": "Resource Group ID."
      },
      {
@@ -175,11 +175,11 @@
     "responses": {
      "200": {
       "description": "A list of caches",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -197,7 +197,9 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·parameters·1"
+      "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·parameters·1",
+      "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·1",
+      "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·1"
      ]
     },
     "name": "resourceGroupName",
@@ -219,50 +221,7 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·0"
-     ]
-    },
-    "name": "subscriptionId",
-    "in": "path",
-    "description": "Subscription ID.",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:1"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·1"
-     ]
-    },
-    "name": "resourceGroupName",
-    "in": "path",
-    "description": "Resource Group ID.",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:2"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·0",
-     "originalLocations": [
+      "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·0",
       "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·0"
      ]
     },
@@ -270,29 +229,7 @@
     "in": "path",
     "description": "Subscription ID.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:3"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·1"
-     ]
-    },
-    "name": "resourceGroupName",
-    "in": "path",
-    "description": "Resource Group ID.",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:4"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -357,66 +294,10 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·1·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·parameters·1·schema",
+      "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·0·schema",
+      "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·1·schema",
+      "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·0·schema",
       "http://localhost:3000/swagger/complex-model.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·1·schema"
      ]
     },
@@ -792,7 +673,8 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·responses·200"
+      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·responses·200",
+      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·responses·200"
      ]
     },
     "description": "A list of caches",
@@ -814,7 +696,9 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·responses·default"
+      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·get·responses·default",
+      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·responses·default",
+      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -844,72 +728,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:11"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:21"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·responses·200"
-     ]
-    },
-    "description": "A list of caches",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:13"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/complex-model.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:21"
       }
      }
     }

--- a/modelerfour/test/inputs/custom-baseUrl-more-options/openapi-document.json
+++ b/modelerfour/test/inputs/custom-baseUrl-more-options/openapi-document.json
@@ -158,7 +158,7 @@
     "in": "path",
     "description": "The subscription id with value 'test12'.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:2"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true
    },
@@ -196,7 +196,8 @@
      ],
      "name": "paths·customuri-subscriptionid-keyname·get·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/custom-baseUrl-more-options.json#/components/schemas/paths·customuri-subscriptionid-keyname·get·parameters·0·schema"
+      "http://localhost:3000/swagger/custom-baseUrl-more-options.json#/components/schemas/paths·customuri-subscriptionid-keyname·get·parameters·0·schema",
+      "http://localhost:3000/swagger/custom-baseUrl-more-options.json#/components/schemas/components·parameters·subscriptionidparameter·schema"
      ]
     },
     "type": "string"
@@ -215,21 +216,6 @@
      ]
     },
     "default": "v1",
-    "type": "string"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·subscriptionidparameter·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/custom-baseUrl-more-options.json#/components/schemas/components·parameters·subscriptionidparameter·schema"
-     ]
-    },
     "type": "string"
    },
    "schemas:3": {

--- a/modelerfour/test/inputs/datalake-storage/openapi-document.json
+++ b/modelerfour/test/inputs/datalake-storage/openapi-document.json
@@ -4502,7 +4502,22 @@
      ],
      "name": "paths·filesystem-path·patch·requestbody·content·application-octet_stream·schema",
      "originalLocations": [
-      "https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-10-31/DataLakeStorage.json#/components/schemas/paths·filesystem-path·patch·requestbody·content·application-octet_stream·schema",
+      "https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-10-31/DataLakeStorage.json#/components/schemas/paths·filesystem-path·patch·requestbody·content·application-octet_stream·schema"
+     ]
+    },
+    "type": "object",
+    "format": "file"
+   },
+   "schemas:148": {
+    "x-ms-metadata": {
+     "apiVersions": [
+      "2019-10-31"
+     ],
+     "filename": [
+      "mem:///94?oai3.shaken.json"
+     ],
+     "name": "paths·filesystem-path·patch·requestbody·content·text-plain·schema",
+     "originalLocations": [
       "https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-10-31/DataLakeStorage.json#/components/schemas/paths·filesystem-path·patch·requestbody·content·text-plain·schema"
      ]
     },
@@ -9936,7 +9951,7 @@
      },
      "text/plain": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:147"
+       "$ref": "#/components/schemas/schemas:148"
       }
      }
     },

--- a/modelerfour/test/inputs/extensible-enums-swagger/openapi-document.json
+++ b/modelerfour/test/inputs/extensible-enums-swagger/openapi-document.json
@@ -99,7 +99,7 @@
     "responses": {
      "200": {
       "description": "OK",
-      "$ref": "#/components/responses/responses:1"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -141,28 +141,7 @@
      ],
      "name": "paths·extensibleenums-pet-petid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/extensible-enums-swagger.json#/components/responses/paths·extensibleenums-pet-petid·get·responses·200"
-     ]
-    },
-    "description": "OK",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:0"
-      }
-     }
-    }
-   },
-   "responses:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2016-07-07"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·extensibleenums-pet-addpet·post·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/extensible-enums-swagger.json#/components/responses/paths·extensibleenums-pet-petid·get·responses·200",
       "http://localhost:3000/swagger/extensible-enums-swagger.json#/components/responses/paths·extensibleenums-pet-addpet·post·responses·200"
      ]
     },

--- a/modelerfour/test/inputs/head-exceptions/openapi-document.json
+++ b/modelerfour/test/inputs/head-exceptions/openapi-document.json
@@ -56,7 +56,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:1"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -102,11 +102,11 @@
     "responses": {
      "204": {
       "description": "Successfully returns the true boolean value",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -152,11 +152,11 @@
     "responses": {
      "204": {
       "description": "Successfully returns the true boolean value",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -174,85 +174,15 @@
      ],
      "name": "paths·http-success-200·head·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-200·head·responses·200"
-     ]
-    },
-    "description": "Successfully returns the true boolean value"
-   },
-   "responses:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-200·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-204·head·responses·204"
-     ]
-    },
-    "description": "Successfully returns the true boolean value"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-204·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-404·head·responses·204"
-     ]
-    },
-    "description": "Successfully returns the true boolean value"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·default",
-     "originalLocations": [
+      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-200·head·responses·200",
+      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-200·head·responses·default",
+      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-204·head·responses·204",
+      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-204·head·responses·default",
+      "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-404·head·responses·204",
       "http://localhost:3000/swagger/head-exceptions.json#/components/responses/paths·http-success-404·head·responses·default"
      ]
     },
-    "description": "Unexpected error"
+    "description": "Successfully returns the true boolean value"
    }
   }
  },

--- a/modelerfour/test/inputs/head/openapi-document.json
+++ b/modelerfour/test/inputs/head/openapi-document.json
@@ -56,11 +56,11 @@
      },
      "404": {
       "description": "Successfully returns the false boolean value",
-      "$ref": "#/components/responses/responses:1"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -106,15 +106,15 @@
     "responses": {
      "204": {
       "description": "Successfully returns the true boolean value",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:0"
      },
      "404": {
       "description": "Successfully returns the false boolean value",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -160,15 +160,15 @@
     "responses": {
      "204": {
       "description": "Successfully returns the true boolean value",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "404": {
       "description": "Successfully returns the false boolean value",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -186,130 +186,18 @@
      ],
      "name": "paths·http-success-200·head·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-200·head·responses·200"
-     ]
-    },
-    "description": "Successfully returns the true boolean value"
-   },
-   "responses:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·head·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-200·head·responses·404"
-     ]
-    },
-    "description": "Successfully returns the false boolean value"
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-200·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-204·head·responses·204"
-     ]
-    },
-    "description": "Successfully returns the true boolean value"
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-204·head·responses·404"
-     ]
-    },
-    "description": "Successfully returns the false boolean value"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-204·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-404·head·responses·204"
-     ]
-    },
-    "description": "Successfully returns the true boolean value"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-404·head·responses·404"
-     ]
-    },
-    "description": "Successfully returns the false boolean value"
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·default",
-     "originalLocations": [
+      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-200·head·responses·200",
+      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-200·head·responses·404",
+      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-200·head·responses·default",
+      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-204·head·responses·204",
+      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-204·head·responses·404",
+      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-204·head·responses·default",
+      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-404·head·responses·204",
+      "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-404·head·responses·404",
       "http://localhost:3000/swagger/head.json#/components/responses/paths·http-success-404·head·responses·default"
      ]
     },
-    "description": "Unexpected error"
+    "description": "Successfully returns the true boolean value"
    }
   }
  },

--- a/modelerfour/test/inputs/header/openapi-document.json
+++ b/modelerfour/test/inputs/header/openapi-document.json
@@ -112,7 +112,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -164,11 +164,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -218,7 +218,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -274,11 +274,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -320,7 +320,7 @@
     "description": "Get a response with header value \"value\": 1 or -2",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:4",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\""
      }
     ],
@@ -334,7 +334,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -379,7 +379,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:5",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\""
      },
      {
@@ -390,11 +390,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -436,7 +436,7 @@
     "description": "Get a response with header value \"value\": 105 or -2",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:7",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\""
      }
     ],
@@ -450,7 +450,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -495,7 +495,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:8",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\""
      },
      {
@@ -506,11 +506,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -552,7 +552,7 @@
     "description": "Get a response with header value \"value\": 0.07 or -3.0",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:10",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\""
      }
     ],
@@ -566,7 +566,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -611,7 +611,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:11",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\""
      },
      {
@@ -622,11 +622,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -668,7 +668,7 @@
     "description": "Get a response with header value \"value\": 7e120 or -3.0",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:13",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\""
      }
     ],
@@ -682,7 +682,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -727,7 +727,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:14",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"true\" or \"false\""
      },
      {
@@ -738,11 +738,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -784,7 +784,7 @@
     "description": "Get a response with header value \"value\": true or false",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:16",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"true\" or \"false\""
      }
     ],
@@ -798,7 +798,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -843,7 +843,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:17",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"null\" or \"empty\""
      },
      {
@@ -854,11 +854,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -900,7 +900,7 @@
     "description": "Get a response with header values \"The quick brown fox jumps over the lazy dog\" or null or \"\"",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:19",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"null\" or \"empty\""
      }
     ],
@@ -914,7 +914,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -959,7 +959,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:20",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\""
      },
      {
@@ -970,11 +970,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1016,7 +1016,7 @@
     "description": "Get a response with header values \"2010-01-01\" or \"0001-01-01\"",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:22",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\""
      }
     ],
@@ -1030,7 +1030,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1075,7 +1075,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:23",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\""
      },
      {
@@ -1086,11 +1086,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1132,7 +1132,7 @@
     "description": "Get a response with header values \"2010-01-01T12:34:56Z\" or \"0001-01-01T00:00:00Z\"",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:25",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\""
      }
     ],
@@ -1146,7 +1146,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1191,7 +1191,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:26",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\""
      },
      {
@@ -1202,11 +1202,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1248,7 +1248,7 @@
     "description": "Get a response with header values \"Wed, 01 Jan 2010 12:34:56 GMT\" or \"Mon, 01 Jan 0001 00:00:00 GMT\"",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:28",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\""
      }
     ],
@@ -1262,7 +1262,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1307,7 +1307,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:29",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\""
      },
      {
@@ -1318,11 +1318,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:44"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1367,7 +1367,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:31",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\""
      }
     ],
@@ -1378,7 +1378,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:47"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1423,7 +1423,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:32",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\""
      },
      {
@@ -1434,11 +1434,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:48"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:49"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1480,7 +1480,7 @@
     "description": "Get a response with header values \"啊齄丂狛狜隣郎隣兀﨩\"",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:34",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\""
      }
     ],
@@ -1494,7 +1494,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1539,7 +1539,7 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:35",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"null\" or \"empty\""
      },
      {
@@ -1550,11 +1550,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:52"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:53"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1596,7 +1596,7 @@
     "description": "Get a response with header values \"GREY\" or null",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:37",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Send a post request with header values \"scenario\": \"valid\" or \"null\" or \"empty\""
      }
     ],
@@ -1610,7 +1610,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:55"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1656,11 +1656,11 @@
     "responses": {
      "200": {
       "description": "Empty Response indicates that x-ms-client-request-id was successfuly received",
-      "$ref": "#/components/responses/responses:56"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1707,7 +1707,7 @@
     "in": "header",
     "description": "Send a post request with header value \"Content-Type\": \"text/html\"",
     "schema": {
-     "$ref": "#/components/schemas/schemas:2"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -1722,14 +1722,37 @@
      ],
      "name": "paths·header-param-prim-integer·post·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-integer·post·parameters·0"
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-integer·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-integer·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-long·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-long·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-float·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-float·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-double·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-double·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-bool·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-bool·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-string·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-string·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-date·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-date·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-datetime·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-datetime·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-datetimerfc1123·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-datetimerfc1123·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-duration·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-duration·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-byte·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-byte·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-enum·post·parameters·0",
+      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-enum·post·parameters·0"
      ]
     },
     "name": "scenario",
     "in": "header",
     "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\"",
     "schema": {
-     "$ref": "#/components/schemas/schemas:4"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -1756,50 +1779,6 @@
     "required": true,
     "x-ms-parameter-location": "method"
    },
-   "parameters:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-integer·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-integer·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:6"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-long·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-long·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:8"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
    "parameters:6": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1818,50 +1797,6 @@
     "description": "Send a post request with header values 105 or -2",
     "schema": {
      "$ref": "#/components/schemas/schemas:9"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-long·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-long·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:10"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-float·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-float·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:12"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -1888,50 +1823,6 @@
     "required": true,
     "x-ms-parameter-location": "method"
    },
-   "parameters:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-float·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-float·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:14"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-double·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-double·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:16"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
    "parameters:12": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1950,50 +1841,6 @@
     "description": "Send a post request with header values 7e120 or -3.0",
     "schema": {
      "$ref": "#/components/schemas/schemas:17"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-double·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-double·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"positive\" or \"negative\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:18"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-bool·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-bool·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"true\" or \"false\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:20"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2020,50 +1867,6 @@
     "required": true,
     "x-ms-parameter-location": "method"
    },
-   "parameters:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-bool·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-bool·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"true\" or \"false\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:22"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-string·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-string·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"null\" or \"empty\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:24"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
    "parameters:18": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -2081,53 +1884,9 @@
     "in": "header",
     "description": "Send a post request with header values \"The quick brown fox jumps over the lazy dog\" or null or \"\"",
     "schema": {
-     "$ref": "#/components/schemas/schemas:25"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-string·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-string·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"null\" or \"empty\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:26"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-date·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-date·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:28"
-    },
-    "required": true,
     "x-ms-parameter-location": "method"
    },
    "parameters:21": {
@@ -2148,50 +1907,6 @@
     "description": "Send a post request with header values \"2010-01-01\" or \"0001-01-01\"",
     "schema": {
      "$ref": "#/components/schemas/schemas:29"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-date·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-date·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:30"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-datetime·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-datetime·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:32"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2218,50 +1933,6 @@
     "required": true,
     "x-ms-parameter-location": "method"
    },
-   "parameters:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-datetime·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-datetime·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:34"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-datetimerfc1123·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-datetimerfc1123·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:36"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
    "parameters:27": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -2283,50 +1954,6 @@
     },
     "x-ms-parameter-location": "method"
    },
-   "parameters:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-datetimerfc1123·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-datetimerfc1123·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"min\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:38"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-duration·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-duration·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:40"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
    "parameters:30": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -2345,50 +1972,6 @@
     "description": "Send a post request with header values \"P123DT22H14M12.011S\"",
     "schema": {
      "$ref": "#/components/schemas/schemas:41"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-duration·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-duration·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:42"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-byte·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-byte·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:44"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2415,50 +1998,6 @@
     "required": true,
     "x-ms-parameter-location": "method"
    },
-   "parameters:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-byte·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-byte·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:46"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-enum·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-param-prim-enum·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"null\" or \"empty\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:48"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
    "parameters:36": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -2480,28 +2019,6 @@
     },
     "required": false,
     "x-ms-parameter-location": "method"
-   },
-   "parameters:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-enum·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/parameters/paths·header-response-prim-enum·post·parameters·0"
-     ]
-    },
-    "name": "scenario",
-    "in": "header",
-    "description": "Send a post request with header values \"scenario\": \"valid\" or \"null\" or \"empty\"",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:50"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
    }
   },
   "schemas": {
@@ -2515,67 +2032,36 @@
      ],
      "name": "paths·header-param-existingkey·post·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-existingkey·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-existingkey·post·responses·200·headers·user_agent·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-existingkey·post·responses·200·headers·user_agent·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-protectedkey·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-protectedkey·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-protectedkey·post·responses·200·headers·content_type·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-protectedkey·post·responses·200·headers·content_type·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-integer·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-integer·post·parameters·0·schema"
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-existingkey·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-existingkey·post·responses·200·headers·user_agent·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-protectedkey·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-protectedkey·post·responses·200·headers·content_type·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-integer·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-integer·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-long·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-long·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-float·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-float·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-double·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-double·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-bool·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-bool·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-string·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-string·post·parameters·1·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-string·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-string·post·responses·200·headers·value·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-date·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-date·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-datetime·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-datetime·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-datetimerfc1123·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-datetimerfc1123·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-duration·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-duration·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-byte·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-byte·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-enum·post·parameters·0·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-enum·post·parameters·0·schema"
      ]
     },
     "type": "string"
@@ -2590,57 +2076,12 @@
      ],
      "name": "paths·header-param-prim-integer·post·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-integer·post·parameters·1·schema"
-     ]
-    },
-    "format": "int32",
-    "type": "integer"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-integer·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-integer·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-integer·post·responses·200·headers·value·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-integer·post·parameters·1·schema",
       "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-integer·post·responses·200·headers·value·schema"
      ]
     },
     "format": "int32",
     "type": "integer"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-long·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-long·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:9": {
     "x-ms-metadata": {
@@ -2652,57 +2093,12 @@
      ],
      "name": "paths·header-param-prim-long·post·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-long·post·parameters·1·schema"
-     ]
-    },
-    "format": "int64",
-    "type": "integer"
-   },
-   "schemas:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-long·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-long·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-long·post·responses·200·headers·value·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-long·post·parameters·1·schema",
       "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-long·post·responses·200·headers·value·schema"
      ]
     },
     "format": "int64",
     "type": "integer"
-   },
-   "schemas:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-float·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-float·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:13": {
     "x-ms-metadata": {
@@ -2714,57 +2110,12 @@
      ],
      "name": "paths·header-param-prim-float·post·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-float·post·parameters·1·schema"
-     ]
-    },
-    "format": "float",
-    "type": "number"
-   },
-   "schemas:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-float·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-float·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-float·post·responses·200·headers·value·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-float·post·parameters·1·schema",
       "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-float·post·responses·200·headers·value·schema"
      ]
     },
     "format": "float",
     "type": "number"
-   },
-   "schemas:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-double·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-double·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:17": {
     "x-ms-metadata": {
@@ -2776,57 +2127,12 @@
      ],
      "name": "paths·header-param-prim-double·post·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-double·post·parameters·1·schema"
-     ]
-    },
-    "format": "double",
-    "type": "number"
-   },
-   "schemas:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-double·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-double·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-double·post·responses·200·headers·value·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-double·post·parameters·1·schema",
       "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-double·post·responses·200·headers·value·schema"
      ]
     },
     "format": "double",
     "type": "number"
-   },
-   "schemas:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-bool·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-bool·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:21": {
     "x-ms-metadata": {
@@ -2838,115 +2144,11 @@
      ],
      "name": "paths·header-param-prim-bool·post·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-bool·post·parameters·1·schema"
-     ]
-    },
-    "type": "boolean"
-   },
-   "schemas:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-bool·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-bool·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-bool·post·responses·200·headers·value·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-bool·post·parameters·1·schema",
       "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-bool·post·responses·200·headers·value·schema"
      ]
     },
     "type": "boolean"
-   },
-   "schemas:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-string·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-string·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-string·post·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-string·post·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-string·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-string·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-string·post·responses·200·headers·value·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-string·post·responses·200·headers·value·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-date·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-date·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:29": {
     "x-ms-metadata": {
@@ -2963,36 +2165,6 @@
      ]
     },
     "format": "date",
-    "type": "string"
-   },
-   "schemas:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-date·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-date·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-datetime·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-datetime·post·parameters·0·schema"
-     ]
-    },
     "type": "string"
    },
    "schemas:33": {
@@ -3012,36 +2184,6 @@
     "format": "date-time",
     "type": "string"
    },
-   "schemas:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-datetime·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-datetime·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-datetimerfc1123·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-datetimerfc1123·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
    "schemas:37": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3057,36 +2199,6 @@
      ]
     },
     "format": "date-time-rfc1123",
-    "type": "string"
-   },
-   "schemas:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-datetimerfc1123·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-datetimerfc1123·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-duration·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-duration·post·parameters·0·schema"
-     ]
-    },
     "type": "string"
    },
    "schemas:41": {
@@ -3106,36 +2218,6 @@
     "format": "duration",
     "type": "string"
    },
-   "schemas:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-duration·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-duration·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-byte·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-byte·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
    "schemas:45": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3151,51 +2233,6 @@
      ]
     },
     "format": "byte",
-    "type": "string"
-   },
-   "schemas:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-byte·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-byte·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-enum·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-enum·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-enum·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-enum·post·parameters·0·schema"
-     ]
-    },
     "type": "string"
    },
    "schemas:52": {
@@ -3247,19 +2284,20 @@
      ],
      "name": "GreyscaleColors",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-enum·post·parameters·1·schema"
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-param-prim-enum·post·parameters·1·schema",
+      "http://localhost:3000/swagger/header.json#/components/schemas/paths·header-response-prim-enum·post·responses·200·headers·value·schema"
      ]
     },
-    "x-ms-enum": {
-     "name": "GreyscaleColors",
-     "modelAsString": false
-    },
-    "type": "string",
     "enum": [
      "White",
      "black",
      "GREY"
-    ]
+    ],
+    "x-ms-enum": {
+     "name": "GreyscaleColors",
+     "modelAsString": false
+    },
+    "type": "string"
    }
   },
   "responses": {
@@ -3273,7 +2311,21 @@
      ],
      "name": "paths·header-param-existingkey·post·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-existingkey·post·responses·200"
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-existingkey·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-protectedkey·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-integer·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-long·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-float·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-double·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-bool·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-string·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-date·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-datetime·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-datetimerfc1123·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-duration·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-byte·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-enum·post·responses·200",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-custom-x_ms_client_request_id-9c4d50ee_2d56_4cd3_8152_34347dc9f2b0·post·responses·200"
      ]
     },
     "description": "Empty Response"
@@ -3288,7 +2340,35 @@
      ],
      "name": "paths·header-param-existingkey·post·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-existingkey·post·responses·default"
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-existingkey·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-existingkey·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-protectedkey·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-protectedkey·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-integer·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-integer·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-long·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-long·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-float·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-float·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-double·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-double·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-bool·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-bool·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-string·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-string·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-date·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-date·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-datetime·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-datetime·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-datetimerfc1123·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-datetimerfc1123·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-duration·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-duration·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-byte·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-byte·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-enum·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-enum·post·responses·default",
+      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-custom-x_ms_client_request_id-9c4d50ee_2d56_4cd3_8152_34347dc9f2b0·post·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -3321,65 +2401,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-existingkey·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-existingkey·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-protectedkey·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-protectedkey·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-protectedkey·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-protectedkey·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
    "responses:6": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3397,66 +2418,7 @@
     "headers": {
      "Content-Type": {
       "description": "response with header value \"Content-Type\": \"text/html\"",
-      "$ref": "#/components/headers/headers:1"
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-protectedkey·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-protectedkey·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-integer·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-integer·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-integer·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-integer·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
+      "$ref": "#/components/headers/headers:0"
      }
     }
    },
@@ -3481,65 +2443,6 @@
      }
     }
    },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-integer·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-integer·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-long·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-long·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-long·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-long·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
    "responses:14": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3558,65 +2461,6 @@
      "value": {
       "description": "response with header value \"value\": 105 or -2",
       "$ref": "#/components/headers/headers:3"
-     }
-    }
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-long·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-long·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-float·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-float·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-float·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-float·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
      }
     }
    },
@@ -3641,65 +2485,6 @@
      }
     }
    },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-float·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-float·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-double·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-double·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-double·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-double·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
    "responses:22": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3718,65 +2503,6 @@
      "value": {
       "description": "response with header value \"value\": 7e120 or -3.0",
       "$ref": "#/components/headers/headers:5"
-     }
-    }
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-double·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-double·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-bool·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-bool·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-bool·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-bool·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
      }
     }
    },
@@ -3801,65 +2527,6 @@
      }
     }
    },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-bool·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-bool·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-string·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-string·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-string·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-string·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
    "responses:30": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -3877,66 +2544,7 @@
     "headers": {
      "value": {
       "description": "response with header values \"The quick brown fox jumps over the lazy dog\" or null or \"\"",
-      "$ref": "#/components/headers/headers:7"
-     }
-    }
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-string·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-string·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-date·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-date·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-date·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-date·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
+      "$ref": "#/components/headers/headers:0"
      }
     }
    },
@@ -3961,65 +2569,6 @@
      }
     }
    },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-date·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-date·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-datetime·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-datetime·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-datetime·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-datetime·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
    "responses:38": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4038,65 +2587,6 @@
      "value": {
       "description": "response with header values \"2010-01-01T12:34:56Z\" or \"0001-01-01T00:00:00Z\"",
       "$ref": "#/components/headers/headers:9"
-     }
-    }
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-datetime·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-datetime·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-datetimerfc1123·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-datetimerfc1123·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-datetimerfc1123·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-datetimerfc1123·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
      }
     }
    },
@@ -4121,65 +2611,6 @@
      }
     }
    },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-datetimerfc1123·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-datetimerfc1123·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-duration·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-duration·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-duration·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-duration·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
    "responses:46": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4198,65 +2629,6 @@
      "value": {
       "description": "response with header values \"P123DT22H14M12.011S\"",
       "$ref": "#/components/headers/headers:11"
-     }
-    }
-   },
-   "responses:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-duration·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-duration·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-byte·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-byte·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-byte·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-byte·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
      }
     }
    },
@@ -4281,65 +2653,6 @@
      }
     }
    },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-byte·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-byte·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-enum·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-enum·post·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-param-prim-enum·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-param-prim-enum·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
    "responses:54": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4360,65 +2673,6 @@
       "$ref": "#/components/headers/headers:13"
      }
     }
-   },
-   "responses:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-enum·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-response-prim-enum·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
-   },
-   "responses:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-custom-x_ms_client_request_id-9c4d50ee_2d56_4cd3_8152_34347dc9f2b0·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-custom-x_ms_client_request_id-9c4d50ee_2d56_4cd3_8152_34347dc9f2b0·post·responses·200"
-     ]
-    },
-    "description": "Empty Response indicates that x-ms-client-request-id was successfuly received"
-   },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-custom-x_ms_client_request_id-9c4d50ee_2d56_4cd3_8152_34347dc9f2b0·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/responses/paths·header-custom-x_ms_client_request_id-9c4d50ee_2d56_4cd3_8152_34347dc9f2b0·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    }
    }
   },
   "headers": {
@@ -4432,31 +2686,15 @@
      ],
      "name": "paths·header-response-existingkey·post·responses·200·headers·user_agent",
      "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/headers/paths·header-response-existingkey·post·responses·200·headers·user_agent"
+      "http://localhost:3000/swagger/header.json#/components/headers/paths·header-response-existingkey·post·responses·200·headers·user_agent",
+      "http://localhost:3000/swagger/header.json#/components/headers/paths·header-response-protectedkey·post·responses·200·headers·content_type",
+      "http://localhost:3000/swagger/header.json#/components/headers/paths·header-response-prim-string·post·responses·200·headers·value"
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:1"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "description": "response with header value \"User-Agent\": \"overwrite\""
-   },
-   "headers:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-protectedkey·post·responses·200·headers·content_type",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/headers/paths·header-response-protectedkey·post·responses·200·headers·content_type"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:3"
-    },
-    "description": "response with header value \"Content-Type\": \"text/html\""
    },
    "headers:2": {
     "x-ms-metadata": {
@@ -4472,7 +2710,7 @@
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:7"
+     "$ref": "#/components/schemas/schemas:5"
     },
     "description": "response with header value \"value\": 1 or -2"
    },
@@ -4490,7 +2728,7 @@
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:11"
+     "$ref": "#/components/schemas/schemas:9"
     },
     "description": "response with header value \"value\": 105 or -2"
    },
@@ -4508,7 +2746,7 @@
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:15"
+     "$ref": "#/components/schemas/schemas:13"
     },
     "description": "response with header value \"value\": 0.07 or -3.0"
    },
@@ -4526,7 +2764,7 @@
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:19"
+     "$ref": "#/components/schemas/schemas:17"
     },
     "description": "response with header value \"value\": 7e120 or -3.0"
    },
@@ -4544,27 +2782,9 @@
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:23"
+     "$ref": "#/components/schemas/schemas:21"
     },
     "description": "response with header value \"value\": true or false"
-   },
-   "headers:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·header-response-prim-string·post·responses·200·headers·value",
-     "originalLocations": [
-      "http://localhost:3000/swagger/header.json#/components/headers/paths·header-response-prim-string·post·responses·200·headers·value"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:27"
-    },
-    "description": "response with header values \"The quick brown fox jumps over the lazy dog\" or null or \"\""
    },
    "headers:8": {
     "x-ms-metadata": {

--- a/modelerfour/test/inputs/httpInfrastructure.quirks/openapi-document.json
+++ b/modelerfour/test/inputs/httpInfrastructure.quirks/openapi-document.json
@@ -102,7 +102,7 @@
     "responses": {
      "200": {
       "description": "Successfully returns 400 error code with the get request",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -148,7 +148,7 @@
     "responses": {
      "200": {
       "description": "Successfully returns 200 error code with the get request",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -198,7 +198,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -230,11 +230,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the get request",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -266,11 +266,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the options request",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -307,11 +307,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -342,17 +342,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:1"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -383,17 +383,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:2"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -424,17 +424,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:3"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -479,17 +479,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:4"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "201": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -520,17 +520,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:5"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "201": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -575,17 +575,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:6"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -616,17 +616,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:7"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -657,17 +657,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:8"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -698,17 +698,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:9"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -754,11 +754,11 @@
     "responses": {
      "204": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -789,17 +789,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:10"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "204": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -830,17 +830,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:11"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "204": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -871,17 +871,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:12"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "204": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -912,17 +912,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:13"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "204": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:38"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -968,15 +968,15 @@
     "responses": {
      "204": {
       "description": "Successfully received the head request",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:4"
      },
      "404": {
       "description": "Successfully received the head request",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1022,7 +1022,7 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:4"
      },
      "300": {
       "description": "Redirect to another endpoint",
@@ -1030,7 +1030,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1062,7 +1062,7 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:46"
+      "$ref": "#/components/responses/responses:4"
      },
      "300": {
       "description": "Redirect to another endpoint",
@@ -1070,7 +1070,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:48"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1116,15 +1116,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:49"
+      "$ref": "#/components/responses/responses:4"
      },
      "301": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:50"
+      "$ref": "#/components/responses/responses:44"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1156,7 +1156,7 @@
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:52"
+      "$ref": "#/components/responses/responses:4"
      },
      "301": {
       "description": "Redirect to another endpoint",
@@ -1164,7 +1164,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:54"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1195,7 +1195,7 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:14"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
@@ -1205,7 +1205,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:56"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1251,15 +1251,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:4"
      },
      "302": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:58"
+      "$ref": "#/components/responses/responses:44"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:59"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1291,15 +1291,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:60"
+      "$ref": "#/components/responses/responses:4"
      },
      "302": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:61"
+      "$ref": "#/components/responses/responses:53"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:62"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1330,17 +1330,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:15"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "302": {
       "description": "Redirect to another endpoint. This redirect should *not* be automatically followed",
-      "$ref": "#/components/responses/responses:63"
+      "$ref": "#/components/responses/responses:55"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:64"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1385,21 +1385,21 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:16"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:65"
+      "$ref": "#/components/responses/responses:4"
      },
      "303": {
       "description": "Redirect to another endpoint. This redirect should be automatically followed with a get request",
-      "$ref": "#/components/responses/responses:66"
+      "$ref": "#/components/responses/responses:53"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:67"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1445,15 +1445,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:68"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:69"
+      "$ref": "#/components/responses/responses:44"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:70"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1485,15 +1485,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:71"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:72"
+      "$ref": "#/components/responses/responses:53"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:73"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1525,7 +1525,7 @@
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:74"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1533,7 +1533,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:76"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1564,13 +1564,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:17"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:77"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1578,7 +1578,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:79"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1609,13 +1609,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:18"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:80"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1623,7 +1623,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:82"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1654,13 +1654,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:19"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:83"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1668,7 +1668,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:85"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1699,13 +1699,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:20"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:86"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1713,7 +1713,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:88"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1759,7 +1759,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:89"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1791,7 +1791,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:90"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1823,7 +1823,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:91"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1854,13 +1854,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:21"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:92"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1891,13 +1891,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:22"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:93"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1928,13 +1928,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:23"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:94"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1965,13 +1965,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:24"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:95"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2017,7 +2017,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:96"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2063,7 +2063,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:97"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2109,7 +2109,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:98"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2141,7 +2141,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:99"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2186,13 +2186,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:25"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:100"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2237,13 +2237,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:26"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:101"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2288,13 +2288,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:27"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:102"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2339,13 +2339,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:28"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:103"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2390,13 +2390,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:29"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:104"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2442,7 +2442,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:105"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2488,7 +2488,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:106"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2534,7 +2534,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:107"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2566,7 +2566,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:108"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2611,13 +2611,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:30"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:109"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2662,13 +2662,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:31"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:110"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2713,13 +2713,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:32"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:111"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2765,7 +2765,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:112"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2810,13 +2810,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:33"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:113"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2862,7 +2862,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:114"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2908,7 +2908,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:115"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2940,7 +2940,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:116"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2985,13 +2985,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:34"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:117"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3022,13 +3022,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:35"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:118"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3074,11 +3074,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:119"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:120"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3123,17 +3123,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:36"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:121"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:122"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3164,17 +3164,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:37"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:123"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:124"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3220,11 +3220,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:125"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:126"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3256,11 +3256,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:127"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:128"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3305,17 +3305,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:38"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:129"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:130"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3346,17 +3346,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:39"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:131"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:132"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3401,17 +3401,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:40"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:133"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:134"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3442,17 +3442,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:41"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:135"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:136"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3502,11 +3502,11 @@
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:138"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:139"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3552,15 +3552,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '204'}",
-      "$ref": "#/components/responses/responses:140"
+      "$ref": "#/components/responses/responses:137"
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:141"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:142"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3606,15 +3606,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:143"
+      "$ref": "#/components/responses/responses:137"
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:144"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:145"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3660,15 +3660,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:146"
+      "$ref": "#/components/responses/responses:137"
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:147"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:148"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3714,15 +3714,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:149"
+      "$ref": "#/components/responses/responses:137"
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:150"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:151"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3768,7 +3768,7 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:152"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
@@ -3776,7 +3776,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:154"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3822,15 +3822,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:155"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
-      "$ref": "#/components/responses/responses:156"
+      "$ref": "#/components/responses/responses:153"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:157"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3876,15 +3876,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:158"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
-      "$ref": "#/components/responses/responses:159"
+      "$ref": "#/components/responses/responses:153"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:160"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3930,7 +3930,7 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:161"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'httpCode': '201'}",
@@ -3942,7 +3942,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:164"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3988,19 +3988,19 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:165"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'httpCode': '201'}",
-      "$ref": "#/components/responses/responses:166"
+      "$ref": "#/components/responses/responses:162"
      },
      "404": {
       "description": "Return {'httpStatusCode': '404'}",
-      "$ref": "#/components/responses/responses:167"
+      "$ref": "#/components/responses/responses:163"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:168"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4046,19 +4046,19 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:169"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'httpCode': '201'}",
-      "$ref": "#/components/responses/responses:170"
+      "$ref": "#/components/responses/responses:162"
      },
      "404": {
       "description": "Return {'httpStatusCode': '404'}",
-      "$ref": "#/components/responses/responses:171"
+      "$ref": "#/components/responses/responses:163"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:172"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4104,19 +4104,19 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:173"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'httpCode': '201'}",
-      "$ref": "#/components/responses/responses:174"
+      "$ref": "#/components/responses/responses:162"
      },
      "404": {
       "description": "Return {'httpStatusCode': '404'}",
-      "$ref": "#/components/responses/responses:175"
+      "$ref": "#/components/responses/responses:163"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:176"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4162,15 +4162,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:177"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No Payload for NoContent",
-      "$ref": "#/components/responses/responses:178"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:179"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4216,15 +4216,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:180"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No Payload for NoContent",
-      "$ref": "#/components/responses/responses:181"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:182"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4270,15 +4270,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:183"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No Payload for NoContent",
-      "$ref": "#/components/responses/responses:184"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error with payload: {'code': '400', 'message': 'client error'}",
-      "$ref": "#/components/responses/responses:185"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4324,15 +4324,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted, but this operation will return {'property': 'value'}",
-      "$ref": "#/components/responses/responses:186"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No payload for NoContent",
-      "$ref": "#/components/responses/responses:187"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error with no payload",
-      "$ref": "#/components/responses/responses:188"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4378,15 +4378,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:189"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No payload for NoContent",
-      "$ref": "#/components/responses/responses:190"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error with no payload",
-      "$ref": "#/components/responses/responses:191"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4432,15 +4432,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:192"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No payload for NoContent",
-      "$ref": "#/components/responses/responses:193"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error with no payload",
-      "$ref": "#/components/responses/responses:194"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4486,15 +4486,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:195"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No payload for NoContent",
-      "$ref": "#/components/responses/responses:196"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error should have no payload, but this operation sends: {'property': 'value'}",
-      "$ref": "#/components/responses/responses:197"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4540,7 +4540,7 @@
     "responses": {
      "default": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:198"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4586,7 +4586,7 @@
     "responses": {
      "default": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:199"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4632,7 +4632,7 @@
     "responses": {
      "default": {
       "description": "Return {'statusCode': '400'}",
-      "$ref": "#/components/responses/responses:200"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4678,7 +4678,7 @@
     "responses": {
      "default": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:201"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4724,7 +4724,7 @@
     "responses": {
      "default": {
       "description": "Return invalid payload {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:202"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4770,7 +4770,7 @@
     "responses": {
      "default": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:203"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4816,7 +4816,7 @@
     "responses": {
      "default": {
       "description": "Return invalid payload{'statusCode': '400'}",
-      "$ref": "#/components/responses/responses:204"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4862,7 +4862,7 @@
     "responses": {
      "default": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:205"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4908,7 +4908,7 @@
     "responses": {
      "200": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:206"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4954,7 +4954,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with valid payload {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:207"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5000,7 +5000,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with invalid payload {'statusCodeInvalid': '200'}",
-      "$ref": "#/components/responses/responses:208"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5046,7 +5046,7 @@
     "responses": {
      "200": {
       "description": "Return no payload, and an unmodeled 400 response",
-      "$ref": "#/components/responses/responses:209"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5092,7 +5092,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with valid payload {'statusCode': '400'}  but error status code 400, which is unmodeled",
-      "$ref": "#/components/responses/responses:210"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5138,7 +5138,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with invalid payload {'statusCodeInvalid': '400'}",
-      "$ref": "#/components/responses/responses:211"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5184,7 +5184,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with valid payload {'statusCode': '202'}  but unmodeled success status code 202, which is unmodeled",
-      "$ref": "#/components/responses/responses:212"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5202,7 +5202,12 @@
      ],
      "name": "paths·http-failure-emptybody-error·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-emptybody-error·get·responses·200"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-emptybody-error·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-nomodel-error·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-nomodel-empty·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·options·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-502·options·responses·200"
      ]
     },
     "description": "Successfully returns 400 error code with the get request",
@@ -5225,7 +5230,96 @@
      ],
      "name": "paths·http-failure-emptybody-error·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-emptybody-error·get·responses·default"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-emptybody-error·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-201·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-201·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-404·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-303·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-401·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-402·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-403·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-403·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-404·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-405·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-406·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-407·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-409·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-410·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-411·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-412·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-412·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-413·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-414·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-415·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-416·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-417·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-429·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-server-501·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-server-501·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-server-505·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-server-505·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-408·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-500·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-500·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-502·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-502·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-503·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-503·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-504·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-504·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -5233,52 +5327,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-nomodel-error·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-nomodel-error·get·responses·200"
-     ]
-    },
-    "description": "Successfully returns 400 error code with the get request",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-nomodel-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-nomodel-empty·get·responses·200"
-     ]
-    },
-    "description": "Successfully returns 200 error code with the get request",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema"
       }
      }
     }
@@ -5293,744 +5341,76 @@
      ],
      "name": "paths·http-success-200·head·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·head·responses·200"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·put·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·patch·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·post·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·delete·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-201·put·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-201·post·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·put·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·patch·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·post·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·delete·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·head·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·put·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·patch·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·post·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·delete·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-404·head·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-404·head·responses·404",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-303·post·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·options·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·put·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·patch·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·post·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·delete·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-408·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-500·put·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-500·patch·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-502·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-503·post·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-503·delete·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-504·put·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-504·patch·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-none-response-200-invalid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-none-response-200-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-none-response-400-invalid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-none-response-400-none·get·responses·default"
      ]
     },
     "description": "Successfully received the head request"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the get request",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-200·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·options·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·options·responses·200"
-     ]
-    },
-    "description": "Successfully received the options request",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-200·options·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·put·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·patch·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·delete·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-200·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-201·put·responses·201"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-201·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·post·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-201·post·responses·201"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-201·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·put·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·put·responses·202"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·patch·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·patch·responses·202"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·post·responses·202"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·delete·responses·202"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-202·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·head·responses·204"
-     ]
-    },
-    "description": "Successfully received the true boolean value"
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·put·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·put·responses·204"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·patch·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·patch·responses·204"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·post·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·post·responses·204"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·delete·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·delete·responses·204"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-204·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-404·head·responses·204"
-     ]
-    },
-    "description": "Successfully received the head request"
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-404·head·responses·404"
-     ]
-    },
-    "description": "Successfully received the head request"
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-success-404·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-300·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·head·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
    },
    "responses:44": {
     "x-ms-metadata": {
@@ -6042,7 +5422,10 @@
      ],
      "name": "paths·http-redirect-300·head·responses·300",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·head·responses·300"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·head·responses·300",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·head·responses·301",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·head·responses·302",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·head·responses·307"
      ]
     },
     "description": "Redirect to another endpoint",
@@ -6052,43 +5435,6 @@
       "$ref": "#/components/headers/headers:0"
      }
     }
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-300·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-300·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·get·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
    },
    "responses:47": {
     "x-ms-metadata": {
@@ -6119,101 +5465,6 @@
      }
     }
    },
-   "responses:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-300·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-300·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·head·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
-   },
-   "responses:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·301",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·head·responses·301"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:2"
-     }
-    }
-   },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·get·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
    "responses:53": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -6224,36 +5475,17 @@
      ],
      "name": "paths·http-redirect-301·get·responses·301",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·get·responses·301"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·get·responses·301",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·get·responses·302",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-303·post·responses·303",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·get·responses·307"
      ]
     },
     "description": "Redirect to another endpoint",
     "headers": {
      "Location": {
       "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:3"
-     }
-    }
-   },
-   "responses:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
+      "$ref": "#/components/headers/headers:1"
      }
     }
    },
@@ -6267,7 +5499,8 @@
      ],
      "name": "paths·http-redirect-301·put·responses·301",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·put·responses·301"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·put·responses·301",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·patch·responses·302"
      ]
     },
     "description": "Redirect to another endpoint. This redirect should *not* be automatically followed",
@@ -6277,376 +5510,6 @@
       "$ref": "#/components/headers/headers:4"
      }
     }
-   },
-   "responses:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-301·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·head·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
-   },
-   "responses:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·302",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·head·responses·302"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:5"
-     }
-    }
-   },
-   "responses:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·get·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
-   },
-   "responses:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·302",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·get·responses·302"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:6"
-     }
-    }
-   },
-   "responses:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·responses·302",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·patch·responses·302"
-     ]
-    },
-    "description": "Redirect to another endpoint. This redirect should *not* be automatically followed",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:7"
-     }
-    }
-   },
-   "responses:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-302·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-303·post·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
-   },
-   "responses:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·303",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-303·post·responses·303"
-     ]
-    },
-    "description": "Redirect to another endpoint. This redirect should be automatically followed with a get request",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:8"
-     }
-    }
-   },
-   "responses:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-303·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·head·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
-   "responses:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·307",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·head·responses·307"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:9"
-     }
-    }
-   },
-   "responses:70": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·get·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
-   "responses:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·307",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·get·responses·307"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:10"
-     }
-    }
-   },
-   "responses:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·options·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·options·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
    },
    "responses:75": {
     "x-ms-metadata": {
@@ -6669,43 +5532,6 @@
      }
     }
    },
-   "responses:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·put·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
    "responses:78": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -6726,43 +5552,6 @@
       "$ref": "#/components/headers/headers:12"
      }
     }
-   },
-   "responses:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·patch·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
    },
    "responses:81": {
     "x-ms-metadata": {
@@ -6785,43 +5574,6 @@
      }
     }
    },
-   "responses:82": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·post·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
    "responses:84": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -6842,43 +5594,6 @@
       "$ref": "#/components/headers/headers:14"
      }
     }
-   },
-   "responses:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:86": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·delete·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
    },
    "responses:87": {
     "x-ms-metadata": {
@@ -6901,1029 +5616,6 @@
      }
     }
    },
-   "responses:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-redirect-307·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:90": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:92": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:94": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-400·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-401·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-401·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-402·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-402·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-403·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-403·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-403·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-403·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:100": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-404·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-404·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-405·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-405·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:102": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-406·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-406·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-407·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-407·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-409·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-409·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-410·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-410·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-411·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-411·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-412·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-412·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:108": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-412·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-412·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-413·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-413·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-414·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-414·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-415·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-415·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-416·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-416·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-417·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-417·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-429·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-client-429·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-501·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-server-501·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-501·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-server-501·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-server-505·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:118": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-failure-server-505·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-408·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-408·head·responses·200"
-     ]
-    },
-    "description": "Successfully received the true boolean value"
-   },
-   "responses:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-408·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-408·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-500·put·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-500·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-500·patch·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-500·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-502·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the true boolean value"
-   },
-   "responses:126": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-502·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·options·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-502·options·responses·200"
-     ]
-    },
-    "description": "Successfully received the true boolean value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-retry-502·options·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:128": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-502·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:129": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-503·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:130": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-503·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:131": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-503·delete·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:132": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-503·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:133": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-504·put·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:134": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-504·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:135": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-504·patch·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:136": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-retry-504·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
    "responses:137": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -7934,302 +5626,29 @@
      ],
      "name": "paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:138": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:139": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:140": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '204'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:141": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:142": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:143": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:144": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:145": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:146": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:147": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:148": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:149": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:150": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:151": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:152": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·200"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-a-response-200-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-a-response-200-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-a-response-400-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-a-response-400-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-200-none·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-200-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-200-invalid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-400-none·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-400-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-400-invalid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-202-valid·get·responses·200"
      ]
     },
     "description": "Return {'statusCode': '200'}",
@@ -8251,138 +5670,8 @@
      ],
      "name": "paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·201",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:154": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:155": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:156": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:157": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:158": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:159": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·201",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·201",
       "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·201"
      ]
     },
@@ -8391,50 +5680,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:160": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:161": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
       }
      }
     }
@@ -8449,7 +5694,10 @@
      ],
      "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·201",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·201"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·201"
      ]
     },
     "description": "Return {'httpCode': '201'}",
@@ -8471,270 +5719,9 @@
      ],
      "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·404",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·404"
-     ]
-    },
-    "description": "Return {'httpStatusCode': '404'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:164": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:165": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:166": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'httpCode': '201'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:72"
-      }
-     }
-    }
-   },
-   "responses:167": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·404"
-     ]
-    },
-    "description": "Return {'httpStatusCode': '404'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:168": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:169": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:170": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'httpCode': '201'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:72"
-      }
-     }
-    }
-   },
-   "responses:171": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·404"
-     ]
-    },
-    "description": "Return {'httpStatusCode': '404'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:172": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:173": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:174": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'httpCode': '201'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:72"
-      }
-     }
-    }
-   },
-   "responses:175": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·404",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·404",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·404",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·404",
       "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·404"
      ]
     },
@@ -8743,666 +5730,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:176": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:177": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:178": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·204"
-     ]
-    },
-    "description": "No Payload for NoContent"
-   },
-   "responses:179": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:180": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:181": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·204"
-     ]
-    },
-    "description": "No Payload for NoContent"
-   },
-   "responses:182": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:183": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:184": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·204"
-     ]
-    },
-    "description": "No Payload for NoContent"
-   },
-   "responses:185": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error with payload: {'code': '400', 'message': 'client error'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:186": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted, but this operation will return {'property': 'value'}"
-   },
-   "responses:187": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·204"
-     ]
-    },
-    "description": "No payload for NoContent"
-   },
-   "responses:188": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error with no payload"
-   },
-   "responses:189": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:190": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·204"
-     ]
-    },
-    "description": "No payload for NoContent"
-   },
-   "responses:191": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error with no payload"
-   },
-   "responses:192": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:193": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·204"
-     ]
-    },
-    "description": "No payload for NoContent"
-   },
-   "responses:194": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error with no payload"
-   },
-   "responses:195": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:196": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·204"
-     ]
-    },
-    "description": "No payload for NoContent"
-   },
-   "responses:197": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error should have no payload, but this operation sends: {'property': 'value'}"
-   },
-   "responses:198": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-a-response-200-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-a-response-200-valid·get·responses·default"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:199": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-a-response-200-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-a-response-200-none·get·responses·default"
-     ]
-    },
-    "description": "Return no payload",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:200": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-a-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-a-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Return {'statusCode': '400'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:201": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-a-response-400-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-a-response-400-none·get·responses·default"
-     ]
-    },
-    "description": "Return no payload",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:202": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-none-response-200-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-none-response-200-invalid·get·responses·default"
-     ]
-    },
-    "description": "Return invalid payload {'statusCode': '200'}"
-   },
-   "responses:203": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-none-response-200-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-none-response-200-none·get·responses·default"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:204": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-none-response-400-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-none-response-400-invalid·get·responses·default"
-     ]
-    },
-    "description": "Return invalid payload{'statusCode': '400'}"
-   },
-   "responses:205": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-none-response-400-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-default-none-response-400-none·get·responses·default"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:206": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-200-none·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-200-none·get·responses·200"
-     ]
-    },
-    "description": "Return no payload",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:207": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-200-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-200-valid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with valid payload {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:208": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-200-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-200-invalid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with invalid payload {'statusCodeInvalid': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:209": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-400-none·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-400-none·get·responses·200"
-     ]
-    },
-    "description": "Return no payload, and an unmodeled 400 response",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:210": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-400-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-400-valid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with valid payload {'statusCode': '400'}  but error status code 400, which is unmodeled",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:211": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-400-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-400-invalid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with invalid payload {'statusCodeInvalid': '400'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:212": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-202-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/responses/paths·http-payloads-200-a-response-202-valid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with valid payload {'statusCode': '202'}  but unmodeled success status code 202, which is unmodeled",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
       }
      }
     }
@@ -9419,215 +5746,48 @@
      ],
      "name": "paths·http-success-200·put·requestbody·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-201·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-201·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-202·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-202·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-202·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-202·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-204·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-204·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-204·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-204·delete·requestbody·content·application-json·schema"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-201·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-201·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-202·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-202·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-202·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-202·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-204·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-204·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-204·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-204·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-301·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-302·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-303·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-400·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-400·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-400·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-400·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-404·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-405·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-406·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-407·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-409·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-413·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-414·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-415·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-417·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-server-505·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-server-505·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-500·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-500·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-503·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-503·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-504·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-504·patch·requestbody·content·application-json·schema"
      ]
     },
     "description": "Simple boolean value true",
@@ -9666,454 +5826,6 @@
      ]
     },
     "type": "string"
-   },
-   "schemas:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-301·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-302·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-303·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-400·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-400·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-400·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-400·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-404·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-404·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-405·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-405·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-406·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-406·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-407·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-407·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-409·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-409·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-413·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-413·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-414·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-414·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-415·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-415·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-417·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-client-417·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-server-505·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-server-505·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-500·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-500·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-503·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-503·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-504·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
-   },
-   "schemas:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-504·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean"
    },
    "schemas:66": {
     "x-ms-metadata": {
@@ -10310,83 +6022,12 @@
      ],
      "name": "paths·http-failure-emptybody-error·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-emptybody-error·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-200·get·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-200·options·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·options·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·options·responses·200·content·application-json·schema"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-emptybody-error·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-success-200·options·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-502·options·responses·200·content·application-json·schema"
      ]
     },
     "description": "Simple boolean value true",
@@ -10405,7 +6046,10 @@
      ],
      "name": "paths·http-redirect-300·head·responses·300·headers·location·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-300·head·responses·300·headers·location·schema"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-300·head·responses·300·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-301·head·responses·301·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-302·head·responses·302·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·head·responses·307·headers·location·schema"
      ]
     },
     "enum": [
@@ -10423,43 +6067,11 @@
      ],
      "name": "paths·http-redirect-300·get·responses·300·headers·location·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-300·get·responses·300·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/get/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-301·head·responses·301·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·301·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-301·head·responses·301·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/head/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-301·get·responses·301·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·get·responses·301·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-301·get·responses·301·headers·location·schema"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-300·get·responses·300·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-301·get·responses·301·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-302·get·responses·302·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-303·post·responses·303·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·get·responses·307·headers·location·schema"
      ]
     },
     "enum": [
@@ -10477,119 +6089,12 @@
      ],
      "name": "paths·http-redirect-301·put·responses·301·headers·location·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-301·put·responses·301·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/failure/500"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-302·head·responses·302·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·302·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-302·head·responses·302·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/head/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-302·get·responses·302·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·302·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-302·get·responses·302·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/get/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-302·patch·responses·302·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·responses·302·headers·location·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-301·put·responses·301·headers·location·schema",
       "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-302·patch·responses·302·headers·location·schema"
      ]
     },
     "enum": [
      "/http/failure/500"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-303·post·responses·303·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·303·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-303·post·responses·303·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/get/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-307·head·responses·307·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·307·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·head·responses·307·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/head/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-307·get·responses·307·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·307·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-redirect-307·get·responses·307·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/get/200"
     ],
     "type": "string"
    },
@@ -10682,25 +6187,6 @@
      "/http/success/delete/200"
     ],
     "type": "string"
-   },
-   "paths·http-retry-502·options·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·options·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/schemas/paths·http-retry-502·options·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
    }
   },
   "requestBodies": {
@@ -10714,990 +6200,47 @@
      ],
      "name": "paths·http-success-200·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-200·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-200·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-200·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:8"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-201·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-201·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:10"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-202·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:11"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-202·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:12"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-202·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:13"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-202·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:14"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-204·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-204·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:16"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-204·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:17"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-204·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:18"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-301·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:25"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-302·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:29"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-303·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:31"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-307·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:36"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-307·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:38"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-307·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:40"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-307·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:42"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-400·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:44"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-400·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-400·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:46"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-400·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:47"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-404·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-404·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:48"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-405·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-405·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:49"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-406·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-406·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:50"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-407·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-407·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:51"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-409·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-409·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:52"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-413·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-413·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:53"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-414·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-414·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:54"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-415·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-415·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:55"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-417·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-417·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:56"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-server-505·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:57"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-server-505·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:58"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-500·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:59"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-500·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:60"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-503·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:62"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-503·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:63"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-504·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:64"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·patch·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-200·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-200·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-200·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-200·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-201·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-201·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-202·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-202·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-202·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-202·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-204·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-204·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-204·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-success-204·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-301·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-302·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-303·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-307·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-307·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-307·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-redirect-307·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-400·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-400·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-400·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-400·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-404·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-405·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-406·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-407·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-409·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-413·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-414·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-415·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-client-417·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-server-505·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-failure-server-505·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-500·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-500·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-503·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-503·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-504·put·requestbody",
       "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/requestBodies/paths·http-retry-504·patch·requestbody"
      ]
     },
@@ -11705,7 +6248,7 @@
      "application/json": {
       "schema": {
        "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/schemas:65"
+       "$ref": "#/components/schemas/schemas:5"
       }
      }
     },
@@ -11724,7 +6267,10 @@
      ],
      "name": "paths·http-redirect-300·head·responses·300·headers·location",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-300·head·responses·300·headers·location"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-300·head·responses·300·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-301·head·responses·301·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-302·head·responses·302·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-307·head·responses·307·headers·location"
      ]
     },
     "schema": {
@@ -11742,47 +6288,15 @@
      ],
      "name": "paths·http-redirect-300·get·responses·300·headers·location",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-300·get·responses·300·headers·location"
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-300·get·responses·300·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-301·get·responses·301·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-302·get·responses·302·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-303·post·responses·303·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-307·get·responses·307·headers·location"
      ]
     },
     "schema": {
      "$ref": "#/components/schemas/paths·http-redirect-300·get·responses·300·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·301·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-301·head·responses·301·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-301·head·responses·301·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·get·responses·301·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-301·get·responses·301·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-301·get·responses·301·headers·location·schema"
     },
     "description": "The redirect location for this request"
    },
@@ -11796,119 +6310,12 @@
      ],
      "name": "paths·http-redirect-301·put·responses·301·headers·location",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-301·put·responses·301·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-301·put·responses·301·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·302·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-302·head·responses·302·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-302·head·responses·302·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·302·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-302·get·responses·302·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-302·get·responses·302·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·responses·302·headers·location",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-301·put·responses·301·headers·location",
       "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-302·patch·responses·302·headers·location"
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-302·patch·responses·302·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·303·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-303·post·responses·303·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-303·post·responses·303·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·307·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-307·head·responses·307·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-307·head·responses·307·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·307·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.quirks.json#/components/headers/paths·http-redirect-307·get·responses·307·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-307·get·responses·307·headers·location·schema"
+     "$ref": "#/components/schemas/paths·http-redirect-301·put·responses·301·headers·location·schema"
     },
     "description": "The redirect location for this request"
    },

--- a/modelerfour/test/inputs/httpInfrastructure/openapi-document.json
+++ b/modelerfour/test/inputs/httpInfrastructure/openapi-document.json
@@ -102,7 +102,7 @@
     "responses": {
      "200": {
       "description": "Successfully returns 400 error code with the get request",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -148,7 +148,7 @@
     "responses": {
      "200": {
       "description": "Successfully returns 200 error code with the get request",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -198,7 +198,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -230,11 +230,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the get request",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -266,11 +266,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the options request",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -307,11 +307,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -342,17 +342,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:1"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -383,17 +383,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:2"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -424,17 +424,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:3"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -479,17 +479,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:4"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "201": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -520,17 +520,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:5"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "201": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -575,17 +575,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:6"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -616,17 +616,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:7"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -657,17 +657,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:8"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -698,17 +698,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:9"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -754,11 +754,11 @@
     "responses": {
      "204": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -789,17 +789,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:10"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "204": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -830,17 +830,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:11"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "204": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -871,17 +871,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:12"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "204": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -912,17 +912,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:13"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "204": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:38"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -968,15 +968,15 @@
     "responses": {
      "204": {
       "description": "Successfully received the head request",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:4"
      },
      "404": {
       "description": "Successfully received the head request",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1022,7 +1022,7 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:4"
      },
      "300": {
       "description": "Redirect to another endpoint",
@@ -1030,7 +1030,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1062,7 +1062,7 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:46"
+      "$ref": "#/components/responses/responses:4"
      },
      "300": {
       "description": "Redirect to another endpoint",
@@ -1070,7 +1070,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:48"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1116,15 +1116,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:49"
+      "$ref": "#/components/responses/responses:4"
      },
      "301": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:50"
+      "$ref": "#/components/responses/responses:44"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1156,7 +1156,7 @@
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:52"
+      "$ref": "#/components/responses/responses:4"
      },
      "301": {
       "description": "Redirect to another endpoint",
@@ -1164,7 +1164,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:54"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1195,7 +1195,7 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:14"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
@@ -1205,7 +1205,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:56"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1251,15 +1251,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:4"
      },
      "302": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:58"
+      "$ref": "#/components/responses/responses:44"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:59"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1291,15 +1291,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:60"
+      "$ref": "#/components/responses/responses:4"
      },
      "302": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:61"
+      "$ref": "#/components/responses/responses:53"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:62"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1330,17 +1330,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:15"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "302": {
       "description": "Redirect to another endpoint. This redirect should *not* be automatically followed",
-      "$ref": "#/components/responses/responses:63"
+      "$ref": "#/components/responses/responses:55"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:64"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1385,21 +1385,21 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:16"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned afyter a successful redirect",
-      "$ref": "#/components/responses/responses:65"
+      "$ref": "#/components/responses/responses:4"
      },
      "303": {
       "description": "Redirect to another endpoint. This redirect should be automatically followed with a get request",
-      "$ref": "#/components/responses/responses:66"
+      "$ref": "#/components/responses/responses:53"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:67"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1445,15 +1445,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:68"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:69"
+      "$ref": "#/components/responses/responses:44"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:70"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1485,15 +1485,15 @@
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:71"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
-      "$ref": "#/components/responses/responses:72"
+      "$ref": "#/components/responses/responses:53"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:73"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1525,7 +1525,7 @@
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:74"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1533,7 +1533,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:76"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1564,13 +1564,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:17"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:77"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1578,7 +1578,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:79"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1609,13 +1609,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:18"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:80"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1623,7 +1623,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:82"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1654,13 +1654,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:19"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:83"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1668,7 +1668,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:85"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1699,13 +1699,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:20"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Success, should be returned after a successful redirect",
-      "$ref": "#/components/responses/responses:86"
+      "$ref": "#/components/responses/responses:4"
      },
      "307": {
       "description": "Redirect to another endpoint",
@@ -1713,7 +1713,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:88"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1759,7 +1759,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:89"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1791,7 +1791,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:90"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1823,7 +1823,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:91"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1854,13 +1854,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:21"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:92"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1891,13 +1891,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:22"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:93"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1928,13 +1928,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:23"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:94"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1965,13 +1965,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:24"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:95"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2017,7 +2017,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:96"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2063,7 +2063,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:97"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2109,7 +2109,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:98"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2141,7 +2141,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:99"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2186,13 +2186,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:25"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:100"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2237,13 +2237,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:26"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:101"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2288,13 +2288,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:27"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:102"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2339,13 +2339,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:28"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:103"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2390,13 +2390,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:29"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:104"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2442,7 +2442,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:105"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2488,7 +2488,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:106"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2534,7 +2534,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:107"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2566,7 +2566,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:108"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2611,13 +2611,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:30"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:109"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2662,13 +2662,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:31"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:110"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2713,13 +2713,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:32"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:111"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2765,7 +2765,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:112"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2810,13 +2810,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:33"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:113"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2862,7 +2862,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:114"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2908,7 +2908,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:115"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2940,7 +2940,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:116"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2985,13 +2985,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:34"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:117"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3022,13 +3022,13 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:35"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:118"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3074,11 +3074,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:119"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:120"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3123,17 +3123,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:36"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:121"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:122"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3164,17 +3164,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:37"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:123"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:124"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3220,11 +3220,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:125"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:126"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3256,11 +3256,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:127"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:128"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3305,17 +3305,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:38"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:129"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:130"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3346,17 +3346,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:39"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:131"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:132"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3401,17 +3401,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:40"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:133"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:134"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3442,17 +3442,17 @@
     ],
     "requestBody": {
      "description": "Simple boolean value true",
-     "$ref": "#/components/requestBodies/requestBodies:41"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Successfully received the boolean true value",
-      "$ref": "#/components/responses/responses:135"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:136"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3502,11 +3502,11 @@
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:138"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:139"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3552,15 +3552,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '204'}",
-      "$ref": "#/components/responses/responses:140"
+      "$ref": "#/components/responses/responses:137"
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:141"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:142"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3606,15 +3606,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:143"
+      "$ref": "#/components/responses/responses:137"
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:144"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:145"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3660,15 +3660,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:146"
+      "$ref": "#/components/responses/responses:137"
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:147"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:148"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3714,15 +3714,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:149"
+      "$ref": "#/components/responses/responses:137"
      },
      "204": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:150"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:151"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3768,7 +3768,7 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:152"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
@@ -3776,7 +3776,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:154"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3822,15 +3822,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:155"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
-      "$ref": "#/components/responses/responses:156"
+      "$ref": "#/components/responses/responses:153"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:157"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3876,15 +3876,15 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:158"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
-      "$ref": "#/components/responses/responses:159"
+      "$ref": "#/components/responses/responses:153"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:160"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3930,7 +3930,7 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:161"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'httpCode': '201'}",
@@ -3942,7 +3942,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:164"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3988,19 +3988,19 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:165"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'httpCode': '201'}",
-      "$ref": "#/components/responses/responses:166"
+      "$ref": "#/components/responses/responses:162"
      },
      "404": {
       "description": "Return {'httpStatusCode': '404'}",
-      "$ref": "#/components/responses/responses:167"
+      "$ref": "#/components/responses/responses:163"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:168"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4046,19 +4046,19 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:169"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'httpCode': '201'}",
-      "$ref": "#/components/responses/responses:170"
+      "$ref": "#/components/responses/responses:162"
      },
      "404": {
       "description": "Return {'httpStatusCode': '404'}",
-      "$ref": "#/components/responses/responses:171"
+      "$ref": "#/components/responses/responses:163"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:172"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4104,19 +4104,19 @@
     "responses": {
      "200": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:173"
+      "$ref": "#/components/responses/responses:137"
      },
      "201": {
       "description": "Return {'httpCode': '201'}",
-      "$ref": "#/components/responses/responses:174"
+      "$ref": "#/components/responses/responses:162"
      },
      "404": {
       "description": "Return {'httpStatusCode': '404'}",
-      "$ref": "#/components/responses/responses:175"
+      "$ref": "#/components/responses/responses:163"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:176"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4162,15 +4162,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:177"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No Payload for NoContent",
-      "$ref": "#/components/responses/responses:178"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:179"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4216,15 +4216,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:180"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No Payload for NoContent",
-      "$ref": "#/components/responses/responses:181"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:182"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4270,15 +4270,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:183"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No Payload for NoContent",
-      "$ref": "#/components/responses/responses:184"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error with payload: {'code': '400', 'message': 'client error'}",
-      "$ref": "#/components/responses/responses:185"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4324,15 +4324,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted, but this operation will return {'property': 'value'}",
-      "$ref": "#/components/responses/responses:186"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No payload for NoContent",
-      "$ref": "#/components/responses/responses:187"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error with no payload",
-      "$ref": "#/components/responses/responses:188"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4378,15 +4378,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:189"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No payload for NoContent",
-      "$ref": "#/components/responses/responses:190"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error with no payload",
-      "$ref": "#/components/responses/responses:191"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4432,15 +4432,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:192"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No payload for NoContent",
-      "$ref": "#/components/responses/responses:193"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error with no payload",
-      "$ref": "#/components/responses/responses:194"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4486,15 +4486,15 @@
     "responses": {
      "202": {
       "description": "No payload for Accepted",
-      "$ref": "#/components/responses/responses:195"
+      "$ref": "#/components/responses/responses:4"
      },
      "204": {
       "description": "No payload for NoContent",
-      "$ref": "#/components/responses/responses:196"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error should have no payload, but this operation sends: {'property': 'value'}",
-      "$ref": "#/components/responses/responses:197"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4540,7 +4540,7 @@
     "responses": {
      "default": {
       "description": "Return {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:198"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4586,7 +4586,7 @@
     "responses": {
      "default": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:199"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4632,7 +4632,7 @@
     "responses": {
      "default": {
       "description": "Return {'statusCode': '400'}",
-      "$ref": "#/components/responses/responses:200"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4678,7 +4678,7 @@
     "responses": {
      "default": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:201"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4724,7 +4724,7 @@
     "responses": {
      "default": {
       "description": "Return invalid payload {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:202"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4770,7 +4770,7 @@
     "responses": {
      "default": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:203"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4816,7 +4816,7 @@
     "responses": {
      "default": {
       "description": "Return invalid payload{'statusCode': '400'}",
-      "$ref": "#/components/responses/responses:204"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4862,7 +4862,7 @@
     "responses": {
      "default": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:205"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -4908,7 +4908,7 @@
     "responses": {
      "200": {
       "description": "Return no payload",
-      "$ref": "#/components/responses/responses:206"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -4954,7 +4954,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with valid payload {'statusCode': '200'}",
-      "$ref": "#/components/responses/responses:207"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5000,7 +5000,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with invalid payload {'statusCodeInvalid': '200'}",
-      "$ref": "#/components/responses/responses:208"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5046,7 +5046,7 @@
     "responses": {
      "200": {
       "description": "Return no payload, and an unmodeled 400 response",
-      "$ref": "#/components/responses/responses:209"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5092,7 +5092,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with valid payload {'statusCode': '400'}  but error status code 400, which is unmodeled",
-      "$ref": "#/components/responses/responses:210"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5138,7 +5138,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with invalid payload {'statusCodeInvalid': '400'}",
-      "$ref": "#/components/responses/responses:211"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5184,7 +5184,7 @@
     "responses": {
      "200": {
       "description": "Return a respose with valid payload {'statusCode': '202'}  but unmodeled success status code 202, which is unmodeled",
-      "$ref": "#/components/responses/responses:212"
+      "$ref": "#/components/responses/responses:137"
      }
     }
    }
@@ -5202,7 +5202,12 @@
      ],
      "name": "paths·http-failure-emptybody-error·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-emptybody-error·get·responses·200"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-emptybody-error·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-nomodel-error·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-nomodel-empty·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·options·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-502·options·responses·200"
      ]
     },
     "description": "Successfully returns 400 error code with the get request",
@@ -5225,7 +5230,96 @@
      ],
      "name": "paths·http-failure-emptybody-error·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-emptybody-error·get·responses·default"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-emptybody-error·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-201·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-201·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-404·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-303·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-401·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-402·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-403·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-403·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-404·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-405·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-406·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-407·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-409·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-410·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-411·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-412·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-412·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-413·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-414·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-415·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-416·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-417·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-429·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-server-501·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-server-501·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-server-505·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-server-505·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-408·head·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-500·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-500·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-502·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-502·options·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-503·post·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-503·delete·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-504·put·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-504·patch·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -5233,52 +5327,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-nomodel-error·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-nomodel-error·get·responses·200"
-     ]
-    },
-    "description": "Successfully returns 400 error code with the get request",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-nomodel-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-nomodel-empty·get·responses·200"
-     ]
-    },
-    "description": "Successfully returns 200 error code with the get request",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema"
       }
      }
     }
@@ -5293,744 +5341,76 @@
      ],
      "name": "paths·http-success-200·head·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·head·responses·200"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·put·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·patch·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·post·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·delete·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-201·put·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-201·post·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·put·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·patch·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·post·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·delete·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·head·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·put·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·patch·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·post·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·delete·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-404·head·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-404·head·responses·404",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-303·post·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·options·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·put·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·patch·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·post·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·delete·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-408·head·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-500·put·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-500·patch·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-502·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-503·post·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-503·delete·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-504·put·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-504·patch·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·202",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·204",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-none-response-200-invalid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-none-response-200-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-none-response-400-invalid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-none-response-400-none·get·responses·default"
      ]
     },
     "description": "Successfully received the head request"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the get request",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-200·get·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·options·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·options·responses·200"
-     ]
-    },
-    "description": "Successfully received the options request",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-200·options·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·put·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·patch·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·delete·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-200·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-201·put·responses·201"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-201·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·post·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-201·post·responses·201"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-201·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·put·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·put·responses·202"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·patch·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·patch·responses·202"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·post·responses·202"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·delete·responses·202"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-202·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·head·responses·204"
-     ]
-    },
-    "description": "Successfully received the true boolean value"
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·put·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·put·responses·204"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·patch·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·patch·responses·204"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·post·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·post·responses·204"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·delete·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·delete·responses·204"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-204·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-404·head·responses·204"
-     ]
-    },
-    "description": "Successfully received the head request"
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-404·head·responses·404"
-     ]
-    },
-    "description": "Successfully received the head request"
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-404·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-success-404·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-300·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·head·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
    },
    "responses:44": {
     "x-ms-metadata": {
@@ -6042,7 +5422,10 @@
      ],
      "name": "paths·http-redirect-300·head·responses·300",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·head·responses·300"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·head·responses·300",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·head·responses·301",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·head·responses·302",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·head·responses·307"
      ]
     },
     "description": "Redirect to another endpoint",
@@ -6052,43 +5435,6 @@
       "$ref": "#/components/headers/headers:0"
      }
     }
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-300·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-300·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·get·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
    },
    "responses:47": {
     "x-ms-metadata": {
@@ -6119,101 +5465,6 @@
      }
     }
    },
-   "responses:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-300·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-300·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·head·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
-   },
-   "responses:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·301",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·head·responses·301"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:2"
-     }
-    }
-   },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·get·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
    "responses:53": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -6224,36 +5475,17 @@
      ],
      "name": "paths·http-redirect-301·get·responses·301",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·get·responses·301"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·get·responses·301",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·get·responses·302",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-303·post·responses·303",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·get·responses·307"
      ]
     },
     "description": "Redirect to another endpoint",
     "headers": {
      "Location": {
       "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:3"
-     }
-    }
-   },
-   "responses:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
+      "$ref": "#/components/headers/headers:1"
      }
     }
    },
@@ -6267,7 +5499,8 @@
      ],
      "name": "paths·http-redirect-301·put·responses·301",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·put·responses·301"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·put·responses·301",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·patch·responses·302"
      ]
     },
     "description": "Redirect to another endpoint. This redirect should *not* be automatically followed",
@@ -6277,376 +5510,6 @@
       "$ref": "#/components/headers/headers:4"
      }
     }
-   },
-   "responses:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-301·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·head·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
-   },
-   "responses:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·302",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·head·responses·302"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:5"
-     }
-    }
-   },
-   "responses:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·get·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
-   },
-   "responses:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·302",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·get·responses·302"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:6"
-     }
-    }
-   },
-   "responses:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·responses·302",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·patch·responses·302"
-     ]
-    },
-    "description": "Redirect to another endpoint. This redirect should *not* be automatically followed",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:7"
-     }
-    }
-   },
-   "responses:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-302·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-303·post·responses·200"
-     ]
-    },
-    "description": "Success, should be returned afyter a successful redirect"
-   },
-   "responses:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·303",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-303·post·responses·303"
-     ]
-    },
-    "description": "Redirect to another endpoint. This redirect should be automatically followed with a get request",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:8"
-     }
-    }
-   },
-   "responses:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-303·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·head·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
-   "responses:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·307",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·head·responses·307"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:9"
-     }
-    }
-   },
-   "responses:70": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·get·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
-   "responses:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·307",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·get·responses·307"
-     ]
-    },
-    "description": "Redirect to another endpoint",
-    "headers": {
-     "Location": {
-      "description": "The redirect location for this request",
-      "$ref": "#/components/headers/headers:10"
-     }
-    }
-   },
-   "responses:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·options·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·options·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
    },
    "responses:75": {
     "x-ms-metadata": {
@@ -6669,43 +5532,6 @@
      }
     }
    },
-   "responses:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·put·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
    "responses:78": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -6726,43 +5552,6 @@
       "$ref": "#/components/headers/headers:12"
      }
     }
-   },
-   "responses:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·patch·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
    },
    "responses:81": {
     "x-ms-metadata": {
@@ -6785,43 +5574,6 @@
      }
     }
    },
-   "responses:82": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·post·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
-   },
    "responses:84": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -6842,43 +5594,6 @@
       "$ref": "#/components/headers/headers:14"
      }
     }
-   },
-   "responses:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:86": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·delete·responses·200"
-     ]
-    },
-    "description": "Success, should be returned after a successful redirect"
    },
    "responses:87": {
     "x-ms-metadata": {
@@ -6901,1029 +5616,6 @@
      }
     }
    },
-   "responses:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-redirect-307·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:90": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:92": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:94": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-400·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-401·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-401·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-402·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-402·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-403·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-403·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-403·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-403·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:100": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-404·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-404·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-405·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-405·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:102": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-406·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-406·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-407·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-407·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-409·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-409·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-410·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-410·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-411·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-411·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-412·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-412·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:108": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-412·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-412·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-413·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-413·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-414·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-414·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-415·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-415·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-416·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-416·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-417·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-417·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-429·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-client-429·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-501·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-server-501·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-501·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-server-501·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-server-505·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:118": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-failure-server-505·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-408·head·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-408·head·responses·200"
-     ]
-    },
-    "description": "Successfully received the true boolean value"
-   },
-   "responses:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-408·head·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-408·head·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-500·put·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-500·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-500·patch·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-500·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-502·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the true boolean value"
-   },
-   "responses:126": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-502·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·options·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-502·options·responses·200"
-     ]
-    },
-    "description": "Successfully received the true boolean value",
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-retry-502·options·responses·200·content·application-json·schema"
-      }
-     }
-    }
-   },
-   "responses:128": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·options·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-502·options·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:129": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-503·post·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:130": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-503·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:131": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-503·delete·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:132": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-503·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:133": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-504·put·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:134": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-504·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:135": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-504·patch·responses·200"
-     ]
-    },
-    "description": "Successfully received the boolean true value"
-   },
-   "responses:136": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·patch·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-retry-504·patch·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
    "responses:137": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -7934,302 +5626,29 @@
      ],
      "name": "paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:138": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:139": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:140": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '204'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:141": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:142": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:143": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:144": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:145": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:146": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:147": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:148": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:149": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:150": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·204"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:151": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:152": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·200"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-200-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-204-none·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-201-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-202-none·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-204-none-default-error-response-400-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-a-response-200-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-a-response-200-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-a-response-400-valid·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-a-response-400-none·get·responses·default",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-200-none·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-200-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-200-invalid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-400-none·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-400-valid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-400-invalid·get·responses·200",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-202-valid·get·responses·200"
      ]
     },
     "description": "Return {'statusCode': '200'}",
@@ -8251,138 +5670,8 @@
      ],
      "name": "paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·201",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:154": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:155": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:156": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:157": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:158": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:159": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·201",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-200-valid·get·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-201-valid·get·responses·201",
       "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·201"
      ]
     },
@@ -8391,50 +5680,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:70"
-      }
-     }
-    }
-   },
-   "responses:160": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-b-default-error-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:161": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
       }
      }
     }
@@ -8449,7 +5694,10 @@
      ],
      "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·201",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·201"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·201",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·201"
      ]
     },
     "description": "Return {'httpCode': '201'}",
@@ -8471,270 +5719,9 @@
      ],
      "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·404",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·404"
-     ]
-    },
-    "description": "Return {'httpStatusCode': '404'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:164": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:165": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:166": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'httpCode': '201'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:72"
-      }
-     }
-    }
-   },
-   "responses:167": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·404"
-     ]
-    },
-    "description": "Return {'httpStatusCode': '404'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:168": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:169": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:170": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'httpCode': '201'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:72"
-      }
-     }
-    }
-   },
-   "responses:171": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·404",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·404"
-     ]
-    },
-    "description": "Return {'httpStatusCode': '404'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:172": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:173": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·200"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:174": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·201"
-     ]
-    },
-    "description": "Return {'httpCode': '201'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:72"
-      }
-     }
-    }
-   },
-   "responses:175": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·404",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-200-valid·get·responses·404",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-201-valid·get·responses·404",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-404-valid·get·responses·404",
       "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·404"
      ]
     },
@@ -8743,666 +5730,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:74"
-      }
-     }
-    }
-   },
-   "responses:176": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-201-c-404-d-default-error-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:177": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:178": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·204"
-     ]
-    },
-    "description": "No Payload for NoContent"
-   },
-   "responses:179": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-202-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:180": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:181": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·204"
-     ]
-    },
-    "description": "No Payload for NoContent"
-   },
-   "responses:182": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-204-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:183": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:184": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·204"
-     ]
-    },
-    "description": "No Payload for NoContent"
-   },
-   "responses:185": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-error-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error with payload: {'code': '400', 'message': 'client error'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:66"
-      }
-     }
-    }
-   },
-   "responses:186": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted, but this operation will return {'property': 'value'}"
-   },
-   "responses:187": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·204"
-     ]
-    },
-    "description": "No payload for NoContent"
-   },
-   "responses:188": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-202-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error with no payload"
-   },
-   "responses:189": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:190": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·204"
-     ]
-    },
-    "description": "No payload for NoContent"
-   },
-   "responses:191": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-204-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error with no payload"
-   },
-   "responses:192": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:193": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·204"
-     ]
-    },
-    "description": "No payload for NoContent"
-   },
-   "responses:194": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-none·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error with no payload"
-   },
-   "responses:195": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·202"
-     ]
-    },
-    "description": "No payload for Accepted"
-   },
-   "responses:196": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·204"
-     ]
-    },
-    "description": "No payload for NoContent"
-   },
-   "responses:197": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-202-none-204-none-default-none-response-400-invalid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error should have no payload, but this operation sends: {'property': 'value'}"
-   },
-   "responses:198": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-a-response-200-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-a-response-200-valid·get·responses·default"
-     ]
-    },
-    "description": "Return {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:199": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-a-response-200-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-a-response-200-none·get·responses·default"
-     ]
-    },
-    "description": "Return no payload",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:200": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-a-response-400-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-a-response-400-valid·get·responses·default"
-     ]
-    },
-    "description": "Return {'statusCode': '400'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:201": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-a-response-400-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-a-response-400-none·get·responses·default"
-     ]
-    },
-    "description": "Return no payload",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:202": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-none-response-200-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-none-response-200-invalid·get·responses·default"
-     ]
-    },
-    "description": "Return invalid payload {'statusCode': '200'}"
-   },
-   "responses:203": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-none-response-200-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-none-response-200-none·get·responses·default"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:204": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-none-response-400-invalid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-none-response-400-invalid·get·responses·default"
-     ]
-    },
-    "description": "Return invalid payload{'statusCode': '400'}"
-   },
-   "responses:205": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-default-none-response-400-none·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-default-none-response-400-none·get·responses·default"
-     ]
-    },
-    "description": "Return no payload"
-   },
-   "responses:206": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-200-none·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-200-none·get·responses·200"
-     ]
-    },
-    "description": "Return no payload",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:207": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-200-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-200-valid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with valid payload {'statusCode': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:208": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-200-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-200-invalid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with invalid payload {'statusCodeInvalid': '200'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:209": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-400-none·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-400-none·get·responses·200"
-     ]
-    },
-    "description": "Return no payload, and an unmodeled 400 response",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:210": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-400-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-400-valid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with valid payload {'statusCode': '400'}  but error status code 400, which is unmodeled",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:211": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-400-invalid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-400-invalid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with invalid payload {'statusCodeInvalid': '400'}",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
-      }
-     }
-    }
-   },
-   "responses:212": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-payloads-200-a-response-202-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/responses/paths·http-payloads-200-a-response-202-valid·get·responses·200"
-     ]
-    },
-    "description": "Return a respose with valid payload {'statusCode': '202'}  but unmodeled success status code 202, which is unmodeled",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:68"
       }
      }
     }
@@ -9638,349 +5965,54 @@
      ],
      "name": "paths·http-failure-emptybody-error·get·responses·200·content·application-json·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-emptybody-error·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-200·get·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·get·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·get·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-200·options·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·options·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·options·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-200·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-200·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-200·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-200·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-201·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-201·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-201·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-201·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-202·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-202·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-202·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-202·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-202·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-202·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-202·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-202·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-204·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-204·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-204·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-204·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-204·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-204·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-success-204·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-204·delete·requestbody·content·application-json·schema"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-emptybody-error·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·get·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·options·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-200·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-201·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-201·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-202·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-202·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-202·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-202·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-204·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-204·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-204·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-success-204·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-301·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-302·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-303·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-400·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-400·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-400·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-400·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-404·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-405·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-406·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-407·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-409·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-413·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-414·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-415·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-417·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-server-505·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-server-505·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-500·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-500·patch·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-502·options·responses·200·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-503·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-503·delete·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-504·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-504·patch·requestbody·content·application-json·schema"
      ]
     },
     "description": "Simple boolean value true",
@@ -9999,7 +6031,10 @@
      ],
      "name": "paths·http-redirect-300·head·responses·300·headers·location·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-300·head·responses·300·headers·location·schema"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-300·head·responses·300·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-301·head·responses·301·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-302·head·responses·302·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·head·responses·307·headers·location·schema"
      ]
     },
     "enum": [
@@ -10017,68 +6052,17 @@
      ],
      "name": "paths·http-redirect-300·get·responses·300·headers·location·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-300·get·responses·300·headers·location·schema"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-300·get·responses·300·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-301·get·responses·301·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-302·get·responses·302·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-303·post·responses·303·headers·location·schema",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·get·responses·307·headers·location·schema"
      ]
     },
     "enum": [
      "/http/success/get/200"
     ],
     "type": "string"
-   },
-   "paths·http-redirect-301·head·responses·301·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·301·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-301·head·responses·301·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/head/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-301·get·responses·301·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·get·responses·301·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-301·get·responses·301·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/get/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-301·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-301·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
    },
    "paths·http-redirect-301·put·responses·301·headers·location·schema": {
     "x-ms-metadata": {
@@ -10090,157 +6074,12 @@
      ],
      "name": "paths·http-redirect-301·put·responses·301·headers·location·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-301·put·responses·301·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/failure/500"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-302·head·responses·302·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·302·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-302·head·responses·302·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/head/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-302·get·responses·302·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·302·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-302·get·responses·302·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/get/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-302·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-302·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-redirect-302·patch·responses·302·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·responses·302·headers·location·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-301·put·responses·301·headers·location·schema",
       "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-302·patch·responses·302·headers·location·schema"
      ]
     },
     "enum": [
      "/http/failure/500"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-303·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-303·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-redirect-303·post·responses·303·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·303·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-303·post·responses·303·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/get/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-307·head·responses·307·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·307·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·head·responses·307·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/head/200"
-    ],
-    "type": "string"
-   },
-   "paths·http-redirect-307·get·responses·307·headers·location·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·307·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·get·responses·307·headers·location·schema"
-     ]
-    },
-    "enum": [
-     "/http/success/get/200"
     ],
     "type": "string"
    },
@@ -10262,25 +6101,6 @@
     ],
     "type": "string"
    },
-   "paths·http-redirect-307·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
    "paths·http-redirect-307·put·responses·307·headers·location·schema": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -10298,25 +6118,6 @@
      "/http/success/put/200"
     ],
     "type": "string"
-   },
-   "paths·http-redirect-307·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
    },
    "paths·http-redirect-307·patch·responses·307·headers·location·schema": {
     "x-ms-metadata": {
@@ -10336,25 +6137,6 @@
     ],
     "type": "string"
    },
-   "paths·http-redirect-307·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
    "paths·http-redirect-307·post·responses·307·headers·location·schema": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -10373,25 +6155,6 @@
     ],
     "type": "string"
    },
-   "paths·http-redirect-307·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-redirect-307·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
    "paths·http-redirect-307·delete·responses·307·headers·location·schema": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -10409,424 +6172,6 @@
      "/http/success/delete/200"
     ],
     "type": "string"
-   },
-   "paths·http-failure-client-400·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-400·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-400·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-400·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-400·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-400·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-400·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-400·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-404·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-404·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-404·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-405·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-405·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-405·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-406·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-406·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-406·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-407·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-407·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-407·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-409·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-409·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-409·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-413·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-413·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-413·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-414·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-414·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-414·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-415·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-415·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-415·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-client-417·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-417·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-client-417·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-server-505·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-server-505·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-failure-server-505·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-failure-server-505·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-retry-500·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-500·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-retry-500·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-500·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-retry-502·options·responses·200·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-502·options·responses·200·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-502·options·responses·200·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-retry-503·post·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-503·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-retry-503·delete·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·delete·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-503·delete·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-retry-504·put·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-504·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
-   },
-   "paths·http-retry-504·patch·requestbody·content·application-json·schema": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·patch·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/schemas/paths·http-retry-504·patch·requestbody·content·application-json·schema"
-     ]
-    },
-    "description": "Simple boolean value true",
-    "type": "boolean",
-    "enum": [
-     true
-    ]
    }
   },
   "requestBodies": {
@@ -10840,990 +6185,47 @@
      ],
      "name": "paths·http-success-200·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-200·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-200·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-200·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-200·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-200·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-200·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-200·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-200·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-201·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-201·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-201·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-201·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-201·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-202·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-202·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-202·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-202·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-202·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-202·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-202·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-202·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-202·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-204·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-204·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-204·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-204·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-204·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-204·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-success-204·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-204·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-success-204·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-301·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-redirect-301·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-302·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-redirect-302·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-303·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-redirect-303·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-307·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-redirect-307·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-307·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-redirect-307·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-307·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-redirect-307·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-307·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-redirect-307·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-400·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-400·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-400·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-400·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-400·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-400·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-400·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-400·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-400·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-404·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-404·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-404·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-405·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-405·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-405·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-406·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-406·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-406·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-407·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-407·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-407·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-409·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-409·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-409·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-413·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-413·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-413·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-414·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-414·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-414·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-415·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-415·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-415·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-client-417·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-417·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-client-417·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-server-505·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-server-505·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-failure-server-505·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-server-505·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-failure-server-505·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-500·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-retry-500·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-500·patch·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-500·patch·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-retry-500·patch·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-503·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-retry-503·post·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-503·delete·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-503·delete·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-retry-503·delete·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-504·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-retry-504·put·requestbody·content·application-json·schema"
-      }
-     }
-    },
-    "description": "Simple boolean value true",
-    "x-ms-requestBody-name": "booleanValue"
-   },
-   "requestBodies:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-retry-504·patch·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-200·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-200·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-200·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-200·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-201·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-201·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-202·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-202·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-202·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-202·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-204·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-204·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-204·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-success-204·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-301·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-302·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-303·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-307·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-307·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-307·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-redirect-307·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-400·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-400·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-400·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-400·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-404·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-405·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-406·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-407·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-409·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-413·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-414·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-415·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-client-417·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-server-505·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-failure-server-505·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-500·put·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-500·patch·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-503·post·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-503·delete·requestbody",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-504·put·requestbody",
       "http://localhost:3000/swagger/httpInfrastructure.json#/components/requestBodies/paths·http-retry-504·patch·requestbody"
      ]
     },
@@ -11831,7 +6233,7 @@
      "application/json": {
       "schema": {
        "description": "Simple boolean value true",
-       "$ref": "#/components/schemas/paths·http-retry-504·patch·requestbody·content·application-json·schema"
+       "$ref": "#/components/schemas/paths·http-failure-emptybody-error·get·responses·200·content·application-json·schema"
       }
      }
     },
@@ -11850,7 +6252,10 @@
      ],
      "name": "paths·http-redirect-300·head·responses·300·headers·location",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-300·head·responses·300·headers·location"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-300·head·responses·300·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-301·head·responses·301·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-302·head·responses·302·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-307·head·responses·307·headers·location"
      ]
     },
     "schema": {
@@ -11868,47 +6273,15 @@
      ],
      "name": "paths·http-redirect-300·get·responses·300·headers·location",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-300·get·responses·300·headers·location"
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-300·get·responses·300·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-301·get·responses·301·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-302·get·responses·302·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-303·post·responses·303·headers·location",
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-307·get·responses·307·headers·location"
      ]
     },
     "schema": {
      "$ref": "#/components/schemas/paths·http-redirect-300·get·responses·300·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·head·responses·301·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-301·head·responses·301·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-301·head·responses·301·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-301·get·responses·301·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-301·get·responses·301·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-301·get·responses·301·headers·location·schema"
     },
     "description": "The redirect location for this request"
    },
@@ -11922,119 +6295,12 @@
      ],
      "name": "paths·http-redirect-301·put·responses·301·headers·location",
      "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-301·put·responses·301·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-301·put·responses·301·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·head·responses·302·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-302·head·responses·302·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-302·head·responses·302·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·get·responses·302·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-302·get·responses·302·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-302·get·responses·302·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-302·patch·responses·302·headers·location",
-     "originalLocations": [
+      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-301·put·responses·301·headers·location",
       "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-302·patch·responses·302·headers·location"
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-302·patch·responses·302·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-303·post·responses·303·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-303·post·responses·303·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-303·post·responses·303·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·head·responses·307·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-307·head·responses·307·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-307·head·responses·307·headers·location·schema"
-    },
-    "description": "The redirect location for this request"
-   },
-   "headers:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·http-redirect-307·get·responses·307·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/httpInfrastructure.json#/components/headers/paths·http-redirect-307·get·responses·307·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/paths·http-redirect-307·get·responses·307·headers·location·schema"
+     "$ref": "#/components/schemas/paths·http-redirect-301·put·responses·301·headers·location·schema"
     },
     "description": "The redirect location for this request"
    },

--- a/modelerfour/test/inputs/lro/openapi-document.json
+++ b/modelerfour/test/inputs/lro/openapi-document.json
@@ -112,17 +112,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:1"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response without ProvisioningState",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -168,17 +168,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:2"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -224,21 +224,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:3"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:0"
      },
      "201": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -284,17 +284,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:4"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -340,21 +340,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:5"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Failed'",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      },
      "201": {
       "description": "Initial response, with ProvisioningState = 'Created'",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -400,17 +400,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:6"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -456,7 +456,7 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:7"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
@@ -466,7 +466,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -512,7 +512,7 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:8"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
@@ -522,7 +522,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -568,7 +568,7 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:9"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
@@ -578,7 +578,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -624,17 +624,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:10"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:19"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -680,17 +680,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:11"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:21"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -736,7 +736,7 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:12"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
@@ -746,7 +746,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -802,7 +802,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -848,17 +848,17 @@
     ],
     "requestBody": {
      "description": "Sku to put",
-     "$ref": "#/components/requestBodies/requestBodies:14"
+     "$ref": "#/components/requestBodies/requestBodies:13"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Accepted'",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:29"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -914,7 +914,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -960,17 +960,17 @@
     ],
     "requestBody": {
      "description": "Sub Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:16"
+     "$ref": "#/components/requestBodies/requestBodies:15"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Accepted'",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:33"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1017,7 +1017,7 @@
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:0"
      },
      "202": {
       "description": "Initial response, with ProvisioningState = 'Deleting'",
@@ -1025,7 +1025,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1072,15 +1072,15 @@
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:0"
      },
      "202": {
       "description": "Inital response",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:38"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1127,15 +1127,15 @@
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:0"
      },
      "202": {
       "description": "Inital response",
-      "$ref": "#/components/responses/responses:44"
+      "$ref": "#/components/responses/responses:38"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1182,11 +1182,11 @@
     "responses": {
      "204": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:46"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:47"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1233,7 +1233,7 @@
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:48"
+      "$ref": "#/components/responses/responses:0"
      },
      "202": {
       "description": "Initial response, with no entity body",
@@ -1241,7 +1241,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:50"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1288,15 +1288,15 @@
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:0"
      },
      "202": {
       "description": "Initial response, with no entity body",
-      "$ref": "#/components/responses/responses:52"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:53"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1347,11 +1347,11 @@
      },
      "204": {
       "description": "Response after completion",
-      "$ref": "#/components/responses/responses:55"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:56"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1398,15 +1398,15 @@
     "responses": {
      "202": {
       "description": "Initial response, with no entity body",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:54"
      },
      "204": {
       "description": "Response after completion",
-      "$ref": "#/components/responses/responses:58"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:59"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1457,7 +1457,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:61"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1504,11 +1504,11 @@
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:62"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:63"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1555,11 +1555,11 @@
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:64"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:65"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1606,11 +1606,11 @@
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:66"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:67"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1657,15 +1657,15 @@
     "responses": {
      "200": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:68"
+      "$ref": "#/components/responses/responses:29"
      },
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:69"
+      "$ref": "#/components/responses/responses:29"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:70"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1711,17 +1711,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:17"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:71"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:72"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1767,17 +1767,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:18"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:73"
+      "$ref": "#/components/responses/responses:38"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:74"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1827,11 +1827,11 @@
     "responses": {
      "202": {
       "description": "Response after completion.",
-      "$ref": "#/components/responses/responses:75"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:76"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1881,11 +1881,11 @@
     "responses": {
      "202": {
       "description": "Response after completion.",
-      "$ref": "#/components/responses/responses:77"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:78"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1932,11 +1932,11 @@
     "responses": {
      "202": {
       "description": "Response after completion.",
-      "$ref": "#/components/responses/responses:79"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:80"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -1982,21 +1982,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:19"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion.",
-      "$ref": "#/components/responses/responses:81"
+      "$ref": "#/components/responses/responses:0"
      },
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:82"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:83"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2042,21 +2042,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:20"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion.",
-      "$ref": "#/components/responses/responses:84"
+      "$ref": "#/components/responses/responses:0"
      },
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:85"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:86"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2102,17 +2102,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:21"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:87"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:88"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2158,17 +2158,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:22"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response",
-      "$ref": "#/components/responses/responses:89"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:90"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2214,21 +2214,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:23"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:91"
+      "$ref": "#/components/responses/responses:0"
      },
      "201": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:92"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:93"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2274,17 +2274,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:24"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:94"
+      "$ref": "#/components/responses/responses:19"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:95"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2331,15 +2331,15 @@
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:96"
+      "$ref": "#/components/responses/responses:0"
      },
      "202": {
       "description": "Initial response, with ProvisioningState = 'Deleting'",
-      "$ref": "#/components/responses/responses:97"
+      "$ref": "#/components/responses/responses:38"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:98"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2386,11 +2386,11 @@
     "responses": {
      "202": {
       "description": "Initial response, with no entity body",
-      "$ref": "#/components/responses/responses:99"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:100"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2437,11 +2437,11 @@
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:101"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:102"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2487,17 +2487,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:25"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:103"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:104"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2543,17 +2543,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:26"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:105"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:106"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2599,21 +2599,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:27"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:107"
+      "$ref": "#/components/responses/responses:0"
      },
      "201": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:108"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:109"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2659,21 +2659,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:28"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:110"
+      "$ref": "#/components/responses/responses:0"
      },
      "201": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:111"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:112"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2719,21 +2719,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:29"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:113"
+      "$ref": "#/components/responses/responses:0"
      },
      "201": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:114"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:115"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2779,17 +2779,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:30"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:116"
+      "$ref": "#/components/responses/responses:19"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:117"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2836,11 +2836,11 @@
     "responses": {
      "202": {
       "description": "Initial response, with no entity body",
-      "$ref": "#/components/responses/responses:118"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:119"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2887,11 +2887,11 @@
     "responses": {
      "202": {
       "description": "Initial response, with no entity body",
-      "$ref": "#/components/responses/responses:120"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:121"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2938,11 +2938,11 @@
     "responses": {
      "202": {
       "description": "For completion only will not return",
-      "$ref": "#/components/responses/responses:122"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:123"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -2988,17 +2988,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:31"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:124"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:125"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3044,17 +3044,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:32"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:126"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:127"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3100,17 +3100,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:33"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:128"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:129"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3156,21 +3156,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:34"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "for completion only will not return",
-      "$ref": "#/components/responses/responses:130"
+      "$ref": "#/components/responses/responses:0"
      },
      "201": {
       "description": "Initial response, with ProvisioningState missing",
-      "$ref": "#/components/responses/responses:131"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:132"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3216,17 +3216,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:35"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:133"
+      "$ref": "#/components/responses/responses:19"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:134"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3272,17 +3272,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:36"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:135"
+      "$ref": "#/components/responses/responses:19"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:136"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3329,11 +3329,11 @@
     "responses": {
      "204": {
       "description": "Final response",
-      "$ref": "#/components/responses/responses:137"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:138"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3380,11 +3380,11 @@
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:139"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:140"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3430,17 +3430,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:37"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:141"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:142"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3486,17 +3486,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:38"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:143"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:144"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3542,21 +3542,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:39"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:145"
+      "$ref": "#/components/responses/responses:0"
      },
      "204": {
       "description": "Final response",
-      "$ref": "#/components/responses/responses:146"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:147"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3602,17 +3602,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:40"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:148"
+      "$ref": "#/components/responses/responses:19"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:149"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3658,17 +3658,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:41"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:150"
+      "$ref": "#/components/responses/responses:19"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:151"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3715,11 +3715,11 @@
     "responses": {
      "202": {
       "description": "Initial response, with no entity body",
-      "$ref": "#/components/responses/responses:152"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:153"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3766,11 +3766,11 @@
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:154"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:155"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3817,11 +3817,11 @@
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:156"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:157"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3867,17 +3867,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:42"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:158"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:159"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3923,17 +3923,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:43"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:160"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:161"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -3979,17 +3979,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:44"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:162"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:163"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -4035,17 +4035,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:45"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:164"
+      "$ref": "#/components/responses/responses:19"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:165"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -4091,21 +4091,21 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:46"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Response after completion, with ProvisioningState='Succeeded'",
-      "$ref": "#/components/responses/responses:166"
+      "$ref": "#/components/responses/responses:0"
      },
      "201": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:167"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:168"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -4151,17 +4151,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:47"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response, with ProvisioningState = 'Creating'",
-      "$ref": "#/components/responses/responses:169"
+      "$ref": "#/components/responses/responses:49"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:170"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -4207,17 +4207,17 @@
     ],
     "requestBody": {
      "description": "Product to put",
-     "$ref": "#/components/requestBodies/requestBodies:48"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "202": {
       "description": "Initial response with ProvisioningState='Updating'",
-      "$ref": "#/components/responses/responses:171"
+      "$ref": "#/components/responses/responses:60"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:172"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -4235,283 +4235,51 @@
      ],
      "name": "paths·lro-put-200-succeeded·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-200-succeeded·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-succeeded-nostate·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-200-succeeded-nostate·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-202-retry-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-202-retry-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-201-creating-succeeded-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-201-creating-succeeded-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-updating-succeeded-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-200-updating-succeeded-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-201-created-failed-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-201-created-failed-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-accepted-canceled-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-200-accepted-canceled-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-noheader-202-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-noheader-202-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-succeeded·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-retry-succeeded·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-succeeded·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-noretry-succeeded·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-retry-failed·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-canceled·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-noretry-canceled·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noheader-201-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-noheader-201-200·put·requestbody"
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-200-succeeded·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-200-succeeded-nostate·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-202-retry-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-201-creating-succeeded-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-200-updating-succeeded-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-201-created-failed-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-200-accepted-canceled-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-put-noheader-202-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-retry-succeeded·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-noretry-succeeded·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-retry-failed·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-noretry-canceled·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putasync-noheader-201-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-post-202-retry-200·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-post-202-noretry-204·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-postasync-retry-succeeded·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-postasync-noretry-succeeded·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-postasync-retry-failed·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-postasync-retry-canceled·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-retryerror-put-201-creating-succeeded-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-retryerror-putasync-retry-succeeded·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-retryerror-post-202-retry-200·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-retryerror-postasync-retry-succeeded·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-put-400·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-put-201-creating-400·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-putasync-retry-400·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-post-400·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-post-202-retry-400·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-postasync-retry-400·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-put-201-noprovisioningstatepayload·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-putasync-retry-nostatus·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-putasync-retry-nostatuspayload·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-post-202-nolocation·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-postasync-retry-nopayload·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-put-200-invalidjson·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-putasync-retry-invalidheader·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-putasync-retry-invalidjsonpolling·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-post-202-retry-invalidheader·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-postasync-retry-invalidheader·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-postasync-retry-invalidjsonpolling·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-customheader-putasync-retry-succeeded·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-customheader-put-201-creating-succeeded-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-customheader-post-202-retry-200·post·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-customheader-postasync-retry-succeeded·post·requestbody"
      ]
     },
     "content": {
@@ -4534,7 +4302,8 @@
      ],
      "name": "paths·lro-putnonresource-202-200·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putnonresource-202-200·put·requestbody"
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putnonresource-202-200·put·requestbody",
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putnonresourceasync-202-200·put·requestbody"
      ]
     },
     "content": {
@@ -4547,29 +4316,6 @@
     "description": "sku to put",
     "x-ms-requestBody-name": "sku"
    },
-   "requestBodies:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putnonresourceasync-202-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putnonresourceasync-202-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:137"
-      }
-     }
-    },
-    "description": "Sku to put",
-    "x-ms-requestBody-name": "sku"
-   },
    "requestBodies:15": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4580,29 +4326,7 @@
      ],
      "name": "paths·lro-putsubresource-202-200·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putsubresource-202-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:144"
-      }
-     }
-    },
-    "description": "Sub Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putsubresourceasync-202-200·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putsubresource-202-200·put·requestbody",
       "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-putsubresourceasync-202-200·put·requestbody"
      ]
     },
@@ -4615,790 +4339,9 @@
     },
     "description": "Sub Product to put",
     "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-retry-200·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-post-202-retry-200·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-noretry-204·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-post-202-noretry-204·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-postasync-retry-succeeded·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-postasync-noretry-succeeded·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-postasync-retry-failed·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-postasync-retry-canceled·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-put-201-creating-succeeded-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-retryerror-put-201-creating-succeeded-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-retryerror-putasync-retry-succeeded·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-post-202-retry-200·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-retryerror-post-202-retry-200·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-retryerror-postasync-retry-succeeded·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-400·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-put-400·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-201-creating-400·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-put-201-creating-400·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-putasync-retry-400·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-400·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-post-400·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-202-retry-400·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-post-202-retry-400·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-nonretryerror-postasync-retry-400·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-put-201-noprovisioningstatepayload·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-put-201-noprovisioningstatepayload·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-putasync-retry-nostatus·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-putasync-retry-nostatuspayload·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-nolocation·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-post-202-nolocation·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-postasync-retry-nopayload·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-put-200-invalidjson·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-put-200-invalidjson·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-putasync-retry-invalidheader·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-putasync-retry-invalidjsonpolling·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-retry-invalidheader·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-post-202-retry-invalidheader·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-postasync-retry-invalidheader·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-error-postasync-retry-invalidjsonpolling·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-customheader-putasync-retry-succeeded·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-put-201-creating-succeeded-200·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-customheader-put-201-creating-succeeded-200·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-post-202-retry-200·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-customheader-post-202-retry-200·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
-   },
-   "requestBodies:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/requestBodies/paths·lro-customheader-postasync-retry-succeeded·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "description": "Product to put",
-    "x-ms-requestBody-name": "product"
    }
   },
   "schemas": {
-   "schemas:0": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-noheader-202-200·put·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-put-noheader-202-200·put·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-succeeded·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-succeeded·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
    "schemas:3": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -5409,1911 +4352,51 @@
      ],
      "name": "paths·lro-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-succeeded·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noretry-succeeded·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-succeeded·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noretry-succeeded·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-failed·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-failed·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·responses·200·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-failed·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-canceled·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noretry-canceled·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-canceled·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noretry-canceled·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noheader-201-200·put·responses·201·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noheader-201-200·put·responses·201·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-retry-200·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-202-retry-200·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-retry-200·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-202-retry-200·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-noretry-204·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-202-noretry-204·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-noretry-204·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-202-noretry-204·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-noheader·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-noheader·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noheader-202-204·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-noheader-202-204·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-failed·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-failed·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-failed·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-retry-200·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-post-202-retry-200·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-retry-200·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-post-202-retry-200·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-noretry-204·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-post-202-noretry-204·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-noretry-204·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-post-202-noretry-204·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-succeeded·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-failed·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-failed·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-failed·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-canceled·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-canceled·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-canceled·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:70": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-400·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-delete-400·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-400·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-delete-400·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:75": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-400·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-post-400·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:78": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-400·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-post-400·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:81": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:82": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:84": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:86": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:87": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:90": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:92": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-nolocation·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-post-202-nolocation·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:94": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-nolocation·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-post-202-nolocation·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:100": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:102": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:108": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:118": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-post-202-retry-200·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-post-202-retry-200·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-post-202-retry-200·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-post-202-retry-200·post·responses·202·headers·retry_after·schema"
-     ]
-    },
-    "format": "Int32",
-    "type": "integer"
-   },
-   "schemas:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:126": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·location·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·location·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-failed·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-202-retry-200·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-202-noretry-204·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-post-202-retry-200·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-post-202-noretry-204·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-failed·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-canceled·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-delete-400·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-post-400·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-post-202-nolocation·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-post-202-retry-200·post·responses·202·headers·retry_after·schema",
       "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema"
      ]
     },
@@ -7462,7 +4545,89 @@
      ],
      "name": "components·schemas·resource·properties·tags·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/schemas/components·schemas·resource·properties·tags·additionalproperties"
+      "http://localhost:3000/swagger/lro.json#/components/schemas/components·schemas·resource·properties·tags·additionalproperties",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-put-noheader-202-200·put·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-succeeded·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noretry-succeeded·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noretry-succeeded·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-failed·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-retry-failed·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noretry-canceled·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noretry-canceled·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-putasync-noheader-201-200·put·responses·201·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-202-retry-200·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-202-noretry-204·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-delete-noheader·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-noheader-202-204·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-post-202-retry-200·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-post-202-noretry-204·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-succeeded·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-failed·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-failed·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-canceled·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-postasync-retry-canceled·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-delete-400·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-post-400·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-post-202-nolocation·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-post-202-retry-200·post·responses·202·headers·location·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema",
+      "http://localhost:3000/swagger/lro.json#/components/schemas/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·location·schema"
      ]
     },
     "type": "string"
@@ -7889,7 +5054,39 @@
      ],
      "name": "paths·lro-put-200-succeeded·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded·put·responses·200"
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded-nostate·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-202-retry-200·put·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-creating-succeeded-200·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-creating-succeeded-200·put·responses·201",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-updating-succeeded-200·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-created-failed-200·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-created-failed-200·put·responses·201",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-accepted-canceled-200·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-retry-200·delete·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-noretry-204·delete·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinallocationget·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinalazureheaderget·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinalazureheadergetdefault·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-succeeded·post·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-noretry-succeeded·post·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·201",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-400·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-400·put·responses·201",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400·put·responses·201",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·201",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-201-noprovisioningstatepayload·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-201-noprovisioningstatepayload·put·responses·201",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-200-invalidjson·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-put-201-creating-succeeded-200·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-put-201-creating-succeeded-200·put·responses·201"
      ]
     },
     "description": "Initial response with ProvisioningState='Succeeded'",
@@ -7911,7 +5108,12 @@
      ],
      "name": "paths·lro-put-200-succeeded·put·responses·204",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded·put·responses·204"
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded·put·responses·204",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-204-succeeded·delete·responses·204",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-noheader·delete·responses·204",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noheader-202-204·delete·responses·204",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-delete-204-nolocation·delete·responses·204",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-200-invalidjson·put·responses·204"
      ]
     },
     "description": "Final response"
@@ -7926,315 +5128,82 @@
      ],
      "name": "paths·lro-put-200-succeeded·put·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-succeeded-nostate·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded-nostate·put·responses·200"
-     ]
-    },
-    "description": "Initial response without ProvisioningState",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-succeeded-nostate·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded-nostate·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-202-retry-200·put·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-202-retry-200·put·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-202-retry-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-202-retry-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-201-creating-succeeded-200·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-creating-succeeded-200·put·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-201-creating-succeeded-200·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-creating-succeeded-200·put·responses·201"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-201-creating-succeeded-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-creating-succeeded-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-updating-succeeded-200·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-updating-succeeded-200·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-updating-succeeded-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-updating-succeeded-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-201-created-failed-200·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-created-failed-200·put·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Failed'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-201-created-failed-200·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-created-failed-200·put·responses·201"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Created'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-201-created-failed-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-created-failed-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-accepted-canceled-200·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-accepted-canceled-200·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-200-accepted-canceled-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-accepted-canceled-200·put·responses·default"
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-succeeded-nostate·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-202-retry-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-creating-succeeded-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-updating-succeeded-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-201-created-failed-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-200-accepted-canceled-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-noheader-202-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-retry-succeeded·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noretry-succeeded·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-retry-failed·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noretry-canceled·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noheader-201-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putnonresource-202-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putnonresourceasync-202-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putsubresource-202-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putsubresourceasync-202-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-204-succeeded·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-retry-200·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-noretry-204·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-noheader·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noheader-202-204·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-succeeded·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noretry-succeeded·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-failed·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-canceled·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-payload-200·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-202-retry-200·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-202-noretry-204·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinallocationget·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinalazureheaderget·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinalazureheadergetdefault·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-succeeded·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-noretry-succeeded·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-failed·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-canceled·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-putasync-retry-succeeded·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-202-retry-200·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-post-202-retry-200·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-postasync-retry-succeeded·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-400·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-putasync-retry-400·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-delete-400·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-post-400·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-post-202-retry-400·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-postasync-retry-400·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-201-noprovisioningstatepayload·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-nostatus·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-nostatuspayload·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-delete-204-nolocation·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-nostatus·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-post-202-nolocation·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-nopayload·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-200-invalidjson·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-invalidheader·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-delete-202-retry-invalidheader·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-post-202-retry-invalidheader·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-invalidheader·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-putasync-retry-succeeded·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-put-201-creating-succeeded-200·put·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-post-202-retry-200·post·responses·default",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-postasync-retry-succeeded·post·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -8274,28 +5243,6 @@
      }
     }
    },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-put-noheader-202-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-put-noheader-202-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
    "responses:19": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -8306,7 +5253,15 @@
      ],
      "name": "paths·lro-putasync-retry-succeeded·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-retry-succeeded·put·responses·200"
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-retry-succeeded·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-retry-failed·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-putasync-retry-400·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-nostatus·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-invalidheader·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-putasync-retry-succeeded·put·responses·200"
      ]
     },
     "description": "Initial response with ProvisioningState='Updating'",
@@ -8320,37 +5275,15 @@
     "headers": {
      "Azure-AsyncOperation": {
       "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:1"
+      "$ref": "#/components/headers/headers:0"
      },
      "Location": {
       "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:2"
+      "$ref": "#/components/headers/headers:0"
      },
      "Retry-After": {
       "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
       "$ref": "#/components/headers/headers:3"
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-succeeded·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-retry-succeeded·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
      }
     }
    },
@@ -8364,118 +5297,7 @@
      ],
      "name": "paths·lro-putasync-noretry-succeeded·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noretry-succeeded·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/noretry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:4"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/noretry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:5"
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-succeeded·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noretry-succeeded·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-retry-failed·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200",
-      "$ref": "#/components/headers/headers:6"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200",
-      "$ref": "#/components/headers/headers:7"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:8"
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-retry-failed·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-canceled·put·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noretry-succeeded·put·responses·200",
       "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noretry-canceled·put·responses·200"
      ]
     },
@@ -8489,34 +5311,12 @@
     },
     "headers": {
      "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/noretry/canceled/operationResults/200",
-      "$ref": "#/components/headers/headers:9"
+      "description": "Location to poll for result status: will be set to /lro/putasync/noretry/succeeded/operationResults/200",
+      "$ref": "#/components/headers/headers:0"
      },
      "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/noretry/canceled/operationResults/200",
-      "$ref": "#/components/headers/headers:10"
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-canceled·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noretry-canceled·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
+      "description": "Location to poll for result status: will be set to /lro/putasync/noretry/succeeded/operationResults/200",
+      "$ref": "#/components/headers/headers:0"
      }
     }
    },
@@ -8543,29 +5343,7 @@
     },
     "headers": {
      "Azure-AsyncOperation": {
-      "$ref": "#/components/headers/headers:11"
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noheader-201-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putasync-noheader-201-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
+      "$ref": "#/components/headers/headers:0"
      }
     }
    },
@@ -8579,7 +5357,10 @@
      ],
      "name": "paths·lro-putnonresource-202-200·put·responses·202",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putnonresource-202-200·put·responses·202"
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putnonresource-202-200·put·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putnonresourceasync-202-200·put·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-payload-200·post·responses·200",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-payload-200·post·responses·202"
      ]
     },
     "description": "Initial response with ProvisioningState='Accepted'",
@@ -8587,72 +5368,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:137"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putnonresource-202-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putnonresource-202-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putnonresourceasync-202-200·put·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putnonresourceasync-202-200·put·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Accepted'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:137"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putnonresourceasync-202-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putnonresourceasync-202-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
       }
      }
     }
@@ -8667,50 +5382,7 @@
      ],
      "name": "paths·lro-putsubresource-202-200·put·responses·202",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putsubresource-202-200·put·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Accepted'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:144"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putsubresource-202-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putsubresource-202-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putsubresourceasync-202-200·put·responses·202",
-     "originalLocations": [
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putsubresource-202-200·put·responses·202",
       "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putsubresourceasync-202-200·put·responses·202"
      ]
     },
@@ -8719,50 +5391,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:144"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putsubresourceasync-202-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-putsubresourceasync-202-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
       }
      }
     }
@@ -8777,1400 +5405,10 @@
      ],
      "name": "paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Deleting'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/delete/provisioning/202/accepted/200/succeeded",
-      "$ref": "#/components/headers/headers:12"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:13"
-     }
-    }
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202"
-     ]
-    },
-    "description": "Inital response",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/delete/provisioning/202/deleting/200/failed",
-      "$ref": "#/components/headers/headers:14"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:15"
-     }
-    }
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202"
-     ]
-    },
-    "description": "Inital response",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/delete/provisioning/202/deleting/200/canceled",
-      "$ref": "#/components/headers/headers:16"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:17"
-     }
-    }
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-204-succeeded·delete·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-204-succeeded·delete·responses·204"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'"
-   },
-   "responses:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-204-succeeded·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-204-succeeded·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-retry-200·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-retry-200·delete·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-retry-200·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-retry-200·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with no entity body",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/delete/202/retry/200",
-      "$ref": "#/components/headers/headers:18"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:19"
-     }
-    }
-   },
-   "responses:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-retry-200·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-retry-200·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-noretry-204·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-noretry-204·delete·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-noretry-204·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-noretry-204·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with no entity body",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/delete/202/noretry/204",
-      "$ref": "#/components/headers/headers:20"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:21"
-     }
-    }
-   },
-   "responses:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-noretry-204·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-noretry-204·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-noheader·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-noheader·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with no entity body",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults",
-      "$ref": "#/components/headers/headers:22"
-     }
-    }
-   },
-   "responses:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-noheader·delete·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-noheader·delete·responses·204"
-     ]
-    },
-    "description": "Response after completion"
-   },
-   "responses:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-noheader·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-noheader·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noheader-202-204·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noheader-202-204·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with no entity body",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults",
-      "$ref": "#/components/headers/headers:23"
-     }
-    }
-   },
-   "responses:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noheader-202-204·delete·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noheader-202-204·delete·responses·204"
-     ]
-    },
-    "description": "Response after completion"
-   },
-   "responses:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noheader-202-204·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noheader-202-204·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-succeeded·delete·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:24"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:25"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:26"
-     }
-    }
-   },
-   "responses:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-succeeded·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noretry-succeeded·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noretry-succeeded·delete·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/noretry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:27"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/noretry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:28"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:29"
-     }
-    }
-   },
-   "responses:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noretry-succeeded·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noretry-succeeded·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-failed·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-failed·delete·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/failed/operationResults/200",
-      "$ref": "#/components/headers/headers:30"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/failed/operationResults/200",
-      "$ref": "#/components/headers/headers:31"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:32"
-     }
-    }
-   },
-   "responses:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-failed·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-failed·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-canceled·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-canceled·delete·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/canceled/operationResults/200",
-      "$ref": "#/components/headers/headers:33"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/canceled/operationResults/200",
-      "$ref": "#/components/headers/headers:34"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:35"
-     }
-    }
-   },
-   "responses:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-canceled·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-canceled·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-payload-200·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-payload-200·post·responses·200"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:137"
-      }
-     }
-    }
-   },
-   "responses:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-payload-200·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-payload-200·post·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:137"
-      }
-     }
-    }
-   },
-   "responses:70": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-payload-200·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-payload-200·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-retry-200·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-202-retry-200·post·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/post/202/retry/200",
-      "$ref": "#/components/headers/headers:36"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:37"
-     }
-    }
-   },
-   "responses:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-retry-200·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-202-retry-200·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-noretry-204·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-202-noretry-204·post·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/post/202/noretry/204",
-      "$ref": "#/components/headers/headers:38"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:39"
-     }
-    }
-   },
-   "responses:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-noretry-204·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-202-noretry-204·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:75": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-lropostdoubleheadersfinallocationget·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinallocationget·post·responses·202"
-     ]
-    },
-    "description": "Response after completion.",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-lropostdoubleheadersfinallocationget·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinallocationget·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-lropostdoubleheadersfinalazureheaderget·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinalazureheaderget·post·responses·202"
-     ]
-    },
-    "description": "Response after completion.",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:78": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-lropostdoubleheadersfinalazureheaderget·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinalazureheaderget·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-lropostdoubleheadersfinalazureheadergetdefault·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinalazureheadergetdefault·post·responses·202"
-     ]
-    },
-    "description": "Response after completion.",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-lropostdoubleheadersfinalazureheadergetdefault·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-lropostdoubleheadersfinalazureheadergetdefault·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:81": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-succeeded·post·responses·200"
-     ]
-    },
-    "description": "Response after completion.",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:82": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-succeeded·post·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:40"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:41"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:42"
-     }
-    }
-   },
-   "responses:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-succeeded·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:84": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-noretry-succeeded·post·responses·200"
-     ]
-    },
-    "description": "Response after completion.",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-noretry-succeeded·post·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:43"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:44"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:45"
-     }
-    }
-   },
-   "responses:86": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-noretry-succeeded·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:87": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-failed·post·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200",
-      "$ref": "#/components/headers/headers:46"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200",
-      "$ref": "#/components/headers/headers:47"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:48"
-     }
-    }
-   },
-   "responses:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-failed·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-canceled·post·responses·202"
-     ]
-    },
-    "description": "Initial response",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/canceled/operationResults/200",
-      "$ref": "#/components/headers/headers:49"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/canceled/operationResults/200",
-      "$ref": "#/components/headers/headers:50"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:51"
-     }
-    }
-   },
-   "responses:90": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-canceled·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:92": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·201"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-put-201-creating-succeeded-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:94": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:52"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:53"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:54"
-     }
-    }
-   },
-   "responses:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-putasync-retry-succeeded·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202",
-     "originalLocations": [
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-202-noretry-204·post·responses·202",
       "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202"
      ]
     },
@@ -10184,16 +5422,16 @@
     },
     "headers": {
      "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/delete/provisioning/202/accepted/200/succeeded",
-      "$ref": "#/components/headers/headers:55"
+      "description": "Location to poll for result status: will be set to /lro/delete/provisioning/202/accepted/200/succeeded",
+      "$ref": "#/components/headers/headers:0"
      },
      "Retry-After": {
       "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:56"
+      "$ref": "#/components/headers/headers:3"
      }
     }
    },
-   "responses:98": {
+   "responses:49": {
     "x-ms-metadata": {
      "apiVersions": [
       "1.0.0"
@@ -10201,1753 +5439,36 @@
      "filename": [
       "mem:///94?oai3.shaken.json"
      ],
-     "name": "paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·default",
+     "name": "paths·lro-delete-202-retry-200·delete·responses·202",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-202-retry-200·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-202-retry-200·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with no entity body",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200",
-      "$ref": "#/components/headers/headers:57"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:58"
-     }
-    }
-   },
-   "responses:100": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-202-retry-200·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-202-retry-200·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/deleteasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:59"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/deleteasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:60"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:61"
-     }
-    }
-   },
-   "responses:102": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-post-202-retry-200·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-post-202-retry-200·post·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200",
-      "$ref": "#/components/headers/headers:62"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:63"
-     }
-    }
-   },
-   "responses:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-post-202-retry-200·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-post-202-retry-200·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:64"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:65"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:66"
-     }
-    }
-   },
-   "responses:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-postasync-retry-succeeded·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-400·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-400·put·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:108": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-400·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-400·put·responses·201"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-400·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-400·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-201-creating-400·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400·put·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-201-creating-400·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400·put·responses·201"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-201-creating-400·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·201"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-put-201-creating-400-invalidjson·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-putasync-retry-400·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400",
-      "$ref": "#/components/headers/headers:67"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400",
-      "$ref": "#/components/headers/headers:68"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:69"
-     }
-    }
-   },
-   "responses:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-putasync-retry-400·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:118": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-400·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-delete-400·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with no entity body",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200",
-      "$ref": "#/components/headers/headers:70"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:71"
-     }
-    }
-   },
-   "responses:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-400·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-delete-400·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with no entity body",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200",
-      "$ref": "#/components/headers/headers:72"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:73"
-     }
-    }
-   },
-   "responses:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-202-retry-400·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202"
-     ]
-    },
-    "description": "For completion only will not return",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/nonretryerror/deleteasync/retry/operationResults/400",
-      "$ref": "#/components/headers/headers:74"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/nonretryerror/deleteasync/retry/operationResults/400",
-      "$ref": "#/components/headers/headers:75"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:76"
-     }
-    }
-   },
-   "responses:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-400·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-post-400·post·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200",
-      "$ref": "#/components/headers/headers:77"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:78"
-     }
-    }
-   },
-   "responses:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-400·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-post-400·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:126": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-202-retry-400·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-post-202-retry-400·post·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200",
-      "$ref": "#/components/headers/headers:79"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:80"
-     }
-    }
-   },
-   "responses:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-202-retry-400·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-post-202-retry-400·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:128": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-postasync-retry-400·post·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400",
-      "$ref": "#/components/headers/headers:81"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400",
-      "$ref": "#/components/headers/headers:82"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:83"
-     }
-    }
-   },
-   "responses:129": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-postasync-retry-400·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:130": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-put-201-noprovisioningstatepayload·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-201-noprovisioningstatepayload·put·responses·200"
-     ]
-    },
-    "description": "for completion only will not return",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:131": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-put-201-noprovisioningstatepayload·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-201-noprovisioningstatepayload·put·responses·201"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState missing",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:132": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-put-201-noprovisioningstatepayload·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-201-noprovisioningstatepayload·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:133": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-nostatus·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:84"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:85"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:86"
-     }
-    }
-   },
-   "responses:134": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-nostatus·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:135": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:87"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:88"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:89"
-     }
-    }
-   },
-   "responses:136": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-nostatuspayload·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:137": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-delete-204-nolocation·delete·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-delete-204-nolocation·delete·responses·204"
-     ]
-    },
-    "description": "Final response"
-   },
-   "responses:138": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-delete-204-nolocation·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-delete-204-nolocation·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:139": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-nostatus·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:90"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:91"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:92"
-     }
-    }
-   },
-   "responses:140": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-nostatus·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-nostatus·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:141": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-nolocation·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-post-202-nolocation·post·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will not be set",
-      "$ref": "#/components/headers/headers:93"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:94"
-     }
-    }
-   },
-   "responses:142": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-nolocation·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-post-202-nolocation·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:143": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-nopayload·post·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/error/putasync/retry/failed/operationResults/nopayload",
-      "$ref": "#/components/headers/headers:95"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/error/putasync/retry/failed/operationResults/nopayload",
-      "$ref": "#/components/headers/headers:96"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:97"
-     }
-    }
-   },
-   "responses:144": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-nopayload·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:145": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-put-200-invalidjson·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-200-invalidjson·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:146": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-put-200-invalidjson·put·responses·204",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-200-invalidjson·put·responses·204"
-     ]
-    },
-    "description": "Final response"
-   },
-   "responses:147": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-put-200-invalidjson·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-put-200-invalidjson·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:148": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-invalidheader·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:98"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:99"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:100"
-     }
-    }
-   },
-   "responses:149": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-invalidheader·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:150": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200",
-      "$ref": "#/components/headers/headers:101"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200",
-      "$ref": "#/components/headers/headers:102"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:103"
-     }
-    }
-   },
-   "responses:151": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:152": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-delete-202-retry-invalidheader·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202"
-     ]
-    },
-    "description": "Initial response, with no entity body",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /foo",
-      "$ref": "#/components/headers/headers:104"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to /bar",
-      "$ref": "#/components/headers/headers:105"
-     }
-    }
-   },
-   "responses:153": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-delete-202-retry-invalidheader·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-delete-202-retry-invalidheader·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:154": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /foo",
-      "$ref": "#/components/headers/headers:106"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /foo",
-      "$ref": "#/components/headers/headers:107"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to /bar",
-      "$ref": "#/components/headers/headers:108"
-     }
-    }
-   },
-   "responses:155": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidheader·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:156": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling",
-      "$ref": "#/components/headers/headers:109"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling",
-      "$ref": "#/components/headers/headers:110"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:111"
-     }
-    }
-   },
-   "responses:157": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:158": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-retry-invalidheader·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-post-202-retry-invalidheader·post·responses·202"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "headers": {
-     "Location": {
-      "description": "Location to poll for result status: will be set to /foo",
-      "$ref": "#/components/headers/headers:112"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to /bar",
-      "$ref": "#/components/headers/headers:113"
-     }
-    }
-   },
-   "responses:159": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-retry-invalidheader·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-post-202-retry-invalidheader·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:160": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-invalidheader·post·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to foo",
-      "$ref": "#/components/headers/headers:114"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to foo",
-      "$ref": "#/components/headers/headers:115"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to /bar",
-      "$ref": "#/components/headers/headers:116"
-     }
-    }
-   },
-   "responses:161": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-invalidheader·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:162": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling",
-      "$ref": "#/components/headers/headers:117"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling",
-      "$ref": "#/components/headers/headers:118"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:119"
-     }
-    }
-   },
-   "responses:163": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:164": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-putasync-retry-succeeded·put·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Updating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    },
-    "headers": {
-     "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:120"
-     },
-     "Location": {
-      "description": "Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:121"
-     },
-     "Retry-After": {
-      "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:122"
-     }
-    }
-   },
-   "responses:165": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-putasync-retry-succeeded·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:166": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-put-201-creating-succeeded-200·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-put-201-creating-succeeded-200·put·responses·200"
-     ]
-    },
-    "description": "Response after completion, with ProvisioningState='Succeeded'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:167": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-put-201-creating-succeeded-200·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-put-201-creating-succeeded-200·put·responses·201"
-     ]
-    },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:140"
-      }
-     }
-    }
-   },
-   "responses:168": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-put-201-creating-succeeded-200·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-put-201-creating-succeeded-200·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
-     }
-    }
-   },
-   "responses:169": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-post-202-retry-200·post·responses·202",
-     "originalLocations": [
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-retry-200·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-202-noretry-204·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-post-202-retry-200·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-delete-202-retry-200·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-post-202-retry-200·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-delete-400·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-post-400·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-post-202-retry-400·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-post-202-nolocation·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-post-202-retry-invalidheader·post·responses·202",
       "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-post-202-retry-200·post·responses·202"
      ]
     },
-    "description": "Initial response, with ProvisioningState = 'Creating'",
+    "description": "Initial response, with no entity body",
     "headers": {
      "Location": {
-      "description": "Location to poll for result status: will be set to /lro/customheader/post/202/retry/200",
-      "$ref": "#/components/headers/headers:123"
+      "description": "Location to poll for result status: will be set to /lro/delete/202/retry/200",
+      "$ref": "#/components/headers/headers:0"
      },
      "Retry-After": {
       "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:124"
+      "$ref": "#/components/headers/headers:3"
      }
     }
    },
-   "responses:170": {
+   "responses:54": {
     "x-ms-metadata": {
      "apiVersions": [
       "1.0.0"
@@ -11955,21 +5476,21 @@
      "filename": [
       "mem:///94?oai3.shaken.json"
      ],
-     "name": "paths·lro-customheader-post-202-retry-200·post·responses·default",
+     "name": "paths·lro-delete-noheader·delete·responses·202",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-post-202-retry-200·post·responses·default"
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-delete-noheader·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noheader-202-204·delete·responses·202"
      ]
     },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
+    "description": "Initial response, with no entity body",
+    "headers": {
+     "Location": {
+      "description": "Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults",
+      "$ref": "#/components/headers/headers:0"
      }
     }
    },
-   "responses:171": {
+   "responses:60": {
     "x-ms-metadata": {
      "apiVersions": [
       "1.0.0"
@@ -11977,46 +5498,42 @@
      "filename": [
       "mem:///94?oai3.shaken.json"
      ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·responses·202",
+     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·202",
      "originalLocations": [
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-succeeded·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-noretry-succeeded·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-failed·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-deleteasync-retry-canceled·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-succeeded·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-noretry-succeeded·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-failed·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-postasync-retry-canceled·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-nonretryerror-postasync-retry-400·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-nopayload·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-invalidheader·post·responses·202",
+      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202",
       "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-postasync-retry-succeeded·post·responses·202"
      ]
     },
     "description": "Initial response with ProvisioningState='Updating'",
     "headers": {
      "Azure-AsyncOperation": {
-      "description": "Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:125"
+      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200",
+      "$ref": "#/components/headers/headers:0"
      },
      "Location": {
-      "description": "Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200",
-      "$ref": "#/components/headers/headers:126"
+      "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200",
+      "$ref": "#/components/headers/headers:0"
      },
      "Retry-After": {
       "description": "Number of milliseconds until the next poll should be sent, will be set to zero",
-      "$ref": "#/components/headers/headers:127"
-     }
-    }
-   },
-   "responses:172": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/responses/paths·lro-customheader-postasync-retry-succeeded·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:128"
-      }
+      "$ref": "#/components/headers/headers:3"
      }
     }
    }
@@ -12032,49 +5549,94 @@
      ],
      "name": "paths·lro-put-noheader-202-200·put·responses·202·headers·location",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-put-noheader-202-200·put·responses·202·headers·location"
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-put-noheader-202-200·put·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-succeeded·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noretry-succeeded·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noretry-succeeded·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-failed·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-failed·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noretry-canceled·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noretry-canceled·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noheader-201-200·put·responses·201·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-202-retry-200·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-202-noretry-204·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-noheader·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-noheader-202-204·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-post-202-retry-200·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-post-202-noretry-204·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-succeeded·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-failed·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-failed·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-canceled·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-canceled·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-delete-400·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-post-400·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-post-202-nolocation·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-post-202-retry-200·post·responses·202·headers·location",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·location"
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:0"
+     "$ref": "#/components/schemas/schemas:134"
     },
     "description": "Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults"
-   },
-   "headers:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:1"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-succeeded·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-succeeded·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:2"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
    },
    "headers:3": {
     "x-ms-metadata": {
@@ -12086,2242 +5648,56 @@
      ],
      "name": "paths·lro-putasync-retry-succeeded·put·responses·200·headers·retry_after",
      "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-succeeded·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:3"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-succeeded·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noretry-succeeded·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:4"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/noretry/succeeded/operationResults/200"
-   },
-   "headers:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-succeeded·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noretry-succeeded·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:5"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/noretry/succeeded/operationResults/200"
-   },
-   "headers:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-failed·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:6"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200"
-   },
-   "headers:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-failed·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:7"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200"
-   },
-   "headers:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-retry-failed·put·responses·200·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-failed·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:8"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-canceled·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noretry-canceled·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:9"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/noretry/canceled/operationResults/200"
-   },
-   "headers:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noretry-canceled·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noretry-canceled·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:10"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/noretry/canceled/operationResults/200"
-   },
-   "headers:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-putasync-noheader-201-200·put·responses·201·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-noheader-201-200·put·responses·201·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:11"
-    }
-   },
-   "headers:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:12"
-    },
-    "description": "Location to poll for result status: will be set to /lro/delete/provisioning/202/accepted/200/succeeded"
-   },
-   "headers:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:13"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:14"
-    },
-    "description": "Location to poll for result status: will be set to /lro/delete/provisioning/202/deleting/200/failed"
-   },
-   "headers:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:15"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:16"
-    },
-    "description": "Location to poll for result status: will be set to /lro/delete/provisioning/202/deleting/200/canceled"
-   },
-   "headers:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:17"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-retry-200·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-202-retry-200·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:18"
-    },
-    "description": "Location to poll for result status: will be set to /lro/delete/202/retry/200"
-   },
-   "headers:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-retry-200·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-202-retry-200·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:19"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-noretry-204·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-202-noretry-204·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:20"
-    },
-    "description": "Location to poll for result status: will be set to /lro/delete/202/noretry/204"
-   },
-   "headers:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-202-noretry-204·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-202-noretry-204·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:21"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-delete-noheader·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-noheader·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:22"
-    },
-    "description": "Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults"
-   },
-   "headers:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noheader-202-204·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-noheader-202-204·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:23"
-    },
-    "description": "Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults"
-   },
-   "headers:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:24"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200"
-   },
-   "headers:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:25"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200"
-   },
-   "headers:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:26"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:27"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/noretry/succeeded/operationResults/200"
-   },
-   "headers:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:28"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/noretry/succeeded/operationResults/200"
-   },
-   "headers:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:29"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-failed·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:30"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/failed/operationResults/200"
-   },
-   "headers:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-failed·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:31"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/failed/operationResults/200"
-   },
-   "headers:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-failed·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:32"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:33"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/canceled/operationResults/200"
-   },
-   "headers:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:34"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/canceled/operationResults/200"
-   },
-   "headers:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:35"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-retry-200·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-post-202-retry-200·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:36"
-    },
-    "description": "Location to poll for result status: will be set to /lro/post/202/retry/200"
-   },
-   "headers:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-retry-200·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-post-202-retry-200·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:37"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-noretry-204·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-post-202-noretry-204·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:38"
-    },
-    "description": "Location to poll for result status: will be set to /lro/post/202/noretry/204"
-   },
-   "headers:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-post-202-noretry-204·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-post-202-noretry-204·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:39"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:40"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-succeeded·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:41"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-succeeded·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-succeeded·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:42"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:43"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:44"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-noretry-succeeded·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:45"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-failed·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:46"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200"
-   },
-   "headers:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-failed·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:47"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200"
-   },
-   "headers:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-failed·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-failed·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:48"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-canceled·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:49"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/canceled/operationResults/200"
-   },
-   "headers:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-canceled·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:50"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/canceled/operationResults/200"
-   },
-   "headers:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-postasync-retry-canceled·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-canceled·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:51"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:52"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:53"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:54"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:55"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/delete/provisioning/202/accepted/200/succeeded"
-   },
-   "headers:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:56"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:57"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200"
-   },
-   "headers:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:58"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:59"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/deleteasync/retry/succeeded/operationResults/200"
-   },
-   "headers:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:60"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/deleteasync/retry/succeeded/operationResults/200"
-   },
-   "headers:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:61"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:62"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200"
-   },
-   "headers:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:63"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:64"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:65"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:66"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:67"
-    },
-    "description": "Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400"
-   },
-   "headers:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:68"
-    },
-    "description": "Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400"
-   },
-   "headers:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:69"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:70": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-400·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-delete-400·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:70"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200"
-   },
-   "headers:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-400·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-delete-400·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:71"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:72"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200"
-   },
-   "headers:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:73"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:74"
-    },
-    "description": "Location to poll for result status: will be set to /lro/nonretryerror/deleteasync/retry/operationResults/400"
-   },
-   "headers:75": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:75"
-    },
-    "description": "Location to poll for result status: will be set to /lro/nonretryerror/deleteasync/retry/operationResults/400"
-   },
-   "headers:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:76"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-400·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-post-400·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:77"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200"
-   },
-   "headers:78": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-400·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-post-400·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:78"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:79"
-    },
-    "description": "Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200"
-   },
-   "headers:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:80"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:81": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:81"
-    },
-    "description": "Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400"
-   },
-   "headers:82": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:82"
-    },
-    "description": "Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400"
-   },
-   "headers:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:83"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:84": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:84"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:85"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:86": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:86"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:87": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:87"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:88"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:89"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:90": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:90"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200"
-   },
-   "headers:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:91"
-    },
-    "description": "Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200"
-   },
-   "headers:92": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:92"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-nolocation·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-post-202-nolocation·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:93"
-    },
-    "description": "Location to poll for result status: will not be set"
-   },
-   "headers:94": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-nolocation·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-post-202-nolocation·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:94"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:95"
-    },
-    "description": "Location to poll for result status: will be set to /lro/error/putasync/retry/failed/operationResults/nopayload"
-   },
-   "headers:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:96"
-    },
-    "description": "Location to poll for result status: will be set to /lro/error/putasync/retry/failed/operationResults/nopayload"
-   },
-   "headers:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:97"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:98"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:99"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:100": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:100"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:101"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200"
-   },
-   "headers:102": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:102"
-    },
-    "description": "Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200"
-   },
-   "headers:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:103"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:104"
-    },
-    "description": "Location to poll for result status: will be set to /foo"
-   },
-   "headers:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:105"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to /bar"
-   },
-   "headers:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:106"
-    },
-    "description": "Location to poll for result status: will be set to /foo"
-   },
-   "headers:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:107"
-    },
-    "description": "Location to poll for result status: will be set to /foo"
-   },
-   "headers:108": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:108"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to /bar"
-   },
-   "headers:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:109"
-    },
-    "description": "Location to poll for result status: will be set to /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling"
-   },
-   "headers:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:110"
-    },
-    "description": "Location to poll for result status: will be set to /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling"
-   },
-   "headers:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:111"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:112"
-    },
-    "description": "Location to poll for result status: will be set to /foo"
-   },
-   "headers:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:113"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to /bar"
-   },
-   "headers:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:114"
-    },
-    "description": "Location to poll for result status: will be set to foo"
-   },
-   "headers:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:115"
-    },
-    "description": "Location to poll for result status: will be set to foo"
-   },
-   "headers:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:116"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to /bar"
-   },
-   "headers:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:117"
-    },
-    "description": "Location to poll for result status: will be set to /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling"
-   },
-   "headers:118": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:118"
-    },
-    "description": "Location to poll for result status: will be set to /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling"
-   },
-   "headers:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:119"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:120"
-    },
-    "description": "Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:121"
-    },
-    "description": "Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:122"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-post-202-retry-200·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-post-202-retry-200·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:123"
-    },
-    "description": "Location to poll for result status: will be set to /lro/customheader/post/202/retry/200"
-   },
-   "headers:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-post-202-retry-200·post·responses·202·headers·retry_after",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-post-202-retry-200·post·responses·202·headers·retry_after"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:124"
-    },
-    "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
-   },
-   "headers:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:125"
-    },
-    "description": "Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:126": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·location",
-     "originalLocations": [
-      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·location"
-     ]
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:126"
-    },
-    "description": "Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200"
-   },
-   "headers:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·retry_after",
-     "originalLocations": [
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-succeeded·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-putasync-retry-failed·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-202-retry-200·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-delete-202-noretry-204·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-failed·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-post-202-retry-200·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-post-202-noretry-204·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-succeeded·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-noretry-succeeded·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-failed·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-postasync-retry-canceled·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-delete-400·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-post-400·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-post-202-nolocation·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·retry_after",
+      "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-post-202-retry-200·post·responses·202·headers·retry_after",
       "http://localhost:3000/swagger/lro.json#/components/headers/paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·retry_after"
      ]
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:127"
+     "$ref": "#/components/schemas/schemas:3"
     },
     "description": "Number of milliseconds until the next poll should be sent, will be set to zero"
    }

--- a/modelerfour/test/inputs/model-flattening/openapi-document.json
+++ b/modelerfour/test/inputs/model-flattening/openapi-document.json
@@ -97,7 +97,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -148,11 +148,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -188,7 +188,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -239,11 +239,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -279,7 +279,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -330,11 +330,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -370,7 +370,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -425,7 +425,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -463,11 +463,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:16"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -525,11 +525,11 @@
     "responses": {
      "200": {
       "description": "Successful Response",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:16"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -788,32 +788,16 @@
      "filename": [
       "mem:///94?oai3.shaken.json"
      ],
-     "name": "ResourceCollection-dictionaryofresources",
+     "name": "paths·model_flatten-dictionary·put·requestbody·content·application-json·schema",
      "originalLocations": [
       "http://localhost:3000/swagger/model-flattening.json#/components/schemas/paths·model_flatten-dictionary·put·requestbody·content·application-json·schema",
-      "http://localhost:3000/swagger/model-flattening.json#/components/schemas/paths·model_flatten-dictionary·get·responses·200·content·application-json·schema",
-      "http://localhost:3000/swagger/model-flattening.json#/components/schemas/ResourceCollection-dictionaryofresources"
+      "http://localhost:3000/swagger/model-flattening.json#/components/schemas/paths·model_flatten-dictionary·get·responses·200·content·application-json·schema"
      ]
     },
     "type": "object",
     "additionalProperties": {
      "$ref": "#/components/schemas/schemas:16"
     }
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-customflattening-parametergrouping-name·put·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/schemas/paths·model_flatten-customflattening-parametergrouping-name·put·parameters·0·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:7": {
     "x-ms-metadata": {
@@ -959,7 +943,8 @@
      ],
      "name": "components·schemas·resource·properties·tags·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/schemas/components·schemas·resource·properties·tags·additionalproperties"
+      "http://localhost:3000/swagger/model-flattening.json#/components/schemas/components·schemas·resource·properties·tags·additionalproperties",
+      "http://localhost:3000/swagger/model-flattening.json#/components/schemas/paths·model_flatten-customflattening-parametergrouping-name·put·parameters·0·schema"
      ]
     },
     "type": "string"
@@ -1126,7 +1111,7 @@
       "$ref": "#/components/schemas/schemas:23"
      },
      "dictionaryofresources": {
-      "$ref": "#/components/schemas/schemas:4"
+      "$ref": "#/components/schemas/schemas:24"
      }
     }
    },
@@ -1145,6 +1130,24 @@
     },
     "type": "array",
     "items": {
+     "$ref": "#/components/schemas/schemas:16"
+    }
+   },
+   "schemas:24": {
+    "x-ms-metadata": {
+     "apiVersions": [
+      "1.0.0"
+     ],
+     "filename": [
+      "mem:///94?oai3.shaken.json"
+     ],
+     "name": "ResourceCollection-dictionaryofresources",
+     "originalLocations": [
+      "http://localhost:3000/swagger/model-flattening.json#/components/schemas/ResourceCollection-dictionaryofresources"
+     ]
+    },
+    "type": "object",
+    "additionalProperties": {
      "$ref": "#/components/schemas/schemas:16"
     }
    },
@@ -1495,7 +1498,10 @@
      ],
      "name": "paths·model_flatten-array·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-array·put·responses·200"
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-array·put·responses·200",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-wrappedarray·put·responses·200",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-dictionary·put·responses·200",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-resourcecollection·put·responses·200"
      ]
     },
     "description": "Successful Response"
@@ -1510,7 +1516,17 @@
      ],
      "name": "paths·model_flatten-array·put·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-array·put·responses·default"
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-array·put·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-array·get·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-wrappedarray·put·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-wrappedarray·get·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-dictionary·put·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-dictionary·get·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-resourcecollection·put·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-resourcecollection·get·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening·put·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening·post·responses·default",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening-parametergrouping-name·put·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -1544,65 +1560,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-array·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-array·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-wrappedarray·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-wrappedarray·put·responses·200"
-     ]
-    },
-    "description": "Successful Response"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-wrappedarray·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-wrappedarray·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
    "responses:6": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1621,65 +1578,6 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-wrappedarray·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-wrappedarray·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-dictionary·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-dictionary·put·responses·200"
-     ]
-    },
-    "description": "Successful Response"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-dictionary·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-dictionary·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
       }
      }
     }
@@ -1706,65 +1604,6 @@
      }
     }
    },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-dictionary·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-dictionary·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-resourcecollection·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-resourcecollection·put·responses·200"
-     ]
-    },
-    "description": "Successful Response"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-resourcecollection·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-resourcecollection·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
    "responses:14": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1787,28 +1626,6 @@
      }
     }
    },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-resourcecollection·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-resourcecollection·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
    "responses:16": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1819,96 +1636,8 @@
      ],
      "name": "paths·model_flatten-customflattening·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening·put·responses·200"
-     ]
-    },
-    "description": "Successful Response",
-    "content": {
-     "application/json": {
-      "schema": {
-       "type": "object",
-       "$ref": "#/components/schemas/schemas:28"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-customflattening·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-customflattening·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening·post·responses·200"
-     ]
-    },
-    "description": "Successful Response",
-    "content": {
-     "application/json": {
-      "schema": {
-       "type": "object",
-       "$ref": "#/components/schemas/schemas:28"
-      }
-     }
-    }
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-customflattening·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-customflattening-parametergrouping-name·put·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening·put·responses·200",
+      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening·post·responses·200",
       "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening-parametergrouping-name·put·responses·200"
      ]
     },
@@ -1918,28 +1647,6 @@
       "schema": {
        "type": "object",
        "$ref": "#/components/schemas/schemas:28"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·model_flatten-customflattening-parametergrouping-name·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/model-flattening.json#/components/responses/paths·model_flatten-customflattening-parametergrouping-name·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:7"
       }
      }
     }
@@ -1966,7 +1673,7 @@
      "name": "flatten-parameter-group"
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:6"
+     "$ref": "#/components/schemas/schemas:13"
     },
     "required": true,
     "x-ms-parameter-location": "method"

--- a/modelerfour/test/inputs/paging/openapi-document.json
+++ b/modelerfour/test/inputs/paging/openapi-document.json
@@ -117,11 +117,11 @@
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Canceled'",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -167,14 +167,14 @@
     "description": "A paging operation that includes a nextLink in odata format that has 10 pages",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:3"
+      "$ref": "#/components/parameters/parameters:0"
      },
      {
-      "$ref": "#/components/parameters/parameters:4",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "Sets the maximum number of items to return in the response."
      },
      {
-      "$ref": "#/components/parameters/parameters:5",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds."
      }
     ],
@@ -185,7 +185,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -231,10 +231,10 @@
     "description": "A paging operation that includes a nextLink that has 10 pages",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:6"
+      "$ref": "#/components/parameters/parameters:0"
      },
      {
-      "$ref": "#/components/parameters/parameters:7",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "Sets the maximum number of items to return in the response."
      },
      {
@@ -242,18 +242,18 @@
       "description": "Offset of return value"
      },
      {
-      "$ref": "#/components/parameters/parameters:9",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds."
      }
     ],
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Canceled'",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -300,11 +300,11 @@
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Canceled'",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -351,11 +351,11 @@
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Canceled'",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -402,11 +402,11 @@
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Canceled'",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -453,11 +453,11 @@
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Canceled'",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -504,11 +504,11 @@
     "responses": {
      "200": {
       "description": "Initial response with ProvisioningState='Canceled'",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -566,11 +566,11 @@
     "responses": {
      "200": {
       "description": "Paging response with a fragment nextLink",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -628,11 +628,11 @@
     "responses": {
      "200": {
       "description": "Paging response with a fragment nextLink",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -679,25 +679,25 @@
     "description": "A long-running paging operation that includes a nextLink that has 10 pages",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:14"
+      "$ref": "#/components/parameters/parameters:0"
      },
      {
-      "$ref": "#/components/parameters/parameters:15",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "Sets the maximum number of items to return in the response."
      },
      {
-      "$ref": "#/components/parameters/parameters:16",
+      "$ref": "#/components/parameters/parameters:2",
       "description": "Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds."
      }
     ],
     "responses": {
      "202": {
       "description": "Operation is in progress.",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -744,11 +744,11 @@
     "description": "A paging operation that doesn't return a full URL, just a fragment",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:17",
+      "$ref": "#/components/parameters/parameters:10",
       "description": "Sets the api version to use."
      },
      {
-      "$ref": "#/components/parameters/parameters:18",
+      "$ref": "#/components/parameters/parameters:11",
       "description": "Sets the tenant to use."
      },
      {
@@ -759,11 +759,11 @@
     "responses": {
      "200": {
       "description": "Paging response with a fragment nextLink",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -810,26 +810,26 @@
     "description": "A paging operation that doesn't return a full URL, just a fragment",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:20",
+      "$ref": "#/components/parameters/parameters:12",
       "description": "Sets the api version to use."
      },
      {
-      "$ref": "#/components/parameters/parameters:21",
+      "$ref": "#/components/parameters/parameters:13",
       "description": "Sets the tenant to use."
      },
      {
-      "$ref": "#/components/parameters/parameters:22",
+      "$ref": "#/components/parameters/parameters:19",
       "description": "Next link for list operation."
      }
     ],
     "responses": {
      "200": {
       "description": "Paging response with a fragment nextLink",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:4"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -847,7 +847,15 @@
      ],
      "name": "paths·paging-single·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-single·get·responses·200"
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-single·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-withpath-offset·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-retryfirst·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-retrysecond·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-single-failure·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-failure·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-failureuri·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-lro·post·responses·202"
      ]
     },
     "description": "Initial response with ProvisioningState='Canceled'",
@@ -869,44 +877,20 @@
      ],
      "name": "paths·paging-single·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-single·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple·get·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Canceled'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple·get·responses·default"
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-single·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-odata·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-withpath-offset·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-retryfirst·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-retrysecond·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-single-failure·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-failure·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-failureuri·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragment-tenant·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragmentwithgrouping-tenant·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-lro·post·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragment-tenant-nextlink·get·responses·default",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·responses·default"
      ]
     },
     "description": "Unexpected error"
@@ -921,417 +905,14 @@
      ],
      "name": "paths·paging-multiple-odata·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-odata·get·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Canceled'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:26"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-odata·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-odata·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-withpath-offset·get·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Canceled'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-withpath-offset·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-retryfirst·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-retryfirst·get·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Canceled'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-retryfirst·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-retryfirst·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-retrysecond·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-retrysecond·get·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Canceled'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-retrysecond·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-retrysecond·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-single-failure·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-single-failure·get·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Canceled'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-single-failure·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-single-failure·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-failure·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-failure·get·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Canceled'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-failure·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-failure·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-failureuri·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-failureuri·get·responses·200"
-     ]
-    },
-    "description": "Initial response with ProvisioningState='Canceled'",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-failureuri·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-failureuri·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragment-tenant·get·responses·200"
-     ]
-    },
-    "description": "Paging response with a fragment nextLink",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:26"
-      }
-     }
-    }
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragment-tenant·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragmentwithgrouping-tenant·get·responses·200"
-     ]
-    },
-    "description": "Paging response with a fragment nextLink",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:26"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragmentwithgrouping-tenant·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-lro·post·responses·202",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-lro·post·responses·202"
-     ]
-    },
-    "description": "Operation is in progress.",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:23"
-      }
-     }
-    }
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-lro·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-lro·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant-nextlink·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragment-tenant-nextlink·get·responses·200"
-     ]
-    },
-    "description": "Paging response with a fragment nextLink",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:26"
-      }
-     }
-    }
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant-nextlink·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragment-tenant-nextlink·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-odata·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragment-tenant·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragmentwithgrouping-tenant·get·responses·200",
+      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragment-tenant-nextlink·get·responses·200",
       "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·responses·200"
      ]
     },
-    "description": "Paging response with a fragment nextLink",
+    "description": "Initial response with ProvisioningState='Canceled'",
     "content": {
      "application/json": {
       "schema": {
@@ -1339,21 +920,6 @@
       }
      }
     }
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/responses/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error"
    }
   },
   "schemas": {
@@ -1367,7 +933,20 @@
      ],
      "name": "paths·paging-multiple·get·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple·get·parameters·0·schema"
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple·get·parameters·0·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-odata·get·parameters·0·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-withpath-offset·get·parameters·0·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant·get·parameters·0·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant·get·parameters·1·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·0·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·1·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-lro·post·parameters·0·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·0·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·1·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·2·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·0·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·1·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·2·schema"
      ]
     },
     "type": "string"
@@ -1382,7 +961,11 @@
      ],
      "name": "paths·paging-multiple·get·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple·get·parameters·1·schema"
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple·get·parameters·1·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-odata·get·parameters·1·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-withpath-offset·get·parameters·1·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-withpath-offset·get·parameters·2·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-lro·post·parameters·1·schema"
      ]
     },
     "format": "int32",
@@ -1398,322 +981,15 @@
      ],
      "name": "paths·paging-multiple·get·parameters·2·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple·get·parameters·2·schema"
-     ]
-    },
-    "format": "int32",
-    "default": 30,
-    "type": "integer"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-odata·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-odata·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-odata·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-odata·get·parameters·1·schema"
-     ]
-    },
-    "format": "int32",
-    "type": "integer"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-odata·get·parameters·2·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-odata·get·parameters·2·schema"
-     ]
-    },
-    "format": "int32",
-    "default": 30,
-    "type": "integer"
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-withpath-offset·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-withpath-offset·get·parameters·1·schema"
-     ]
-    },
-    "format": "int32",
-    "type": "integer"
-   },
-   "schemas:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·parameters·2·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-withpath-offset·get·parameters·2·schema"
-     ]
-    },
-    "format": "int32",
-    "type": "integer"
-   },
-   "schemas:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·parameters·3·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-withpath-offset·get·parameters·3·schema"
-     ]
-    },
-    "format": "int32",
-    "default": 30,
-    "type": "integer"
-   },
-   "schemas:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-lro·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-lro·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-lro·post·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-lro·post·parameters·1·schema"
-     ]
-    },
-    "format": "int32",
-    "type": "integer"
-   },
-   "schemas:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-lro·post·parameters·2·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple·get·parameters·2·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-odata·get·parameters·2·schema",
+      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-withpath-offset·get·parameters·3·schema",
       "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-lro·post·parameters·2·schema"
      ]
     },
     "format": "int32",
     "default": 30,
     "type": "integer"
-   },
-   "schemas:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant-nextlink·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant-nextlink·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant-nextlink·get·parameters·2·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·2·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·2·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/schemas/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·2·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:23": {
     "x-ms-metadata": {
@@ -1947,7 +1223,10 @@
      ],
      "name": "paths·paging-multiple·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple·get·parameters·0"
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple·get·parameters·0",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-odata·get·parameters·0",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-withpath-offset·get·parameters·0",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-lro·post·parameters·0"
      ]
     },
     "name": "client-request-id",
@@ -1968,7 +1247,10 @@
      ],
      "name": "paths·paging-multiple·get·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple·get·parameters·1"
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple·get·parameters·1",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-odata·get·parameters·1",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-withpath-offset·get·parameters·1",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-lro·post·parameters·1"
      ]
     },
     "name": "maxresults",
@@ -1993,7 +1275,10 @@
      ],
      "name": "paths·paging-multiple·get·parameters·2",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple·get·parameters·2"
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple·get·parameters·2",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-odata·get·parameters·2",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-withpath-offset·get·parameters·3",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-lro·post·parameters·2"
      ]
     },
     "name": "timeout",
@@ -2004,123 +1289,6 @@
     },
     "schema": {
      "$ref": "#/components/schemas/schemas:2"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-odata·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-odata·get·parameters·0"
-     ]
-    },
-    "name": "client-request-id",
-    "in": "header",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:3"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-odata·get·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-odata·get·parameters·1"
-     ]
-    },
-    "name": "maxresults",
-    "in": "header",
-    "description": "Sets the maximum number of items to return in the response.",
-    "x-ms-parameter-grouping": {
-     "postfix": "Options"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:4"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-odata·get·parameters·2",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-odata·get·parameters·2"
-     ]
-    },
-    "name": "timeout",
-    "in": "header",
-    "description": "Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.",
-    "x-ms-parameter-grouping": {
-     "postfix": "Options"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:5"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-withpath-offset·get·parameters·0"
-     ]
-    },
-    "name": "client-request-id",
-    "in": "header",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:6"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-withpath-offset·get·parameters·1"
-     ]
-    },
-    "name": "maxresults",
-    "in": "header",
-    "description": "Sets the maximum number of items to return in the response.",
-    "x-ms-parameter-grouping": {
-     "postfix": "Options"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:7"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -2145,34 +1313,9 @@
      "postfix": "Options"
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:8"
+     "$ref": "#/components/schemas/schemas:1"
     },
     "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-withpath-offset·get·parameters·3",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-withpath-offset·get·parameters·3"
-     ]
-    },
-    "name": "timeout",
-    "in": "header",
-    "description": "Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.",
-    "x-ms-parameter-grouping": {
-     "postfix": "Options"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:9"
-    },
-    "required": false,
     "x-ms-parameter-location": "method"
    },
    "parameters:10": {
@@ -2185,14 +1328,15 @@
      ],
      "name": "paths·paging-multiple-fragment-tenant·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant·get·parameters·0"
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant·get·parameters·0",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·0"
      ]
     },
     "name": "api_version",
     "in": "query",
     "description": "Sets the api version to use.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:10"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2207,14 +1351,15 @@
      ],
      "name": "paths·paging-multiple-fragment-tenant·get·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant·get·parameters·1"
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant·get·parameters·1",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·1"
      ]
     },
     "name": "tenant",
     "in": "path",
     "description": "Sets the tenant to use.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:11"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2229,7 +1374,8 @@
      ],
      "name": "paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·0"
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·0",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·0"
      ]
     },
     "name": "api_version",
@@ -2239,7 +1385,7 @@
      "name": "custom-parameter-group"
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:12"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2254,7 +1400,8 @@
      ],
      "name": "paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·1"
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·1",
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·1"
      ]
     },
     "name": "tenant",
@@ -2264,122 +1411,7 @@
      "name": "custom-parameter-group"
     },
     "schema": {
-     "$ref": "#/components/schemas/schemas:13"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-lro·post·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-lro·post·parameters·0"
-     ]
-    },
-    "name": "client-request-id",
-    "in": "header",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:14"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-lro·post·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-lro·post·parameters·1"
-     ]
-    },
-    "name": "maxresults",
-    "in": "header",
-    "description": "Sets the maximum number of items to return in the response.",
-    "x-ms-parameter-grouping": {
-     "postfix": "Options"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:15"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-lro·post·parameters·2",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-lro·post·parameters·2"
-     ]
-    },
-    "name": "timeout",
-    "in": "header",
-    "description": "Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.",
-    "x-ms-parameter-grouping": {
-     "postfix": "Options"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:16"
-    },
-    "required": false,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant-nextlink·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·0"
-     ]
-    },
-    "name": "api_version",
-    "in": "query",
-    "description": "Sets the api version to use.",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:17"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragment-tenant-nextlink·get·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·1"
-     ]
-    },
-    "name": "tenant",
-    "in": "path",
-    "description": "Sets the tenant to use.",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:18"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2394,79 +1426,7 @@
      ],
      "name": "paths·paging-multiple-fragment-tenant-nextlink·get·parameters·2",
      "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·2"
-     ]
-    },
-    "name": "nextLink",
-    "in": "path",
-    "description": "Next link for list operation.",
-    "x-ms-skip-url-encoding": true,
-    "schema": {
-     "$ref": "#/components/schemas/schemas:19"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·0"
-     ]
-    },
-    "name": "api_version",
-    "in": "query",
-    "description": "Sets the api version to use.",
-    "x-ms-parameter-grouping": {
-     "name": "custom-parameter-group"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:20"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·1"
-     ]
-    },
-    "name": "tenant",
-    "in": "path",
-    "description": "Sets the tenant to use.",
-    "x-ms-parameter-grouping": {
-     "name": "custom-parameter-group"
-    },
-    "schema": {
-     "$ref": "#/components/schemas/schemas:21"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·2",
-     "originalLocations": [
+      "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragment-tenant-nextlink·get·parameters·2",
       "http://localhost:3000/swagger/paging.json#/components/parameters/paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·2"
      ]
     },
@@ -2475,7 +1435,7 @@
     "description": "Next link for list operation.",
     "x-ms-skip-url-encoding": true,
     "schema": {
-     "$ref": "#/components/schemas/schemas:22"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"

--- a/modelerfour/test/inputs/parameter-flattening/openapi-document.json
+++ b/modelerfour/test/inputs/parameter-flattening/openapi-document.json
@@ -135,7 +135,8 @@
      ],
      "name": "paths·parameterflattening-resourcegroupname-availabilitysetname·patch·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/parameter-flattening.json#/components/schemas/paths·parameterflattening-resourcegroupname-availabilitysetname·patch·parameters·0·schema"
+      "http://localhost:3000/swagger/parameter-flattening.json#/components/schemas/paths·parameterflattening-resourcegroupname-availabilitysetname·patch·parameters·0·schema",
+      "http://localhost:3000/swagger/parameter-flattening.json#/components/schemas/components·schemas·availabilitysetupdateparameters·properties·tags·additionalproperties"
      ]
     },
     "type": "string"
@@ -197,23 +198,8 @@
     "title": "A set of tags.",
     "description": "A description about the set of tags.",
     "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:4"
+     "$ref": "#/components/schemas/schemas:0"
     }
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·schemas·availabilitysetupdateparameters·properties·tags·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/parameter-flattening.json#/components/schemas/components·schemas·availabilitysetupdateparameters·properties·tags·additionalproperties"
-     ]
-    },
-    "type": "string"
    }
   },
   "requestBodies": {

--- a/modelerfour/test/inputs/required-optional/openapi-document.json
+++ b/modelerfour/test/inputs/required-optional/openapi-document.json
@@ -50,7 +50,7 @@
     "in": "query",
     "description": "number of items to skip",
     "schema": {
-     "$ref": "#/components/schemas/schemas:1"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true
    },
@@ -91,7 +91,7 @@
     "name": "pathParameter",
     "in": "path",
     "schema": {
-     "$ref": "#/components/schemas/schemas:21"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -112,7 +112,7 @@
     "name": "queryParameter",
     "in": "query",
     "schema": {
-     "$ref": "#/components/schemas/schemas:22"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "x-ms-parameter-location": "method"
    },
@@ -132,7 +132,7 @@
     "name": "queryParameter",
     "in": "header",
     "schema": {
-     "$ref": "#/components/schemas/schemas:23"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "x-ms-parameter-location": "method"
    },
@@ -173,7 +173,7 @@
     "name": "headerParameter",
     "in": "header",
     "schema": {
-     "$ref": "#/components/schemas/schemas:28"
+     "$ref": "#/components/schemas/schemas:27"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -194,7 +194,7 @@
     "name": "headerParameter",
     "in": "header",
     "schema": {
-     "$ref": "#/components/schemas/schemas:31"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -215,7 +215,7 @@
     "name": "bodyParameter",
     "in": "header",
     "schema": {
-     "$ref": "#/components/schemas/schemas:32"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": false,
     "x-ms-parameter-location": "method"
@@ -276,22 +276,18 @@
      ],
      "name": "components·parameters·required_global_path·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/components·parameters·required_global_path·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·required_global_query·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/components·parameters·required_global_query·schema"
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/components·parameters·required_global_path·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/components·parameters·required_global_query·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-implicit-required-path-pathparameter·get·parameters·0·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-implicit-optional-query·put·parameters·0·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-implicit-optional-header·put·parameters·0·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-implicit-optional-body·put·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-requied-string-parameter·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-string-parameter·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-requied-string-header·post·parameters·0·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-string-header·post·parameters·0·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-array-parameter·post·requestbody·content·application-json·schema·items",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-array-header·post·parameters·0·schema·items"
      ]
     },
     "type": "string"
@@ -662,96 +658,6 @@
     },
     "type": "string"
    },
-   "schemas:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-required-path-pathparameter·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-implicit-required-path-pathparameter·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-optional-query·put·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-implicit-optional-query·put·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-optional-header·put·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-implicit-optional-header·put·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-optional-body·put·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-implicit-optional-body·put·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-integer-parameter·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-requied-integer-parameter·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-integer-parameter·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-integer-parameter·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "integer"
-   },
    "schemas:27": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -762,85 +668,13 @@
      ],
      "name": "paths·reqopt-requied-integer-header·post·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-requied-integer-header·post·parameters·0·schema"
-     ]
-    },
-    "type": "integer"
-   },
-   "schemas:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-integer-header·post·parameters·0·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-requied-integer-header·post·parameters·0·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-requied-integer-parameter·post·requestbody·content·application-json·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-integer-parameter·post·requestbody·content·application-json·schema",
       "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-integer-header·post·parameters·0·schema"
      ]
     },
     "type": "integer"
-   },
-   "schemas:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-string-parameter·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-requied-string-parameter·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-parameter·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-string-parameter·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-string-header·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-requied-string-header·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-header·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-string-header·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:33": {
     "x-ms-metadata": {
@@ -871,39 +705,6 @@
      "name": "post-content-schemaItem",
      "originalLocations": [
       "http://localhost:3000/swagger/required-optional.json#/components/schemas/post-content-schemaItem"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-parameter·post·requestbody·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-array-parameter·post·requestbody·content·application-json·schema"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:36"
-    }
-   },
-   "schemas:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-parameter·post·requestbody·content·application-json·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-array-parameter·post·requestbody·content·application-json·schema·items"
      ]
     },
     "type": "string"
@@ -951,28 +752,14 @@
      ],
      "name": "paths·reqopt-optional-array-header·post·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-array-header·post·parameters·0·schema"
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-array-header·post·parameters·0·schema",
+      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-array-parameter·post·requestbody·content·application-json·schema"
      ]
     },
     "type": "array",
     "items": {
-     "$ref": "#/components/schemas/schemas:40"
+     "$ref": "#/components/schemas/schemas:0"
     }
-   },
-   "schemas:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-header·post·parameters·0·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/schemas/paths·reqopt-optional-array-header·post·parameters·0·schema·items"
-     ]
-    },
-    "type": "string"
    }
   },
   "responses": {
@@ -986,7 +773,35 @@
      ],
      "name": "paths·reqopt-implicit-required-path-pathparameter·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-required-path-pathparameter·get·responses·default"
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-required-path-pathparameter·get·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-query·put·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-header·put·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-body·put·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-integer-parameter·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-parameter·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-integer-property·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-property·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-integer-header·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-header·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-string-parameter·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-parameter·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-string-property·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-property·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-string-header·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-header·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-class-parameter·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-class-parameter·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-class-property·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-class-property·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-array-parameter·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-parameter·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-array-property·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-property·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-array-header·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-header·post·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-global-required-path-required_global_path·get·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-global-required-query·get·responses·default",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-global-optional-query·get·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -1008,821 +823,23 @@
      ],
      "name": "paths·reqopt-implicit-optional-query·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-query·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-optional-query·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-query·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-optional-header·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-header·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-optional-header·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-header·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-optional-body·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-body·put·responses·200"
-     ]
-    },
-    "description": "Empty Response"
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-implicit-optional-body·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-body·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-integer-parameter·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-integer-parameter·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-integer-parameter·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-parameter·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-integer-parameter·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-parameter·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-integer-property·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-integer-property·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-integer-property·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-property·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-integer-property·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-property·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-integer-header·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-integer-header·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-integer-header·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-header·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-integer-header·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-header·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-string-parameter·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-string-parameter·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-parameter·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-parameter·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-parameter·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-parameter·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-string-property·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-string-property·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-property·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-property·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-property·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-property·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-string-header·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-string-header·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-header·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-header·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-header·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-header·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-class-parameter·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-class-parameter·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-class-parameter·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-class-parameter·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-class-parameter·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-class-parameter·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-class-property·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-class-property·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-class-property·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-class-property·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-class-property·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-class-property·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-array-parameter·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-array-parameter·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-parameter·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-parameter·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-parameter·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-parameter·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-array-property·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-array-property·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-property·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-property·post·responses·200"
-     ]
-    },
-    "description": "Empty response"
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-property·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-property·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-requied-array-header·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-requied-array-header·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-header·post·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-query·put·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-header·put·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-implicit-optional-body·put·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-parameter·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-property·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-integer-header·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-parameter·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-property·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-string-header·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-class-parameter·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-class-property·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-parameter·post·responses·200",
+      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-property·post·responses·200",
       "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-header·post·responses·200"
      ]
     },
-    "description": "Empty response"
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-array-header·post·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-optional-array-header·post·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-global-required-path-required_global_path·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-global-required-path-required_global_path·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-global-required-query·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-global-required-query·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-global-optional-query·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/responses/paths·reqopt-global-optional-query·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
+    "description": "Empty Response"
    }
   },
   "requestBodies": {
@@ -1836,13 +853,14 @@
      ],
      "name": "paths·reqopt-implicit-optional-body·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/requestBodies/paths·reqopt-implicit-optional-body·put·requestbody"
+      "http://localhost:3000/swagger/required-optional.json#/components/requestBodies/paths·reqopt-implicit-optional-body·put·requestbody",
+      "http://localhost:3000/swagger/required-optional.json#/components/requestBodies/paths·reqopt-optional-string-parameter·post·requestbody"
      ]
     },
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:24"
+       "$ref": "#/components/schemas/schemas:0"
       }
      }
     },
@@ -1864,7 +882,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:25"
+       "$ref": "#/components/schemas/schemas:27"
       }
      }
     },
@@ -1887,7 +905,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:26"
+       "$ref": "#/components/schemas/schemas:27"
       }
      }
     },
@@ -1954,33 +972,11 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:29"
+       "$ref": "#/components/schemas/schemas:0"
       }
      }
     },
     "required": true,
-    "x-ms-requestBody-name": "bodyParameter"
-   },
-   "requestBodies:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·reqopt-optional-string-parameter·post·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/required-optional.json#/components/requestBodies/paths·reqopt-optional-string-parameter·post·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:30"
-      }
-     }
-    },
     "x-ms-requestBody-name": "bodyParameter"
    },
    "requestBodies:7": {
@@ -2157,7 +1153,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:35"
+       "$ref": "#/components/schemas/schemas:39"
       }
      }
     },
@@ -2306,7 +1302,7 @@
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2354,11 +1350,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2405,11 +1401,11 @@
     "responses": {
      "200": {
       "description": "Empty Response",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2456,7 +1452,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2503,11 +1499,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2554,7 +1550,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2601,11 +1597,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2653,7 +1649,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2701,11 +1697,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2752,7 +1748,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2793,17 +1789,17 @@
     "operationId": "explicit_postOptionalStringParameter",
     "description": "Test explicitly optional string. Please put null.",
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:6"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2850,7 +1846,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2897,11 +1893,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2949,7 +1945,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -2997,11 +1993,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3048,7 +2044,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3095,11 +2091,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3146,7 +2142,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3193,11 +2189,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3244,7 +2240,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3291,11 +2287,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3342,7 +2338,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3389,11 +2385,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3441,7 +2437,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3489,11 +2485,11 @@
     "responses": {
      "200": {
       "description": "Empty response",
-      "$ref": "#/components/responses/responses:38"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -3536,7 +2532,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:0"
      }
     },
     "parameters": [
@@ -3584,7 +2580,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:0"
      }
     },
     "parameters": [
@@ -3632,7 +2628,7 @@
     "responses": {
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:0"
      }
     },
     "parameters": [

--- a/modelerfour/test/inputs/storage/openapi-document.json
+++ b/modelerfour/test/inputs/storage/openapi-document.json
@@ -169,7 +169,7 @@
       "$ref": "#/components/parameters/parameters:8"
      },
      {
-      "$ref": "#/components/parameters/parameters:1",
+      "$ref": "#/components/parameters/parameters:0",
       "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  "
      },
      {
@@ -182,11 +182,11 @@
     "responses": {
      "200": {
       "description": "OK",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:2"
      },
      "204": {
       "description": "No Content",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:2"
      }
     }
    }
@@ -220,7 +220,7 @@
       "$ref": "#/components/parameters/parameters:8"
      },
      {
-      "$ref": "#/components/parameters/parameters:2",
+      "$ref": "#/components/parameters/parameters:0",
       "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  "
      },
      {
@@ -233,7 +233,7 @@
     "responses": {
      "200": {
       "description": "OK",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -267,7 +267,7 @@
       "$ref": "#/components/parameters/parameters:8"
      },
      {
-      "$ref": "#/components/parameters/parameters:3",
+      "$ref": "#/components/parameters/parameters:0",
       "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  "
      },
      {
@@ -285,7 +285,7 @@
     "responses": {
      "200": {
       "description": "OK",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -333,7 +333,7 @@
       "$ref": "#/components/parameters/parameters:8"
      },
      {
-      "$ref": "#/components/parameters/parameters:4",
+      "$ref": "#/components/parameters/parameters:0",
       "description": "The name of the storage account."
      },
      {
@@ -460,7 +460,7 @@
     "responses": {
      "200": {
       "description": "OK",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:8"
      }
     },
     "x-ms-pageable": {
@@ -511,7 +511,7 @@
       "$ref": "#/components/parameters/parameters:8"
      },
      {
-      "$ref": "#/components/parameters/parameters:5",
+      "$ref": "#/components/parameters/parameters:0",
       "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  "
      },
      {
@@ -529,7 +529,7 @@
     "responses": {
      "200": {
       "description": "OK",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:7"
      }
     }
    }
@@ -709,96 +709,6 @@
    }
   },
   "schemas": {
-   "schemas:0": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
    "schemas:6": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1297,7 +1207,7 @@
      },
      "key2": {
       "description": "Gets the value of key 2.",
-      "$ref": "#/components/schemas/schemas:35"
+      "$ref": "#/components/schemas/schemas:34"
      }
     },
     "description": "The access keys for the storage account."
@@ -1312,27 +1222,12 @@
      ],
      "name": "StorageAccountKeys-key1",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountKeys-key1"
-     ]
-    },
-    "type": "string",
-    "description": "Gets the value of key 1."
-   },
-   "schemas:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "StorageAccountKeys-key2",
-     "originalLocations": [
+      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountKeys-key1",
       "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountKeys-key2"
      ]
     },
     "type": "string",
-    "description": "Gets the value of key 2."
+    "description": "Gets the value of key 1."
    },
    "schemas:36": {
     "x-ms-metadata": {
@@ -1742,7 +1637,16 @@
      ],
      "name": "components·schemas·resource·properties·tags·additionalproperties",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/components·schemas·resource·properties·tags·additionalproperties"
+      "http://localhost:3000/swagger/storage.json#/components/schemas/components·schemas·resource·properties·tags·additionalproperties",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·parameters·1·schema",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·parameters·1·schema",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·parameters·1·schema",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·parameters·1·schema",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·parameters·1·schema",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·parameters·1·schema",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/components·parameters·subscriptionidparameter·schema",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/components·parameters·apiversionparameter·schema",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/components·parameters·resourcegroupname·schema"
      ]
     },
     "type": "string"
@@ -1785,51 +1689,6 @@
     "type": "string",
     "description": "Resource Id"
    },
-   "schemas:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·subscriptionidparameter·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/components·parameters·subscriptionidparameter·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·apiversionparameter·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/components·parameters·apiversionparameter·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·resourcegroupname·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/components·parameters·resourcegroupname·schema"
-     ]
-    },
-    "type": "string"
-   },
    "Reason": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1863,21 +1722,23 @@
      ],
      "name": "AccountType",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountPropertiesCreateParameters-accountType"
+      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountPropertiesCreateParameters-accountType",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountProperties-accountType",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountPropertiesUpdateParameters-accountType"
      ]
     },
-    "description": "Gets or sets the account type.",
-    "x-ms-enum": {
-     "name": "AccountType"
-    },
     "type": "string",
+    "description": "Gets or sets the account type.",
     "enum": [
      "Standard_LRS",
      "Standard_ZRS",
      "Standard_GRS",
      "Standard_RAGRS",
      "Premium_LRS"
-    ]
+    ],
+    "x-ms-enum": {
+     "name": "AccountType"
+    }
    },
    "ProvisioningState": {
     "x-ms-metadata": {
@@ -1913,18 +1774,19 @@
      ],
      "name": "AccountStatus",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountProperties-statusOfPrimary"
+      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountProperties-statusOfPrimary",
+      "http://localhost:3000/swagger/storage.json#/components/schemas/StorageAccountProperties-statusOfSecondary"
      ]
     },
-    "description": "Gets the status indicating whether the primary location of the storage account is available or unavailable.",
-    "x-ms-enum": {
-     "name": "AccountStatus"
-    },
     "type": "string",
+    "description": "Gets the status indicating whether the primary location of the storage account is available or unavailable.",
     "enum": [
      "Available",
      "Unavailable"
-    ]
+    ],
+    "x-ms-enum": {
+     "name": "AccountStatus"
+    }
    },
    "KeyName": {
     "x-ms-metadata": {
@@ -1987,116 +1849,11 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·parameters·1"
-     ]
-    },
-    "name": "accountName",
-    "in": "path",
-    "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:0"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·parameters·1"
-     ]
-    },
-    "name": "accountName",
-    "in": "path",
-    "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:1"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·parameters·1"
-     ]
-    },
-    "name": "accountName",
-    "in": "path",
-    "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:2"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·parameters·1"
-     ]
-    },
-    "name": "accountName",
-    "in": "path",
-    "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:3"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·parameters·1"
-     ]
-    },
-    "name": "accountName",
-    "in": "path",
-    "description": "The name of the storage account.",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:4"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·parameters·1",
-     "originalLocations": [
+      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·parameters·1",
+      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·parameters·1",
+      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·parameters·1",
+      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·parameters·1",
+      "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·parameters·1",
       "http://localhost:3000/swagger/storage.json#/components/parameters/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·parameters·1"
      ]
     },
@@ -2104,7 +1861,7 @@
     "in": "path",
     "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
     "schema": {
-     "$ref": "#/components/schemas/schemas:5"
+     "$ref": "#/components/schemas/schemas:57"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -2126,7 +1883,7 @@
     "in": "path",
     "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:60"
+     "$ref": "#/components/schemas/schemas:57"
     },
     "required": true
    },
@@ -2147,7 +1904,7 @@
     "in": "query",
     "description": "Client Api Version.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:61"
+     "$ref": "#/components/schemas/schemas:57"
     },
     "required": true
    },
@@ -2169,7 +1926,7 @@
     "description": "The name of the resource group within the user’s subscription.",
     "x-ms-parameter-location": "method",
     "schema": {
-     "$ref": "#/components/schemas/schemas:62"
+     "$ref": "#/components/schemas/schemas:57"
     },
     "required": true
    }
@@ -2212,7 +1969,9 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·responses·200"
+      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·responses·200",
+      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·responses·200",
+      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·responses·200"
      ]
     },
     "description": "OK",
@@ -2239,94 +1998,12 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·responses·202",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·responses·202"
-     ]
-    },
-    "description": "Accepted"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·responses·200"
-     ]
-    },
-    "description": "OK"
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·responses·204",
-     "originalLocations": [
+      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·responses·202",
+      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·responses·200",
       "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·responses·204"
      ]
     },
-    "description": "No Content"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·responses·200"
-     ]
-    },
-    "description": "OK",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:32"
-      }
-     },
-     "text/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:32"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·responses·200"
-     ]
-    },
-    "description": "OK",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:32"
-      }
-     },
-     "text/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:32"
-      }
-     }
-    }
+    "description": "Accepted"
    },
    "responses:7": {
     "x-ms-metadata": {
@@ -2338,7 +2015,8 @@
      ],
      "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·responses·200"
+      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·responses·200",
+      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·responses·200"
      ]
     },
     "description": "OK",
@@ -2365,33 +2043,7 @@
      ],
      "name": "paths·subscriptions-subscriptionid-providers-microsoft-storage-storageaccounts·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-providers-microsoft-storage-storageaccounts·get·responses·200"
-     ]
-    },
-    "description": "OK",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:36"
-      }
-     },
-     "text/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:36"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts·get·responses·200",
-     "originalLocations": [
+      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-providers-microsoft-storage-storageaccounts·get·responses·200",
       "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts·get·responses·200"
      ]
     },
@@ -2405,33 +2057,6 @@
      "text/json": {
       "schema": {
        "$ref": "#/components/schemas/schemas:36"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2015-05-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/storage.json#/components/responses/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·responses·200"
-     ]
-    },
-    "description": "OK",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:33"
-      }
-     },
-     "text/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:33"
       }
      }
     }

--- a/modelerfour/test/inputs/subscriptionId-apiVersion/openapi-document.json
+++ b/modelerfour/test/inputs/subscriptionId-apiVersion/openapi-document.json
@@ -50,7 +50,7 @@
     "in": "query",
     "description": "API Version with value '2014-04-01-preview'.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:1"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true
    },
@@ -71,7 +71,7 @@
     "in": "path",
     "description": "Resource Group name 'testgroup101'.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:7"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -88,22 +88,9 @@
      ],
      "name": "components·parameters·subscriptionidparameter·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/subscriptionId-apiVersion.json#/components/schemas/components·parameters·subscriptionidparameter·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·apiversionparameter·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/subscriptionId-apiVersion.json#/components/schemas/components·parameters·apiversionparameter·schema"
+      "http://localhost:3000/swagger/subscriptionId-apiVersion.json#/components/schemas/components·parameters·subscriptionidparameter·schema",
+      "http://localhost:3000/swagger/subscriptionId-apiVersion.json#/components/schemas/components·parameters·apiversionparameter·schema",
+      "http://localhost:3000/swagger/subscriptionId-apiVersion.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname·get·parameters·1·schema"
      ]
     },
     "type": "string"
@@ -200,21 +187,6 @@
      "name": "Error-message",
      "originalLocations": [
       "http://localhost:3000/swagger/subscriptionId-apiVersion.json#/components/schemas/Error-message"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "2014-04-01-preview"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/subscriptionId-apiVersion.json#/components/schemas/paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname·get·parameters·1·schema"
      ]
     },
     "type": "string"

--- a/modelerfour/test/inputs/url-multi-collectionFormat/openapi-document.json
+++ b/modelerfour/test/inputs/url-multi-collectionFormat/openapi-document.json
@@ -114,11 +114,11 @@
     "responses": {
      "200": {
       "description": "Successfully received no query parameters",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -163,18 +163,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:2",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the mult-array format"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received ?arrayQuery=ArrayQuery1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -214,7 +214,8 @@
      ],
      "name": "paths·queries-array-multi-string-empty·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/parameters/paths·queries-array-multi-string-empty·get·parameters·0"
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/parameters/paths·queries-array-multi-string-empty·get·parameters·0",
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/parameters/paths·queries-array-multi-string-valid·get·parameters·0"
      ]
     },
     "name": "arrayQuery",
@@ -223,28 +224,6 @@
     "explode": true,
     "schema": {
      "$ref": "#/components/schemas/schemas:2"
-    },
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-multi-string-valid·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/parameters/paths·queries-array-multi-string-valid·get·parameters·0"
-     ]
-    },
-    "name": "arrayQuery",
-    "in": "query",
-    "description": "an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the mult-array format",
-    "explode": true,
-    "schema": {
-     "$ref": "#/components/schemas/schemas:4"
     },
     "x-ms-parameter-location": "method"
    }
@@ -293,7 +272,8 @@
      ],
      "name": "paths·queries-array-multi-string-empty·get·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/schemas/paths·queries-array-multi-string-empty·get·parameters·0·schema"
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/schemas/paths·queries-array-multi-string-empty·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/schemas/paths·queries-array-multi-string-valid·get·parameters·0·schema"
      ]
     },
     "type": "array",
@@ -311,39 +291,7 @@
      ],
      "name": "paths·queries-array-multi-string-empty·get·parameters·0·schema·items",
      "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/schemas/paths·queries-array-multi-string-empty·get·parameters·0·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-multi-string-valid·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/schemas/paths·queries-array-multi-string-valid·get·parameters·0·schema"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:5"
-    }
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-multi-string-valid·get·parameters·0·schema·items",
-     "originalLocations": [
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/schemas/paths·queries-array-multi-string-empty·get·parameters·0·schema·items",
       "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/schemas/paths·queries-array-multi-string-valid·get·parameters·0·schema·items"
      ]
     },
@@ -400,7 +348,9 @@
      ],
      "name": "paths·queries-array-multi-string-null·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-null·get·responses·200"
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-null·get·responses·200",
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-empty·get·responses·200",
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-valid·get·responses·200"
      ]
     },
     "description": "Successfully received no query parameters"
@@ -415,80 +365,8 @@
      ],
      "name": "paths·queries-array-multi-string-null·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-multi-string-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-empty·get·responses·200"
-     ]
-    },
-    "description": "Successfully received no query parameters"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-multi-string-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:6"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-multi-string-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-valid·get·responses·200"
-     ]
-    },
-    "description": "Successfully received ?arrayQuery=ArrayQuery1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-multi-string-valid·get·responses·default",
-     "originalLocations": [
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-null·get·responses·default",
+      "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-empty·get·responses·default",
       "http://localhost:3000/swagger/url-multi-collectionFormat.json#/components/responses/paths·queries-array-multi-string-valid·get·responses·default"
      ]
     },

--- a/modelerfour/test/inputs/url/openapi-document.json
+++ b/modelerfour/test/inputs/url/openapi-document.json
@@ -114,11 +114,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the false Boolean value",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -170,11 +170,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '1000000' integer value",
-      "$ref": "#/components/responses/responses:4"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -226,11 +226,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '-1000000' integer value",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -282,11 +282,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '10000000000' integer value",
-      "$ref": "#/components/responses/responses:8"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -338,11 +338,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '-10000000000' integer value",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:11"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -394,11 +394,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '1.034E+20' numeric value",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -450,11 +450,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '-1.034E-20' numeric value",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -506,11 +506,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '9999999.999' numeric value",
-      "$ref": "#/components/responses/responses:16"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -562,11 +562,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '-9999999.999' numeric value",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -618,11 +618,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -674,11 +674,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received 'begin!*'();:@ &=+$,/?#[]end' url encoded string value",
-      "$ref": "#/components/responses/responses:22"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -730,11 +730,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '' string value",
-      "$ref": "#/components/responses/responses:24"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:25"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -786,11 +786,11 @@
     "responses": {
      "400": {
       "description": "You should not reach this, null should throw",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:27"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -842,11 +842,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received 'green color' in url encoded enum value",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:29"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -891,18 +891,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:15",
+      "$ref": "#/components/parameters/parameters:14",
       "description": "send null should throw"
      }
     ],
     "responses": {
      "400": {
       "description": "You should not reach this, null should throw",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:31"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -954,11 +954,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array",
-      "$ref": "#/components/responses/responses:32"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:33"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1010,11 +1010,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '' as byte array",
-      "$ref": "#/components/responses/responses:34"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:35"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1059,18 +1059,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:18",
+      "$ref": "#/components/parameters/parameters:16",
       "description": "null as byte array (should throw)"
      }
     ],
     "responses": {
      "400": {
       "description": "Failure - client-side code should throw at null path parameter",
-      "$ref": "#/components/responses/responses:36"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:37"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1122,11 +1122,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '2012-01-01' as date",
-      "$ref": "#/components/responses/responses:38"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:39"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1178,11 +1178,11 @@
     "responses": {
      "400": {
       "description": "This should never happen - client code should not accept this",
-      "$ref": "#/components/responses/responses:40"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:41"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1234,11 +1234,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '2012-01-01T01:01:01Z' as date-time",
-      "$ref": "#/components/responses/responses:42"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:43"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1290,11 +1290,11 @@
     "responses": {
      "400": {
       "description": "This should not occur: the test fails if you contact the server",
-      "$ref": "#/components/responses/responses:44"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:45"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1346,11 +1346,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received 'lorem' encoded value as 'bG9yZW0' (base64url)",
-      "$ref": "#/components/responses/responses:46"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:47"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1402,11 +1402,11 @@
     "responses": {
      "200": {
       "description": "Successfully received /paths/array/ArrayPath1,begin!*'();:@ &=+$,/?#[]end,,/ArrayPath1,begin!*'();:@ &=+$,/?#[]end,,",
-      "$ref": "#/components/responses/responses:48"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:49"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1458,11 +1458,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received date 2016-04-13 encoded value as '1460505600' (Unix time)",
-      "$ref": "#/components/responses/responses:50"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:51"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1514,11 +1514,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the true boolean value",
-      "$ref": "#/components/responses/responses:52"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:53"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1570,11 +1570,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the false Boolean value",
-      "$ref": "#/components/responses/responses:54"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:55"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1626,11 +1626,11 @@
     "responses": {
      "200": {
       "description": "Successfully received the null Boolean value",
-      "$ref": "#/components/responses/responses:56"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:57"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1682,11 +1682,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '1000000' integer value",
-      "$ref": "#/components/responses/responses:58"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:59"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1738,11 +1738,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '-1000000' integer value",
-      "$ref": "#/components/responses/responses:60"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:61"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1794,11 +1794,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received null integer value",
-      "$ref": "#/components/responses/responses:62"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:63"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1850,11 +1850,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '10000000000' integer value",
-      "$ref": "#/components/responses/responses:64"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:65"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1906,11 +1906,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '-10000000000' integer value",
-      "$ref": "#/components/responses/responses:66"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:67"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1962,11 +1962,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received null 64-bit integer value (no param in uri)",
-      "$ref": "#/components/responses/responses:68"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:69"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2018,11 +2018,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '1.034E+20' numeric value",
-      "$ref": "#/components/responses/responses:70"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:71"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2074,11 +2074,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '-1.034E-20' numeric value",
-      "$ref": "#/components/responses/responses:72"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:73"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2130,11 +2130,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received null numeric value (no query parameter)",
-      "$ref": "#/components/responses/responses:74"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:75"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2186,11 +2186,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '9999999.999' numeric value",
-      "$ref": "#/components/responses/responses:76"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:77"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2242,11 +2242,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '-9999999.999' numeric value",
-      "$ref": "#/components/responses/responses:78"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:79"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2298,11 +2298,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received null numeric value (no query parameter)",
-      "$ref": "#/components/responses/responses:80"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:81"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2354,11 +2354,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value",
-      "$ref": "#/components/responses/responses:82"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:83"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2410,11 +2410,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received 'begin!*'();:@ &=+$,/?#[]end' url encoded string value",
-      "$ref": "#/components/responses/responses:84"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:85"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2466,11 +2466,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '' string value",
-      "$ref": "#/components/responses/responses:86"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:87"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2522,11 +2522,11 @@
     "responses": {
      "200": {
       "description": "Successfully received null parameter (no query string in url)",
-      "$ref": "#/components/responses/responses:88"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:89"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2578,11 +2578,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received 'green color' string value",
-      "$ref": "#/components/responses/responses:90"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:91"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2627,18 +2627,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:46",
+      "$ref": "#/components/parameters/parameters:45",
       "description": "null string value"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received null parameter (no query string in url)",
-      "$ref": "#/components/responses/responses:92"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:93"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2690,11 +2690,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array",
-      "$ref": "#/components/responses/responses:94"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:95"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2746,11 +2746,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '' as byte array",
-      "$ref": "#/components/responses/responses:96"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:97"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2795,18 +2795,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:49",
+      "$ref": "#/components/parameters/parameters:47",
       "description": "null as byte array (no query parameters in uri)"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received no query parameters in uri",
-      "$ref": "#/components/responses/responses:98"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:99"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2858,11 +2858,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '2012-01-01' as date",
-      "$ref": "#/components/responses/responses:100"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:101"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2914,11 +2914,11 @@
     "responses": {
      "200": {
       "description": "Successfully received no query parameters in uri",
-      "$ref": "#/components/responses/responses:102"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:103"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -2970,11 +2970,11 @@
     "responses": {
      "200": {
       "description": "Successfully Received '2012-01-01T01:01:01Z' as date-time",
-      "$ref": "#/components/responses/responses:104"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:105"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3026,11 +3026,11 @@
     "responses": {
      "200": {
       "description": "Successfully received no query parameters in uri",
-      "$ref": "#/components/responses/responses:106"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:107"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3082,11 +3082,11 @@
     "responses": {
      "200": {
       "description": "Successfully received ?arrayQuery=ArrayQuery1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c",
-      "$ref": "#/components/responses/responses:108"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:109"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3131,18 +3131,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:55",
+      "$ref": "#/components/parameters/parameters:54",
       "description": "a null array of string using the csv-array format"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received no query parameters",
-      "$ref": "#/components/responses/responses:110"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:111"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3187,18 +3187,18 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:56",
+      "$ref": "#/components/parameters/parameters:54",
       "description": "an empty array [] of string using the csv-array format"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received no query parameters",
-      "$ref": "#/components/responses/responses:112"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:113"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3250,11 +3250,11 @@
     "responses": {
      "200": {
       "description": "Successfully received ?arrayQuery=ArrayQuery1%20begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%20%20",
-      "$ref": "#/components/responses/responses:114"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:115"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3306,11 +3306,11 @@
     "responses": {
      "200": {
       "description": "Successfully received ?arrayQuery=ArrayQuery1\tbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend\t\t",
-      "$ref": "#/components/responses/responses:116"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:117"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3362,11 +3362,11 @@
     "responses": {
      "200": {
       "description": "Successfully received ?arrayQuery=ArrayQuery1%|begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend||",
-      "$ref": "#/components/responses/responses:118"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:119"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3439,11 +3439,11 @@
     "responses": {
      "200": {
       "description": "Successfully received all query parameters in uri",
-      "$ref": "#/components/responses/responses:120"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:121"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3505,22 +3505,22 @@
       }
      },
      {
-      "$ref": "#/components/parameters/parameters:62",
+      "$ref": "#/components/parameters/parameters:60",
       "description": "should contain value 'localStringPath'"
      },
      {
-      "$ref": "#/components/parameters/parameters:63",
+      "$ref": "#/components/parameters/parameters:61",
       "description": "should contain value 'localStringQuery'"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received all query parameters but global",
-      "$ref": "#/components/responses/responses:122"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:123"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3582,22 +3582,22 @@
       }
      },
      {
-      "$ref": "#/components/parameters/parameters:64",
+      "$ref": "#/components/parameters/parameters:60",
       "description": "should contain value 'localStringPath'"
      },
      {
-      "$ref": "#/components/parameters/parameters:65",
+      "$ref": "#/components/parameters/parameters:61",
       "description": "should contain null value"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received only the pathItemQuery query parameter",
-      "$ref": "#/components/responses/responses:124"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:125"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -3659,22 +3659,22 @@
       }
      },
      {
-      "$ref": "#/components/parameters/parameters:66",
+      "$ref": "#/components/parameters/parameters:60",
       "description": "should contain value 'localStringPath'"
      },
      {
-      "$ref": "#/components/parameters/parameters:67",
+      "$ref": "#/components/parameters/parameters:61",
       "description": "should contain value null"
      }
     ],
     "responses": {
      "200": {
       "description": "Successfully received only global query parameter",
-      "$ref": "#/components/responses/responses:126"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:127"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -4043,34 +4043,13 @@
      ],
      "name": "paths·paths-enum-green-20color-enumpath·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·paths-enum-green-20color-enumpath·get·parameters·0"
-     ]
-    },
-    "name": "enumPath",
-    "in": "path",
-    "description": "send the value green",
-    "schema": {
-     "$ref": "#/components/schemas/UriColor"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-null-enumpath·get·parameters·0",
-     "originalLocations": [
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·paths-enum-green-20color-enumpath·get·parameters·0",
       "http://localhost:3000/swagger/url.json#/components/parameters/paths·paths-string-null-enumpath·get·parameters·0"
      ]
     },
     "name": "enumPath",
     "in": "path",
-    "description": "send null should throw",
+    "description": "send the value green",
     "schema": {
      "$ref": "#/components/schemas/UriColor"
     },
@@ -4087,7 +4066,8 @@
      ],
      "name": "paths·paths-byte-multibyte-bytepath·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·paths-byte-multibyte-bytepath·get·parameters·0"
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·paths-byte-multibyte-bytepath·get·parameters·0",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·paths-byte-null-bytepath·get·parameters·0"
      ]
     },
     "name": "bytePath",
@@ -4121,28 +4101,6 @@
       ""
      ],
      "type": "string"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-byte-null-bytepath·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·paths-byte-null-bytepath·get·parameters·0"
-     ]
-    },
-    "name": "bytePath",
-    "in": "path",
-    "description": "null as byte array (should throw)",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:3"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -4761,7 +4719,7 @@
     "in": "query",
     "description": "null string value",
     "schema": {
-     "$ref": "#/components/schemas/schemas:16"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "x-ms-parameter-location": "method"
    },
@@ -4775,33 +4733,13 @@
      ],
      "name": "paths·queries-enum-green-20color·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-enum-green-20color·get·parameters·0"
-     ]
-    },
-    "name": "enumQuery",
-    "in": "query",
-    "description": "'green color' enum value",
-    "schema": {
-     "$ref": "#/components/schemas/UriColor"
-    },
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-enum-null·get·parameters·0",
-     "originalLocations": [
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-enum-green-20color·get·parameters·0",
       "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-enum-null·get·parameters·0"
      ]
     },
     "name": "enumQuery",
     "in": "query",
-    "description": "null string value",
+    "description": "'green color' enum value",
     "schema": {
      "$ref": "#/components/schemas/UriColor"
     },
@@ -4817,7 +4755,8 @@
      ],
      "name": "paths·queries-byte-multibyte·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-byte-multibyte·get·parameters·0"
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-byte-multibyte·get·parameters·0",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-byte-null·get·parameters·0"
      ]
     },
     "name": "byteQuery",
@@ -4852,27 +4791,6 @@
      "type": "string"
     },
     "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-byte-null·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-byte-null·get·parameters·0"
-     ]
-    },
-    "name": "byteQuery",
-    "in": "query",
-    "description": "null as byte array (no query parameters in uri)",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:3"
-    },
     "x-ms-parameter-location": "method"
    },
    "parameters:50": {
@@ -4979,7 +4897,9 @@
      ],
      "name": "paths·queries-array-csv-string-valid·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-array-csv-string-valid·get·parameters·0"
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-array-csv-string-valid·get·parameters·0",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-array-csv-string-null·get·parameters·0",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-array-csv-string-empty·get·parameters·0"
      ]
     },
     "name": "arrayQuery",
@@ -4988,50 +4908,6 @@
     "style": "form",
     "schema": {
      "$ref": "#/components/schemas/schemas:23"
-    },
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-null·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-array-csv-string-null·get·parameters·0"
-     ]
-    },
-    "name": "arrayQuery",
-    "in": "query",
-    "description": "a null array of string using the csv-array format",
-    "style": "form",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:25"
-    },
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-empty·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·queries-array-csv-string-empty·get·parameters·0"
-     ]
-    },
-    "name": "arrayQuery",
-    "in": "query",
-    "description": "an empty array [] of string using the csv-array format",
-    "style": "form",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:27"
     },
     "x-ms-parameter-location": "method"
    },
@@ -5053,7 +4929,7 @@
     "description": "an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format",
     "style": "spaceDelimited",
     "schema": {
-     "$ref": "#/components/schemas/schemas:29"
+     "$ref": "#/components/schemas/schemas:23"
     },
     "x-ms-parameter-location": "method"
    },
@@ -5075,7 +4951,7 @@
     "description": "an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format",
     "style": "tabDelimited",
     "schema": {
-     "$ref": "#/components/schemas/schemas:31"
+     "$ref": "#/components/schemas/schemas:23"
     },
     "x-ms-parameter-location": "method"
    },
@@ -5097,7 +4973,7 @@
     "description": "an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format",
     "style": "pipeDelimited",
     "schema": {
-     "$ref": "#/components/schemas/schemas:33"
+     "$ref": "#/components/schemas/schemas:23"
     },
     "x-ms-parameter-location": "method"
    },
@@ -5111,14 +4987,17 @@
      ],
      "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·0"
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·0",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·0",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·0",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·0"
      ]
     },
     "name": "localStringPath",
     "in": "path",
     "description": "should contain value 'localStringPath'",
     "schema": {
-     "$ref": "#/components/schemas/schemas:35"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -5133,143 +5012,17 @@
      ],
      "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·1"
-     ]
-    },
-    "name": "localStringQuery",
-    "in": "query",
-    "description": "should contain value 'localStringQuery'",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:36"
-    },
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·0"
-     ]
-    },
-    "name": "localStringPath",
-    "in": "path",
-    "description": "should contain value 'localStringPath'",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:37"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·1"
-     ]
-    },
-    "name": "localStringQuery",
-    "in": "query",
-    "description": "should contain value 'localStringQuery'",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:38"
-    },
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·0"
-     ]
-    },
-    "name": "localStringPath",
-    "in": "path",
-    "description": "should contain value 'localStringPath'",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:39"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·1"
-     ]
-    },
-    "name": "localStringQuery",
-    "in": "query",
-    "description": "should contain null value",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:40"
-    },
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·0"
-     ]
-    },
-    "name": "localStringPath",
-    "in": "path",
-    "description": "should contain value 'localStringPath'",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:41"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·1",
-     "originalLocations": [
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·1",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·1",
+      "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·1",
       "http://localhost:3000/swagger/url.json#/components/parameters/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·1"
      ]
     },
     "name": "localStringQuery",
     "in": "query",
-    "description": "should contain value null",
+    "description": "should contain value 'localStringQuery'",
     "schema": {
-     "$ref": "#/components/schemas/schemas:42"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "x-ms-parameter-location": "method"
    },
@@ -5290,7 +5043,7 @@
     "in": "path",
     "description": "A string value 'globalItemStringPath' that appears in the path",
     "schema": {
-     "$ref": "#/components/schemas/schemas:43"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true
    },
@@ -5311,7 +5064,7 @@
     "in": "query",
     "description": "should contain value null",
     "schema": {
-     "$ref": "#/components/schemas/schemas:44"
+     "$ref": "#/components/schemas/schemas:0"
     }
    }
   },
@@ -5326,7 +5079,70 @@
      ],
      "name": "paths·paths-bool-true-boolpath·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-bool-true-boolpath·get·responses·200"
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-bool-true-boolpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-bool-false-boolpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-1000000-intpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-_1000000-intpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-long-10000000000-longpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-long-_10000000000-longpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-float-1-034e-20-floatpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-float-_1-034e_20-floatpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-double-9999999-999-doublepath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-double-_9999999-999-doublepath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-unicode-stringpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-stringpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-empty-stringpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-null-stringpath·get·responses·400",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-enum-green-20color-enumpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-null-enumpath·get·responses·400",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-multibyte-bytepath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-empty-bytepath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-null-bytepath·get·responses·400",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-date-2012_01_01-datepath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-date-null-datepath·get·responses·400",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-datetime-2012_01_01t01-3a01-3a01z-datetimepath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-datetime-null-datetimepath·get·responses·400",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-bg9yzw0-base64urlpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-1460505600-unixtimeurlpath·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-true·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-false·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-1000000·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-_1000000·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-10000000000·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-_10000000000·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-1-034e-20·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-_1-034e_20·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-9999999-999·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-_9999999-999·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-unicode·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-empty·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-enum-green-20color·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-enum-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-multibyte·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-empty·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-date-2012_01_01·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-date-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-datetime-2012_01_01t01-3a01-3a01z·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-datetime-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-valid·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-empty·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-ssv-string-valid·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-tsv-string-valid·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-pipes-string-valid·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·responses·200",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·responses·200"
      ]
     },
     "description": "Successfully received the true boolean value"
@@ -5341,2337 +5157,69 @@
      ],
      "name": "paths·paths-bool-true-boolpath·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-bool-true-boolpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-bool-false-boolpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-bool-false-boolpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the false Boolean value"
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-bool-false-boolpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-bool-false-boolpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-int-1000000-intpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-1000000-intpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '1000000' integer value"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-int-1000000-intpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-1000000-intpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-int-_1000000-intpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-_1000000-intpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '-1000000' integer value"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-int-_1000000-intpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-_1000000-intpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-long-10000000000-longpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-long-10000000000-longpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '10000000000' integer value"
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-long-10000000000-longpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-long-10000000000-longpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-long-_10000000000-longpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-long-_10000000000-longpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '-10000000000' integer value"
-   },
-   "responses:11": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-long-_10000000000-longpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-long-_10000000000-longpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-float-1-034e-20-floatpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-float-1-034e-20-floatpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '1.034E+20' numeric value"
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-float-1-034e-20-floatpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-float-1-034e-20-floatpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-float-_1-034e_20-floatpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-float-_1-034e_20-floatpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '-1.034E-20' numeric value"
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-float-_1-034e_20-floatpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-float-_1-034e_20-floatpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-double-9999999-999-doublepath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-double-9999999-999-doublepath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '9999999.999' numeric value"
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-double-9999999-999-doublepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-double-9999999-999-doublepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-double-_9999999-999-doublepath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-double-_9999999-999-doublepath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '-9999999.999' numeric value"
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-double-_9999999-999-doublepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-double-_9999999-999-doublepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-unicode-stringpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-unicode-stringpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value"
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-unicode-stringpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-unicode-stringpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:22": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-stringpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-stringpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received 'begin!*'();:@ &=+$,/?#[]end' url encoded string value"
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-stringpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-stringpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-empty-stringpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-empty-stringpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '' string value"
-   },
-   "responses:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-empty-stringpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-empty-stringpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-null-stringpath·get·responses·400",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-null-stringpath·get·responses·400"
-     ]
-    },
-    "description": "You should not reach this, null should throw"
-   },
-   "responses:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-null-stringpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-null-stringpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-enum-green-20color-enumpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-enum-green-20color-enumpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received 'green color' in url encoded enum value"
-   },
-   "responses:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-enum-green-20color-enumpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-enum-green-20color-enumpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-null-enumpath·get·responses·400",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-null-enumpath·get·responses·400"
-     ]
-    },
-    "description": "You should not reach this, null should throw"
-   },
-   "responses:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-null-enumpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-null-enumpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-byte-multibyte-bytepath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-multibyte-bytepath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array"
-   },
-   "responses:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-byte-multibyte-bytepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-multibyte-bytepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-byte-empty-bytepath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-empty-bytepath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '' as byte array"
-   },
-   "responses:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-byte-empty-bytepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-empty-bytepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-byte-null-bytepath·get·responses·400",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-null-bytepath·get·responses·400"
-     ]
-    },
-    "description": "Failure - client-side code should throw at null path parameter"
-   },
-   "responses:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-byte-null-bytepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-null-bytepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-date-2012_01_01-datepath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-date-2012_01_01-datepath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '2012-01-01' as date"
-   },
-   "responses:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-date-2012_01_01-datepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-date-2012_01_01-datepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-date-null-datepath·get·responses·400",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-date-null-datepath·get·responses·400"
-     ]
-    },
-    "description": "This should never happen - client code should not accept this"
-   },
-   "responses:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-date-null-datepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-date-null-datepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-datetime-2012_01_01t01-3a01-3a01z-datetimepath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-datetime-2012_01_01t01-3a01-3a01z-datetimepath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '2012-01-01T01:01:01Z' as date-time"
-   },
-   "responses:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-datetime-2012_01_01t01-3a01-3a01z-datetimepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-datetime-2012_01_01t01-3a01-3a01z-datetimepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-datetime-null-datetimepath·get·responses·400",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-datetime-null-datetimepath·get·responses·400"
-     ]
-    },
-    "description": "This should not occur: the test fails if you contact the server"
-   },
-   "responses:45": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-datetime-null-datetimepath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-datetime-null-datetimepath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:46": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-bg9yzw0-base64urlpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-bg9yzw0-base64urlpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received 'lorem' encoded value as 'bG9yZW0' (base64url)"
-   },
-   "responses:47": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-string-bg9yzw0-base64urlpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-bg9yzw0-base64urlpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:48": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·responses·200"
-     ]
-    },
-    "description": "Successfully received /paths/array/ArrayPath1,begin!*'();:@ &=+$,/?#[]end,,/ArrayPath1,begin!*'();:@ &=+$,/?#[]end,,"
-   },
-   "responses:49": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:50": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-int-1460505600-unixtimeurlpath·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-1460505600-unixtimeurlpath·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received date 2016-04-13 encoded value as '1460505600' (Unix time)"
-   },
-   "responses:51": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·paths-int-1460505600-unixtimeurlpath·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-1460505600-unixtimeurlpath·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:52": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-bool-true·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-true·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the true boolean value"
-   },
-   "responses:53": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-bool-true·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-true·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:54": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-bool-false·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-false·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the false Boolean value"
-   },
-   "responses:55": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-bool-false·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-false·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:56": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-bool-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received the null Boolean value"
-   },
-   "responses:57": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-bool-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:58": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-int-1000000·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-1000000·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '1000000' integer value"
-   },
-   "responses:59": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-int-1000000·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-1000000·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:60": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-int-_1000000·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-_1000000·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '-1000000' integer value"
-   },
-   "responses:61": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-int-_1000000·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-_1000000·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:62": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-int-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received null integer value"
-   },
-   "responses:63": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-int-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:64": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-long-10000000000·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-10000000000·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '10000000000' integer value"
-   },
-   "responses:65": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-long-10000000000·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-10000000000·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:66": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-long-_10000000000·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-_10000000000·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '-10000000000' integer value"
-   },
-   "responses:67": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-long-_10000000000·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-_10000000000·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:68": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-long-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received null 64-bit integer value (no param in uri)"
-   },
-   "responses:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-long-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:70": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-float-1-034e-20·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-1-034e-20·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '1.034E+20' numeric value"
-   },
-   "responses:71": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-float-1-034e-20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-1-034e-20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:72": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-float-_1-034e_20·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-_1-034e_20·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '-1.034E-20' numeric value"
-   },
-   "responses:73": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-float-_1-034e_20·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-_1-034e_20·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:74": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-float-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received null numeric value (no query parameter)"
-   },
-   "responses:75": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-float-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:76": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-double-9999999-999·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-9999999-999·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '9999999.999' numeric value"
-   },
-   "responses:77": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-double-9999999-999·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-9999999-999·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:78": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-double-_9999999-999·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-_9999999-999·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '-9999999.999' numeric value"
-   },
-   "responses:79": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-double-_9999999-999·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-_9999999-999·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:80": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-double-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received null numeric value (no query parameter)"
-   },
-   "responses:81": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-double-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:82": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-unicode·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-unicode·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value"
-   },
-   "responses:83": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-unicode·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-unicode·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:84": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received 'begin!*'();:@ &=+$,/?#[]end' url encoded string value"
-   },
-   "responses:85": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:86": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-empty·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '' string value"
-   },
-   "responses:87": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:88": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received null parameter (no query string in url)"
-   },
-   "responses:89": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:90": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-enum-green-20color·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-enum-green-20color·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received 'green color' string value"
-   },
-   "responses:91": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-enum-green-20color·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-enum-green-20color·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:92": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-enum-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-enum-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received null parameter (no query string in url)"
-   },
-   "responses:93": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-enum-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-enum-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:94": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-byte-multibyte·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-multibyte·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array"
-   },
-   "responses:95": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-byte-multibyte·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-multibyte·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:96": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-byte-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-empty·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '' as byte array"
-   },
-   "responses:97": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-byte-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:98": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-byte-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received no query parameters in uri"
-   },
-   "responses:99": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-byte-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:100": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-date-2012_01_01·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-date-2012_01_01·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '2012-01-01' as date"
-   },
-   "responses:101": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-date-2012_01_01·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-date-2012_01_01·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:102": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-date-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-date-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received no query parameters in uri"
-   },
-   "responses:103": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-date-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-date-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:104": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-datetime-2012_01_01t01-3a01-3a01z·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-datetime-2012_01_01t01-3a01-3a01z·get·responses·200"
-     ]
-    },
-    "description": "Successfully Received '2012-01-01T01:01:01Z' as date-time"
-   },
-   "responses:105": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-datetime-2012_01_01t01-3a01-3a01z·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-datetime-2012_01_01t01-3a01-3a01z·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:106": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-datetime-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-datetime-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received no query parameters in uri"
-   },
-   "responses:107": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-datetime-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-datetime-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:108": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-valid·get·responses·200"
-     ]
-    },
-    "description": "Successfully received ?arrayQuery=ArrayQuery1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c"
-   },
-   "responses:109": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:110": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received no query parameters"
-   },
-   "responses:111": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:112": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-empty·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-empty·get·responses·200"
-     ]
-    },
-    "description": "Successfully received no query parameters"
-   },
-   "responses:113": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-empty·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-empty·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:114": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-ssv-string-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-ssv-string-valid·get·responses·200"
-     ]
-    },
-    "description": "Successfully received ?arrayQuery=ArrayQuery1%20begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%20%20"
-   },
-   "responses:115": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-ssv-string-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-ssv-string-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:116": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-tsv-string-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-tsv-string-valid·get·responses·200"
-     ]
-    },
-    "description": "Successfully received ?arrayQuery=ArrayQuery1\tbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend\t\t"
-   },
-   "responses:117": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-tsv-string-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-tsv-string-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:118": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-pipes-string-valid·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-pipes-string-valid·get·responses·200"
-     ]
-    },
-    "description": "Successfully received ?arrayQuery=ArrayQuery1%|begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend||"
-   },
-   "responses:119": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-pipes-string-valid·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-pipes-string-valid·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:120": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·responses·200"
-     ]
-    },
-    "description": "Successfully received all query parameters in uri"
-   },
-   "responses:121": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:122": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·responses·200"
-     ]
-    },
-    "description": "Successfully received all query parameters but global"
-   },
-   "responses:123": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:124": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received only the pathItemQuery query parameter"
-   },
-   "responses:125": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:45"
-      }
-     }
-    }
-   },
-   "responses:126": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·responses·200"
-     ]
-    },
-    "description": "Successfully received only global query parameter"
-   },
-   "responses:127": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·responses·default",
-     "originalLocations": [
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-bool-true-boolpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-bool-false-boolpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-1000000-intpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-_1000000-intpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-long-10000000000-longpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-long-_10000000000-longpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-float-1-034e-20-floatpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-float-_1-034e_20-floatpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-double-9999999-999-doublepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-double-_9999999-999-doublepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-unicode-stringpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-stringpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-empty-stringpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-null-stringpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-enum-green-20color-enumpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-null-enumpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-multibyte-bytepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-empty-bytepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-byte-null-bytepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-date-2012_01_01-datepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-date-null-datepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-datetime-2012_01_01t01-3a01-3a01z-datetimepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-datetime-null-datetimepath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-string-bg9yzw0-base64urlpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·paths-int-1460505600-unixtimeurlpath·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-true·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-false·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-bool-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-1000000·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-_1000000·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-int-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-10000000000·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-_10000000000·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-long-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-1-034e-20·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-_1-034e_20·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-float-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-9999999-999·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-_9999999-999·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-double-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-unicode·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-begin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-empty·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-string-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-enum-green-20color·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-enum-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-multibyte·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-empty·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-byte-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-date-2012_01_01·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-date-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-datetime-2012_01_01t01-3a01-3a01z·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-datetime-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-valid·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-null·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-csv-string-empty·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-ssv-string-valid·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-tsv-string-valid·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·queries-array-pipes-string-valid·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·responses·default",
+      "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·responses·default",
       "http://localhost:3000/swagger/url.json#/components/responses/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·responses·default"
      ]
     },
@@ -7696,7 +5244,24 @@
      ],
      "name": "paths·paths-string-null-stringpath·get·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·paths-string-null-stringpath·get·parameters·0·schema"
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·paths-string-null-stringpath·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-string-null·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-valid·get·parameters·0·schema·items",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-null·get·parameters·0·schema·items",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-empty·get·parameters·0·schema·items",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-ssv-string-valid·get·parameters·0·schema·items",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-tsv-string-valid·get·parameters·0·schema·items",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-pipes-string-valid·get·parameters·0·schema·items",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·1·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·1·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·1·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·1·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/components·parameters·globalstringpath·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/components·parameters·globalstringquery·schema"
      ]
     },
     "type": "string"
@@ -7896,21 +5461,6 @@
     "format": "double",
     "type": "number"
    },
-   "schemas:16": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-string-null·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-string-null·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
    "schemas:23": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -7921,343 +5471,18 @@
      ],
      "name": "paths·queries-array-csv-string-valid·get·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-valid·get·parameters·0·schema"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:24"
-    }
-   },
-   "schemas:24": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-valid·get·parameters·0·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-valid·get·parameters·0·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:25": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-null·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-null·get·parameters·0·schema"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:26"
-    }
-   },
-   "schemas:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-null·get·parameters·0·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-null·get·parameters·0·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:27": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-empty·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-empty·get·parameters·0·schema"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:28"
-    }
-   },
-   "schemas:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-csv-string-empty·get·parameters·0·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-empty·get·parameters·0·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:29": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-ssv-string-valid·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-ssv-string-valid·get·parameters·0·schema"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:30"
-    }
-   },
-   "schemas:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-ssv-string-valid·get·parameters·0·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-ssv-string-valid·get·parameters·0·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:31": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-tsv-string-valid·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-tsv-string-valid·get·parameters·0·schema"
-     ]
-    },
-    "type": "array",
-    "items": {
-     "$ref": "#/components/schemas/schemas:32"
-    }
-   },
-   "schemas:32": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-tsv-string-valid·get·parameters·0·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-tsv-string-valid·get·parameters·0·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:33": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-pipes-string-valid·get·parameters·0·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-valid·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-null·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-csv-string-empty·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-ssv-string-valid·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-tsv-string-valid·get·parameters·0·schema",
       "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-pipes-string-valid·get·parameters·0·schema"
      ]
     },
     "type": "array",
     "items": {
-     "$ref": "#/components/schemas/schemas:34"
+     "$ref": "#/components/schemas/schemas:0"
     }
-   },
-   "schemas:34": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·queries-array-pipes-string-valid·get·parameters·0·schema·items",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-array-pipes-string-valid·get·parameters·0·schema·items"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:35": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:36": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:37": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:38": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:39": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:40": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:41": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:42": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·1·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:43": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·globalstringpath·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/components·parameters·globalstringpath·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:44": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "components·parameters·globalstringquery·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/components·parameters·globalstringquery·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:45": {
     "x-ms-metadata": {
@@ -8308,18 +5533,21 @@
      ],
      "name": "UriColor",
      "originalLocations": [
-      "http://localhost:3000/swagger/url.json#/components/schemas/paths·paths-enum-green-20color-enumpath·get·parameters·0·schema"
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·paths-enum-green-20color-enumpath·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·paths-string-null-enumpath·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-enum-green-20color·get·parameters·0·schema",
+      "http://localhost:3000/swagger/url.json#/components/schemas/paths·queries-enum-null·get·parameters·0·schema"
      ]
     },
-    "x-ms-enum": {
-     "name": "UriColor"
-    },
-    "type": "string",
     "enum": [
      "red color",
      "green color",
      "blue color"
-    ]
+    ],
+    "x-ms-enum": {
+     "name": "UriColor"
+    },
+    "type": "string"
    }
   }
  },

--- a/modelerfour/test/inputs/validation/openapi-document.json
+++ b/modelerfour/test/inputs/validation/openapi-document.json
@@ -105,11 +105,11 @@
       "$ref": "#/components/parameters/parameters:6"
      },
      {
-      "$ref": "#/components/parameters/parameters:2",
+      "$ref": "#/components/parameters/parameters:0",
       "description": "Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+."
      },
      {
-      "$ref": "#/components/parameters/parameters:3",
+      "$ref": "#/components/parameters/parameters:1",
       "description": "Required int multiple of 10 from 100 to 1000."
      },
      {
@@ -126,11 +126,11 @@
     "responses": {
      "200": {
       "description": "A list of caches",
-      "$ref": "#/components/responses/responses:2"
+      "$ref": "#/components/responses/responses:0"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -204,17 +204,17 @@
     "operationId": "postWithConstantInBody",
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:5"
+      "$ref": "#/components/parameters/parameters:4"
      }
     ],
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:1"
+     "$ref": "#/components/requestBodies/requestBodies:0"
     },
     "x-ms-requestBody-index": 1,
     "responses": {
      "200": {
       "description": "Success",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:0"
      }
     }
    }
@@ -232,7 +232,8 @@
      ],
      "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/parameters/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·1"
+      "http://localhost:3000/swagger/validation.json#/components/parameters/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·1",
+      "http://localhost:3000/swagger/validation.json#/components/parameters/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·1"
      ]
     },
     "name": "resourceGroupName",
@@ -254,50 +255,7 @@
      ],
      "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·2",
      "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/parameters/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·2"
-     ]
-    },
-    "name": "id",
-    "in": "path",
-    "description": "Required int multiple of 10 from 100 to 1000.",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:1"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/parameters/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·1"
-     ]
-    },
-    "name": "resourceGroupName",
-    "in": "path",
-    "description": "Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.",
-    "schema": {
-     "$ref": "#/components/schemas/schemas:2"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·2",
-     "originalLocations": [
+      "http://localhost:3000/swagger/validation.json#/components/parameters/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·2",
       "http://localhost:3000/swagger/validation.json#/components/parameters/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·2"
      ]
     },
@@ -305,7 +263,7 @@
     "in": "path",
     "description": "Required int multiple of 10 from 100 to 1000.",
     "schema": {
-     "$ref": "#/components/schemas/schemas:3"
+     "$ref": "#/components/schemas/schemas:1"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -320,30 +278,7 @@
      ],
      "name": "paths·validation-constantsinpath-constantparam-value·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/parameters/paths·validation-constantsinpath-constantparam-value·get·parameters·0"
-     ]
-    },
-    "name": "constantParam",
-    "in": "path",
-    "schema": {
-     "enum": [
-      "constant"
-     ],
-     "type": "string"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·validation-constantsinpath-constantparam-value·post·parameters·0",
-     "originalLocations": [
+      "http://localhost:3000/swagger/validation.json#/components/parameters/paths·validation-constantsinpath-constantparam-value·get·parameters·0",
       "http://localhost:3000/swagger/validation.json#/components/parameters/paths·validation-constantsinpath-constantparam-value·post·parameters·0"
      ]
     },
@@ -412,7 +347,8 @@
      ],
      "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·1·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/schemas/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·1·schema"
+      "http://localhost:3000/swagger/validation.json#/components/schemas/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·1·schema",
+      "http://localhost:3000/swagger/validation.json#/components/schemas/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·1·schema"
      ]
     },
     "maxLength": 10,
@@ -430,42 +366,7 @@
      ],
      "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·2·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/schemas/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·2·schema"
-     ]
-    },
-    "multipleOf": 10,
-    "maximum": 1000,
-    "minimum": 100,
-    "type": "integer"
-   },
-   "schemas:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·1·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/schemas/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·1·schema"
-     ]
-    },
-    "maxLength": 10,
-    "minLength": 3,
-    "pattern": "[a-zA-Z0-9]+",
-    "type": "string"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·2·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/validation.json#/components/schemas/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·parameters·2·schema",
       "http://localhost:3000/swagger/validation.json#/components/schemas/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·2·schema"
      ]
     },
@@ -847,7 +748,9 @@
      ],
      "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/responses/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·responses·200"
+      "http://localhost:3000/swagger/validation.json#/components/responses/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·responses·200",
+      "http://localhost:3000/swagger/validation.json#/components/responses/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·responses·200",
+      "http://localhost:3000/swagger/validation.json#/components/responses/paths·validation-constantsinpath-constantparam-value·post·responses·200"
      ]
     },
     "description": "A list of caches",
@@ -869,50 +772,7 @@
      ],
      "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/responses/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:15"
-      }
-     }
-    }
-   },
-   "responses:2": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/responses/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·responses·200"
-     ]
-    },
-    "description": "A list of caches",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
-   },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·responses·default",
-     "originalLocations": [
+      "http://localhost:3000/swagger/validation.json#/components/responses/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·get·responses·default",
       "http://localhost:3000/swagger/validation.json#/components/responses/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·responses·default"
      ]
     },
@@ -939,28 +799,6 @@
      ]
     },
     "description": "Success"
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·validation-constantsinpath-constantparam-value·post·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/responses/paths·validation-constantsinpath-constantparam-value·post·responses·200"
-     ]
-    },
-    "description": "Success",
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    }
    }
   },
   "requestBodies": {
@@ -974,28 +812,7 @@
      ],
      "name": "paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/validation.json#/components/requestBodies/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/json": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    },
-    "x-ms-requestBody-name": "body"
-   },
-   "requestBodies:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·validation-constantsinpath-constantparam-value·post·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/validation.json#/components/requestBodies/paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·requestbody",
       "http://localhost:3000/swagger/validation.json#/components/requestBodies/paths·validation-constantsinpath-constantparam-value·post·requestbody"
      ]
     },

--- a/modelerfour/test/inputs/xml-service/openapi-document.json
+++ b/modelerfour/test/inputs/xml-service/openapi-document.json
@@ -170,7 +170,7 @@
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:3"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -256,11 +256,11 @@
     "responses": {
      "201": {
       "description": "Indicates success",
-      "$ref": "#/components/responses/responses:6"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:7"
+      "$ref": "#/components/responses/responses:5"
      }
     }
    }
@@ -342,11 +342,11 @@
     "responses": {
      "201": {
       "description": "Indicates success",
-      "$ref": "#/components/responses/responses:9"
+      "$ref": "#/components/responses/responses:1"
      },
      "default": {
       "description": "Unexpected error",
-      "$ref": "#/components/responses/responses:10"
+      "$ref": "#/components/responses/responses:5"
      }
     }
    }
@@ -438,7 +438,7 @@
     "responses": {
      "200": {
       "description": "The empty list.",
-      "$ref": "#/components/responses/responses:12"
+      "$ref": "#/components/responses/responses:4"
      }
     }
    }
@@ -468,13 +468,13 @@
      "XML Operations"
     ],
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:4"
+     "$ref": "#/components/requestBodies/requestBodies:2"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:13"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -520,7 +520,7 @@
     "responses": {
      "200": {
       "description": "The empty lists.",
-      "$ref": "#/components/responses/responses:14"
+      "$ref": "#/components/responses/responses:8"
      }
     }
    }
@@ -556,7 +556,7 @@
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:15"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -638,7 +638,7 @@
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:17"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -684,7 +684,7 @@
     "responses": {
      "200": {
       "description": "The root list.",
-      "$ref": "#/components/responses/responses:18"
+      "$ref": "#/components/responses/responses:16"
      }
     }
    }
@@ -714,13 +714,13 @@
      "XML Operations"
     ],
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:7"
+     "$ref": "#/components/requestBodies/requestBodies:6"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:19"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -766,7 +766,7 @@
     "responses": {
      "200": {
       "description": "The root list.",
-      "$ref": "#/components/responses/responses:20"
+      "$ref": "#/components/responses/responses:16"
      }
     }
    }
@@ -796,13 +796,13 @@
      "XML Operations"
     ],
     "requestBody": {
-     "$ref": "#/components/requestBodies/requestBodies:8"
+     "$ref": "#/components/requestBodies/requestBodies:6"
     },
     "x-ms-requestBody-index": 0,
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:21"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -884,7 +884,7 @@
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:23"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1020,10 +1020,10 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:3"
+      "$ref": "#/components/parameters/parameters:1"
      },
      {
-      "$ref": "#/components/parameters/parameters:4"
+      "$ref": "#/components/parameters/parameters:2"
      }
     ],
     "requestBody": {
@@ -1033,7 +1033,7 @@
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:26"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1118,10 +1118,10 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:7"
+      "$ref": "#/components/parameters/parameters:5"
      },
      {
-      "$ref": "#/components/parameters/parameters:8"
+      "$ref": "#/components/parameters/parameters:6"
      }
     ],
     "requestBody": {
@@ -1131,7 +1131,7 @@
     "responses": {
      "201": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:28"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1176,10 +1176,10 @@
     ],
     "parameters": [
      {
-      "$ref": "#/components/parameters/parameters:9"
+      "$ref": "#/components/parameters/parameters:0"
      },
      {
-      "$ref": "#/components/parameters/parameters:10"
+      "$ref": "#/components/parameters/parameters:6"
      }
     ],
     "responses": {
@@ -1235,7 +1235,7 @@
     "responses": {
      "200": {
       "description": "Indicates success.",
-      "$ref": "#/components/responses/responses:30"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -1321,7 +1321,19 @@
      ],
      "name": "paths·xml-complex_type_ref_no_meta·put·responses·201",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-complex_type_ref_no_meta·put·responses·201"
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-complex_type_ref_no_meta·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-complex_type_ref_with_meta·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-simple·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-wrapped_lists·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_list·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_wrapped_lists·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-root_list·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-root_list_single_item·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_root_list·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_child_element·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-comp-properties-restype-service·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-mycontainer-comp-acl-restype-container·put·responses·201",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-jsoninput·put·responses·200"
      ]
     },
     "description": "Indicates success."
@@ -1348,21 +1360,6 @@
      }
     }
    },
-   "responses:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-complex_type_ref_with_meta·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-complex_type_ref_with_meta·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
-   },
    "responses:4": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1373,7 +1370,8 @@
      ],
      "name": "paths·xml-simple·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-simple·get·responses·200"
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-simple·get·responses·200",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_list·get·responses·200"
      ]
     },
     "description": "The simple XML document",
@@ -1395,44 +1393,9 @@
      ],
      "name": "paths·xml-simple·get·responses·default",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-simple·get·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
-      }
-     }
-    }
-   },
-   "responses:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-simple·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-simple·put·responses·201"
-     ]
-    },
-    "description": "Indicates success"
-   },
-   "responses:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-simple·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-simple·put·responses·default"
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-simple·get·responses·default",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-simple·put·responses·default",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-wrapped_lists·put·responses·default"
      ]
     },
     "description": "Unexpected error",
@@ -1454,7 +1417,8 @@
      ],
      "name": "paths·xml-wrapped_lists·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-wrapped_lists·get·responses·200"
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-wrapped_lists·get·responses·200",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_wrapped_lists·get·responses·200"
      ]
     },
     "description": "The XML document with multiple wrapped lists",
@@ -1462,43 +1426,6 @@
      "application/xml": {
       "schema": {
        "$ref": "#/components/schemas/schemas:21"
-      }
-     }
-    }
-   },
-   "responses:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-wrapped_lists·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-wrapped_lists·put·responses·201"
-     ]
-    },
-    "description": "Indicates success"
-   },
-   "responses:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-wrapped_lists·put·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-wrapped_lists·put·responses·default"
-     ]
-    },
-    "description": "Unexpected error",
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:9"
       }
      }
     }
@@ -1524,80 +1451,6 @@
      }
     }
    },
-   "responses:12": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_list·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_list·get·responses·200"
-     ]
-    },
-    "description": "The empty list.",
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:16"
-      }
-     }
-    }
-   },
-   "responses:13": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_list·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_list·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
-   },
-   "responses:14": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_wrapped_lists·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_wrapped_lists·get·responses·200"
-     ]
-    },
-    "description": "The empty lists.",
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:21"
-      }
-     }
-    }
-   },
-   "responses:15": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_wrapped_lists·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_wrapped_lists·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
-   },
    "responses:16": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1608,7 +1461,9 @@
      ],
      "name": "paths·xml-root_list·get·responses·200",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-root_list·get·responses·200"
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-root_list·get·responses·200",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-root_list_single_item·get·responses·200",
+      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_root_list·get·responses·200"
      ]
     },
     "description": "The root list.",
@@ -1619,95 +1474,6 @@
       }
      }
     }
-   },
-   "responses:17": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-root_list·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-root_list·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
-   },
-   "responses:18": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-root_list_single_item·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-root_list_single_item·get·responses·200"
-     ]
-    },
-    "description": "The root list.",
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:3"
-      }
-     }
-    }
-   },
-   "responses:19": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-root_list_single_item·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-root_list_single_item·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
-   },
-   "responses:20": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_root_list·get·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_root_list·get·responses·200"
-     ]
-    },
-    "description": "The root list.",
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:5"
-      }
-     }
-    }
-   },
-   "responses:21": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_root_list·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_root_list·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
    },
    "responses:22": {
     "x-ms-metadata": {
@@ -1730,21 +1496,6 @@
       }
      }
     }
-   },
-   "responses:23": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_child_element·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-empty_child_element·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
    },
    "responses:24": {
     "x-ms-metadata": {
@@ -1790,21 +1541,6 @@
      }
     }
    },
-   "responses:26": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-comp-properties-restype-service·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-comp-properties-restype-service·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
-   },
    "responses:27": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1827,21 +1563,6 @@
      }
     }
    },
-   "responses:28": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-mycontainer-comp-acl-restype-container·put·responses·201",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-mycontainer-comp-acl-restype-container·put·responses·201"
-     ]
-    },
-    "description": "Indicates success."
-   },
    "responses:29": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -1863,21 +1584,6 @@
       }
      }
     }
-   },
-   "responses:30": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-jsoninput·put·responses·200",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/responses/paths·xml-jsoninput·put·responses·200"
-     ]
-    },
-    "description": "Indicates success."
    },
    "responses:31": {
     "x-ms-metadata": {
@@ -1913,7 +1619,8 @@
      ],
      "name": "paths·xml-headers·get·responses·200·headers·custom_header·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-headers·get·responses·200·headers·custom_header·schema"
+      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-headers·get·responses·200·headers·custom_header·schema",
+      "http://localhost:3000/swagger/xml-service.json#/components/schemas/components·schemas·metadata·additionalproperties"
      ]
     },
     "type": "string"
@@ -1928,7 +1635,9 @@
      ],
      "name": "paths·xml-root_list·get·responses·200·content·application-xml·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-root_list·get·responses·200·content·application-xml·schema"
+      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-root_list·get·responses·200·content·application-xml·schema",
+      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-root_list_single_item·get·responses·200·content·application-xml·schema",
+      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-empty_root_list·get·responses·200·content·application-xml·schema"
      ]
     },
     "type": "array",
@@ -1949,92 +1658,8 @@
      ],
      "name": "paths·xml-root_list·put·requestbody·content·application-xml·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-root_list·put·requestbody·content·application-xml·schema"
-     ]
-    },
-    "type": "array",
-    "xml": {
-     "name": "bananas",
-     "wrapped": true
-    },
-    "items": {
-     "$ref": "#/components/schemas/schemas:26"
-    }
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-root_list_single_item·get·responses·200·content·application-xml·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-root_list_single_item·get·responses·200·content·application-xml·schema"
-     ]
-    },
-    "type": "array",
-    "xml": {
-     "name": "bananas"
-    },
-    "items": {
-     "$ref": "#/components/schemas/schemas:26"
-    }
-   },
-   "schemas:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-root_list_single_item·put·requestbody·content·application-xml·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-root_list_single_item·put·requestbody·content·application-xml·schema"
-     ]
-    },
-    "type": "array",
-    "xml": {
-     "name": "bananas",
-     "wrapped": true
-    },
-    "items": {
-     "$ref": "#/components/schemas/schemas:26"
-    }
-   },
-   "schemas:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_root_list·get·responses·200·content·application-xml·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-empty_root_list·get·responses·200·content·application-xml·schema"
-     ]
-    },
-    "type": "array",
-    "xml": {
-     "name": "bananas"
-    },
-    "items": {
-     "$ref": "#/components/schemas/schemas:26"
-    }
-   },
-   "schemas:6": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_root_list·put·requestbody·content·application-xml·schema",
-     "originalLocations": [
+      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-root_list·put·requestbody·content·application-xml·schema",
+      "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-root_list_single_item·put·requestbody·content·application-xml·schema",
       "http://localhost:3000/swagger/xml-service.json#/components/schemas/paths·xml-empty_root_list·put·requestbody·content·application-xml·schema"
      ]
     },
@@ -3361,23 +2986,8 @@
     },
     "type": "object",
     "additionalProperties": {
-     "$ref": "#/components/schemas/schemas:69"
+     "$ref": "#/components/schemas/schemas:0"
     }
-   },
-   "schemas:69": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "components·schemas·metadata·additionalproperties",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/schemas/components·schemas·metadata·additionalproperties"
-     ]
-    },
-    "type": "string"
    },
    "schemas:70": {
     "x-ms-metadata": {
@@ -4364,7 +3974,8 @@
      ],
      "name": "paths·xml-simple·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-simple·put·requestbody"
+      "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-simple·put·requestbody",
+      "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-empty_list·put·requestbody"
      ]
     },
     "content": {
@@ -4400,29 +4011,6 @@
     "required": true,
     "x-ms-requestBody-name": "wrappedLists"
    },
-   "requestBodies:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_list·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-empty_list·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:16"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "slideshow"
-   },
    "requestBodies:5": {
     "x-ms-metadata": {
      "apiVersions": [
@@ -4456,59 +4044,15 @@
      ],
      "name": "paths·xml-root_list·put·requestbody",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-root_list·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:2"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "bananas"
-   },
-   "requestBodies:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-root_list_single_item·put·requestbody",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-root_list_single_item·put·requestbody"
-     ]
-    },
-    "content": {
-     "application/xml": {
-      "schema": {
-       "$ref": "#/components/schemas/schemas:4"
-      }
-     }
-    },
-    "required": true,
-    "x-ms-requestBody-name": "bananas"
-   },
-   "requestBodies:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-empty_root_list·put·requestbody",
-     "originalLocations": [
+      "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-root_list·put·requestbody",
+      "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-root_list_single_item·put·requestbody",
       "http://localhost:3000/swagger/xml-service.json#/components/requestBodies/paths·xml-empty_root_list·put·requestbody"
      ]
     },
     "content": {
      "application/xml": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:6"
+       "$ref": "#/components/schemas/schemas:2"
       }
      }
     },
@@ -4639,7 +4183,8 @@
      ],
      "name": "paths·xml-comp-list·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-list·get·parameters·0"
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-list·get·parameters·0",
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-list-restype-container·get·parameters·0"
      ]
     },
     "name": "comp",
@@ -4663,7 +4208,8 @@
      ],
      "name": "paths·xml-comp-properties-restype-service·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-properties-restype-service·get·parameters·0"
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-properties-restype-service·get·parameters·0",
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-properties-restype-service·put·parameters·0"
      ]
     },
     "name": "comp",
@@ -4687,54 +4233,7 @@
      ],
      "name": "paths·xml-comp-properties-restype-service·get·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-properties-restype-service·get·parameters·1"
-     ]
-    },
-    "name": "restype",
-    "in": "query",
-    "schema": {
-     "enum": [
-      "service"
-     ],
-     "type": "string"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-comp-properties-restype-service·put·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-properties-restype-service·put·parameters·0"
-     ]
-    },
-    "name": "comp",
-    "in": "query",
-    "schema": {
-     "enum": [
-      "properties"
-     ],
-     "type": "string"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:4": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-comp-properties-restype-service·put·parameters·1",
-     "originalLocations": [
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-properties-restype-service·get·parameters·1",
       "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-comp-properties-restype-service·put·parameters·1"
      ]
     },
@@ -4759,7 +4258,8 @@
      ],
      "name": "paths·xml-mycontainer-comp-acl-restype-container·get·parameters·0",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-acl-restype-container·get·parameters·0"
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-acl-restype-container·get·parameters·0",
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-acl-restype-container·put·parameters·0"
      ]
     },
     "name": "comp",
@@ -4783,102 +4283,8 @@
      ],
      "name": "paths·xml-mycontainer-comp-acl-restype-container·get·parameters·1",
      "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-acl-restype-container·get·parameters·1"
-     ]
-    },
-    "name": "restype",
-    "in": "query",
-    "schema": {
-     "enum": [
-      "container"
-     ],
-     "type": "string"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:7": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-mycontainer-comp-acl-restype-container·put·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-acl-restype-container·put·parameters·0"
-     ]
-    },
-    "name": "comp",
-    "in": "query",
-    "schema": {
-     "enum": [
-      "acl"
-     ],
-     "type": "string"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:8": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-mycontainer-comp-acl-restype-container·put·parameters·1",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-acl-restype-container·put·parameters·1"
-     ]
-    },
-    "name": "restype",
-    "in": "query",
-    "schema": {
-     "enum": [
-      "container"
-     ],
-     "type": "string"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:9": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-mycontainer-comp-list-restype-container·get·parameters·0",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-list-restype-container·get·parameters·0"
-     ]
-    },
-    "name": "comp",
-    "in": "query",
-    "schema": {
-     "enum": [
-      "list"
-     ],
-     "type": "string"
-    },
-    "required": true,
-    "x-ms-parameter-location": "method"
-   },
-   "parameters:10": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "1.0.0"
-     ],
-     "filename": [
-      "mem:///95?oai3.shaken.json"
-     ],
-     "name": "paths·xml-mycontainer-comp-list-restype-container·get·parameters·1",
-     "originalLocations": [
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-acl-restype-container·get·parameters·1",
+      "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-acl-restype-container·put·parameters·1",
       "http://localhost:3000/swagger/xml-service.json#/components/parameters/paths·xml-mycontainer-comp-list-restype-container·get·parameters·1"
      ]
     },

--- a/modelerfour/test/inputs/xms-error-responses/openapi-document.json
+++ b/modelerfour/test/inputs/xms-error-responses/openapi-document.json
@@ -75,7 +75,7 @@
      },
      "default": {
       "description": "default stuff",
-      "$ref": "#/components/responses/responses:5"
+      "$ref": "#/components/responses/responses:1"
      }
     }
    }
@@ -179,7 +179,7 @@
     "in": "path",
     "description": "what action the pet should do",
     "schema": {
-     "$ref": "#/components/schemas/schemas:3"
+     "$ref": "#/components/schemas/schemas:0"
     },
     "required": true,
     "x-ms-parameter-location": "method"
@@ -196,22 +196,9 @@
      ],
      "name": "paths·errorstatuscodes-pets-petid-getpet·get·parameters·0·schema",
      "originalLocations": [
-      "http://localhost:3000/swagger/xms-error-responses.json#/components/schemas/paths·errorstatuscodes-pets-petid-getpet·get·parameters·0·schema"
-     ]
-    },
-    "type": "string"
-   },
-   "schemas:1": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "0.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·errorstatuscodes-pets-petid-getpet·get·responses·400·content·application-json·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xms-error-responses.json#/components/schemas/paths·errorstatuscodes-pets-petid-getpet·get·responses·400·content·application-json·schema"
+      "http://localhost:3000/swagger/xms-error-responses.json#/components/schemas/paths·errorstatuscodes-pets-petid-getpet·get·parameters·0·schema",
+      "http://localhost:3000/swagger/xms-error-responses.json#/components/schemas/paths·errorstatuscodes-pets-petid-getpet·get·responses·400·content·application-json·schema",
+      "http://localhost:3000/swagger/xms-error-responses.json#/components/schemas/paths·errorstatuscodes-pets-dosomething-whataction·post·parameters·0·schema"
      ]
     },
     "type": "string"
@@ -230,21 +217,6 @@
      ]
     },
     "type": "integer"
-   },
-   "schemas:3": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "0.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·errorstatuscodes-pets-dosomething-whataction·post·parameters·0·schema",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xms-error-responses.json#/components/schemas/paths·errorstatuscodes-pets-dosomething-whataction·post·parameters·0·schema"
-     ]
-    },
-    "type": "string"
    },
    "schemas:4": {
     "x-ms-metadata": {
@@ -711,7 +683,8 @@
      ],
      "name": "paths·errorstatuscodes-pets-petid-getpet·get·responses·202",
      "originalLocations": [
-      "http://localhost:3000/swagger/xms-error-responses.json#/components/responses/paths·errorstatuscodes-pets-petid-getpet·get·responses·202"
+      "http://localhost:3000/swagger/xms-error-responses.json#/components/responses/paths·errorstatuscodes-pets-petid-getpet·get·responses·202",
+      "http://localhost:3000/swagger/xms-error-responses.json#/components/responses/paths·errorstatuscodes-pets-petid-getpet·get·responses·default"
      ]
     },
     "description": "something something dark side"
@@ -733,7 +706,7 @@
     "content": {
      "application/json": {
       "schema": {
-       "$ref": "#/components/schemas/schemas:1"
+       "$ref": "#/components/schemas/schemas:0"
       }
      }
     },
@@ -784,21 +757,6 @@
      }
     },
     "x-ms-error-response": true
-   },
-   "responses:5": {
-    "x-ms-metadata": {
-     "apiVersions": [
-      "0.0.0"
-     ],
-     "filename": [
-      "mem:///94?oai3.shaken.json"
-     ],
-     "name": "paths·errorstatuscodes-pets-petid-getpet·get·responses·default",
-     "originalLocations": [
-      "http://localhost:3000/swagger/xms-error-responses.json#/components/responses/paths·errorstatuscodes-pets-petid-getpet·get·responses·default"
-     ]
-    },
-    "description": "default stuff"
    },
    "responses:6": {
     "x-ms-metadata": {

--- a/modelerfour/test/outputs/additionalProperties/flattened.yaml
+++ b/modelerfour/test/outputs/additionalProperties/flattened.yaml
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           - *ref_0
         properties:
         - !<!Property> 
-          schema: !<!BooleanSchema> &ref_9
+          schema: !<!BooleanSchema> &ref_11
             type: boolean
             language: !<!Languages> 
               default:
@@ -62,7 +62,7 @@ schemas: !<!Schemas>
       - *ref_2
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_14
+      schema: !<!NumberSchema> &ref_16
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -96,7 +96,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_8
+      schema: !<!BooleanSchema> &ref_10
         type: boolean
         language: !<!Languages> 
           default:
@@ -117,14 +117,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_33
+  - !<!ObjectSchema> &ref_31
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_15
+      schema: !<!NumberSchema> &ref_17
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_1
-  - !<!ObjectSchema> &ref_34
+  - !<!ObjectSchema> &ref_32
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -187,7 +187,7 @@ schemas: !<!Schemas>
       - *ref_3
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_16
+      schema: !<!NumberSchema> &ref_18
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -221,7 +221,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_10
+      schema: !<!BooleanSchema> &ref_12
         type: boolean
         language: !<!Languages> 
           default:
@@ -242,7 +242,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_35
+  - !<!ObjectSchema> &ref_33
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
       all:
       - !<!DictionarySchema> &ref_4
         type: dictionary
-        elementType: !<!StringSchema> &ref_25
+        elementType: !<!StringSchema> &ref_5
           type: string
           apiVersions:
           - !<!ApiVersion> 
@@ -270,7 +270,69 @@ schemas: !<!Schemas>
       - *ref_4
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_17
+      schema: !<!NumberSchema> &ref_19
+        type: integer
+        precision: 32
+        language: !<!Languages> 
+          default:
+            name: typeForid
+            description: MISSING·SCHEMA-DESCRIPTION-INTEGER
+        protocol: !<!Protocols> {}
+      required: true
+      serializedName: id
+      language: !<!Languages> 
+        default:
+          name: id
+          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: !<!StringSchema> &ref_25
+        type: string
+        apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+        language: !<!Languages> 
+          default:
+            name: PetAPString-name
+            description: MISSING·SCHEMA-DESCRIPTION-STRING
+        protocol: !<!Protocols> {}
+      required: false
+      serializedName: name
+      language: !<!Languages> 
+        default:
+          name: name
+          description: MISSING·SCHEMA-DESCRIPTION-STRING
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: !<!BooleanSchema> &ref_13
+        type: boolean
+        language: !<!Languages> 
+          default:
+            name: typeForstatus
+            description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
+        protocol: !<!Protocols> {}
+      readOnly: true
+      required: false
+      serializedName: status
+      language: !<!Languages> 
+        default:
+          name: status
+          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
+      protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: PetAPString
+        description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
+        namespace: Api100
+    protocol: !<!Protocols> {}
+  - !<!ObjectSchema> &ref_34
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: !<!NumberSchema> &ref_20
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -293,68 +355,6 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: PetAPString-name
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      required: false
-      serializedName: name
-      language: !<!Languages> 
-        default:
-          name: name
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    - !<!Property> 
-      schema: !<!BooleanSchema> &ref_11
-        type: boolean
-        language: !<!Languages> 
-          default:
-            name: typeForstatus
-            description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-        protocol: !<!Protocols> {}
-      readOnly: true
-      required: false
-      serializedName: status
-      language: !<!Languages> 
-        default:
-          name: status
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: PetAPString
-        description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
-        namespace: Api100
-    protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_36
-    type: object
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    properties:
-    - !<!Property> 
-      schema: !<!NumberSchema> &ref_18
-        type: integer
-        precision: 32
-        language: !<!Languages> 
-          default:
-            name: typeForid
-            description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        protocol: !<!Protocols> {}
-      required: true
-      serializedName: id
-      language: !<!Languages> 
-        default:
-          name: id
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    - !<!Property> 
-      schema: !<!StringSchema> &ref_27
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
             name: PetAPInProperties-name
             description: MISSING·SCHEMA-DESCRIPTION-STRING
         protocol: !<!Protocols> {}
@@ -366,7 +366,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_12
+      schema: !<!BooleanSchema> &ref_14
         type: boolean
         language: !<!Languages> 
           default:
@@ -382,9 +382,9 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_6
+      schema: !<!DictionarySchema> &ref_8
         type: dictionary
-        elementType: !<!NumberSchema> &ref_19
+        elementType: !<!NumberSchema> &ref_7
           type: number
           apiVersions:
           - !<!ApiVersion> 
@@ -413,35 +413,26 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_37
+  - !<!ObjectSchema> &ref_35
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     parents: !<!Relations> 
       all:
-      - !<!DictionarySchema> &ref_5
+      - !<!DictionarySchema> &ref_6
         type: dictionary
-        elementType: !<!StringSchema> &ref_28
-          type: string
-          apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-          language: !<!Languages> 
-            default:
-              name: string
-              description: MISSING·SCHEMA-DESCRIPTION-STRING
-          protocol: !<!Protocols> {}
+        elementType: *ref_5
         language: !<!Languages> 
           default:
             name: Dictionary of string
-            description: Dictionary of <components·schemas·petapinpropertieswithapstring·additionalproperties>
+            description: Dictionary of <components·schemas·petapstring·additionalproperties>
         protocol: !<!Protocols> {}
       immediate:
-      - *ref_5
+      - *ref_6
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_20
+      schema: !<!NumberSchema> &ref_21
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -457,7 +448,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_29
+      schema: !<!StringSchema> &ref_27
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -475,7 +466,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_13
+      schema: !<!BooleanSchema> &ref_15
         type: boolean
         language: !<!Languages> 
           default:
@@ -491,7 +482,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_30
+      schema: !<!StringSchema> &ref_28
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -509,30 +500,20 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_7
+      schema: !<!DictionarySchema> &ref_9
         type: dictionary
-        elementType: !<!NumberSchema> &ref_21
-          type: number
-          apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-          precision: 32
-          language: !<!Languages> 
-            default:
-              name: number
-              description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-          protocol: !<!Protocols> {}
+        elementType: *ref_7
         language: !<!Languages> 
           default:
             name: Dictionary of number
-            description: Dictionary of <components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties>
+            description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
         protocol: !<!Protocols> {}
       required: false
       serializedName: additionalProperties
       language: !<!Languages> 
         default:
           name: additionalProperties
-          description: Dictionary of <components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties>
+          description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -544,27 +525,26 @@ schemas: !<!Schemas>
   - *ref_2
   - *ref_3
   - *ref_4
-  - *ref_6
-  - *ref_5
-  - *ref_7
-  booleans:
   - *ref_8
+  - *ref_6
   - *ref_9
+  booleans:
   - *ref_10
   - *ref_11
   - *ref_12
   - *ref_13
-  numbers:
   - *ref_14
   - *ref_15
+  numbers:
   - *ref_16
   - *ref_17
   - *ref_18
   - *ref_19
   - *ref_20
+  - *ref_7
   - *ref_21
   strings:
-  - !<!StringSchema> &ref_31
+  - !<!StringSchema> &ref_29
     type: string
     language: !<!Languages> 
       default:
@@ -574,15 +554,14 @@ schemas: !<!Schemas>
   - *ref_22
   - *ref_23
   - *ref_24
+  - *ref_5
   - *ref_25
   - *ref_26
   - *ref_27
   - *ref_28
-  - *ref_29
-  - *ref_30
 globalParameters:
-- !<!Parameter> &ref_32
-  schema: *ref_31
+- !<!Parameter> &ref_30
+  schema: *ref_29
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -592,7 +571,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: additionalProperties
@@ -606,7 +585,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
         schema: *ref_0
         implementation: Method
@@ -627,11 +606,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/true'
+          path: /additionalProperties/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -648,7 +628,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -673,7 +653,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -694,11 +674,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/true-subclass'
+          path: /additionalProperties/true-subclass
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -715,7 +696,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -740,9 +721,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -761,14 +742,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/type/object'
+          path: /additionalProperties/type/object
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_34
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -782,7 +764,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -807,9 +789,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -828,14 +810,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/type/string'
+          path: /additionalProperties/type/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_35
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -849,7 +832,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -874,9 +857,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -895,14 +878,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/in/properties'
+          path: /additionalProperties/in/properties
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_36
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -916,7 +900,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -941,9 +925,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -962,14 +946,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/in/properties/with/additionalProperties/string'
+          path: /additionalProperties/in/properties/with/additionalProperties/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_37
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -983,7 +968,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/additionalProperties/modeler.yaml
+++ b/modelerfour/test/outputs/additionalProperties/modeler.yaml
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           - *ref_4
         properties:
         - !<!Property> 
-          schema: !<!BooleanSchema> &ref_26
+          schema: !<!BooleanSchema> &ref_24
             type: boolean
             language: !<!Languages> 
               default:
@@ -96,7 +96,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_25
+      schema: !<!BooleanSchema> &ref_23
         type: boolean
         language: !<!Languages> 
           default:
@@ -117,7 +117,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_32
+  - !<!ObjectSchema> &ref_30
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_5
-  - !<!ObjectSchema> &ref_34
+  - !<!ObjectSchema> &ref_32
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -221,7 +221,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_27
+      schema: !<!BooleanSchema> &ref_25
         type: boolean
         language: !<!Languages> 
           default:
@@ -242,7 +242,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_35
+  - !<!ObjectSchema> &ref_33
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -304,7 +304,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_28
+      schema: !<!BooleanSchema> &ref_26
         type: boolean
         language: !<!Languages> 
           default:
@@ -325,7 +325,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_36
+  - !<!ObjectSchema> &ref_34
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -366,7 +366,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_29
+      schema: !<!BooleanSchema> &ref_27
         type: boolean
         language: !<!Languages> 
           default:
@@ -384,7 +384,7 @@ schemas: !<!Schemas>
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_12
         type: dictionary
-        elementType: !<!NumberSchema> &ref_22
+        elementType: !<!NumberSchema> &ref_1
           type: number
           apiVersions:
           - !<!ApiVersion> 
@@ -413,7 +413,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_37
+  - !<!ObjectSchema> &ref_35
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -422,26 +422,17 @@ schemas: !<!Schemas>
       all:
       - !<!DictionarySchema> &ref_16
         type: dictionary
-        elementType: !<!StringSchema> &ref_1
-          type: string
-          apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-          language: !<!Languages> 
-            default:
-              name: components·schemas·petapinpropertieswithapstring·additionalproperties
-              description: MISSING·SCHEMA-DESCRIPTION-STRING
-          protocol: !<!Protocols> {}
+        elementType: *ref_0
         language: !<!Languages> 
           default:
             name: PetAPInPropertiesWithAPString
-            description: Dictionary of <components·schemas·petapinpropertieswithapstring·additionalproperties>
+            description: Dictionary of <components·schemas·petapstring·additionalproperties>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_16
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_23
+      schema: !<!NumberSchema> &ref_22
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -475,7 +466,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_30
+      schema: !<!BooleanSchema> &ref_28
         type: boolean
         language: !<!Languages> 
           default:
@@ -511,28 +502,18 @@ schemas: !<!Schemas>
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_15
         type: dictionary
-        elementType: !<!NumberSchema> &ref_24
-          type: number
-          apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-          precision: 32
-          language: !<!Languages> 
-            default:
-              name: components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties
-              description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-          protocol: !<!Protocols> {}
+        elementType: *ref_1
         language: !<!Languages> 
           default:
             name: PetAPInPropertiesWithAPString-additionalProperties
-            description: Dictionary of <components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties>
+            description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
         protocol: !<!Protocols> {}
       required: false
       serializedName: additionalProperties
       language: !<!Languages> 
         default:
           name: additionalProperties
-          description: Dictionary of <components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties>
+          description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -548,23 +529,22 @@ schemas: !<!Schemas>
   - *ref_16
   - *ref_15
   booleans:
+  - *ref_23
+  - *ref_24
   - *ref_25
   - *ref_26
   - *ref_27
   - *ref_28
-  - *ref_29
-  - *ref_30
   numbers:
   - *ref_17
   - *ref_18
   - *ref_19
   - *ref_20
   - *ref_21
+  - *ref_1
   - *ref_22
-  - *ref_23
-  - *ref_24
   strings:
-  - !<!StringSchema> &ref_31
+  - !<!StringSchema> &ref_29
     type: string
     language: !<!Languages> 
       default:
@@ -577,12 +557,11 @@ schemas: !<!Schemas>
   - *ref_0
   - *ref_9
   - *ref_11
-  - *ref_1
   - *ref_13
   - *ref_14
 globalParameters:
-- !<!Parameter> &ref_33
-  schema: *ref_31
+- !<!Parameter> &ref_31
+  schema: *ref_29
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -592,7 +571,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: additionalProperties
@@ -606,7 +585,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_31
       - !<!Parameter> 
         schema: *ref_4
         implementation: Method
@@ -627,11 +606,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/true'
+          path: /additionalProperties/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -648,7 +628,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -673,7 +653,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_31
       - !<!Parameter> 
         schema: *ref_5
         implementation: Method
@@ -694,11 +674,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/true-subclass'
+          path: /additionalProperties/true-subclass
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -715,7 +696,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -740,9 +721,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_31
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -761,14 +742,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/type/object'
+          path: /additionalProperties/type/object
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_34
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -782,7 +764,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -807,9 +789,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_31
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -828,14 +810,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/type/string'
+          path: /additionalProperties/type/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_35
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -849,7 +832,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -874,9 +857,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_31
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -895,14 +878,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/in/properties'
+          path: /additionalProperties/in/properties
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_36
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -916,7 +900,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -941,9 +925,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_31
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -962,14 +946,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/in/properties/with/additionalProperties/string'
+          path: /additionalProperties/in/properties/with/additionalProperties/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_37
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -983,7 +968,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/additionalProperties/namer.yaml
+++ b/modelerfour/test/outputs/additionalProperties/namer.yaml
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           - *ref_0
         properties:
         - !<!Property> 
-          schema: !<!BooleanSchema> &ref_9
+          schema: !<!BooleanSchema> &ref_11
             type: boolean
             language: !<!Languages> 
               default:
@@ -62,7 +62,7 @@ schemas: !<!Schemas>
       - *ref_2
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_14
+      schema: !<!NumberSchema> &ref_16
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -96,7 +96,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_8
+      schema: !<!BooleanSchema> &ref_10
         type: boolean
         language: !<!Languages> 
           default:
@@ -117,14 +117,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_33
+  - !<!ObjectSchema> &ref_31
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_15
+      schema: !<!NumberSchema> &ref_17
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_1
-  - !<!ObjectSchema> &ref_34
+  - !<!ObjectSchema> &ref_32
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -187,7 +187,7 @@ schemas: !<!Schemas>
       - *ref_3
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_16
+      schema: !<!NumberSchema> &ref_18
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -221,7 +221,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_10
+      schema: !<!BooleanSchema> &ref_12
         type: boolean
         language: !<!Languages> 
           default:
@@ -242,7 +242,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_35
+  - !<!ObjectSchema> &ref_33
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
       all:
       - !<!DictionarySchema> &ref_4
         type: dictionary
-        elementType: !<!StringSchema> &ref_25
+        elementType: !<!StringSchema> &ref_5
           type: string
           apiVersions:
           - !<!ApiVersion> 
@@ -270,7 +270,69 @@ schemas: !<!Schemas>
       - *ref_4
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_17
+      schema: !<!NumberSchema> &ref_19
+        type: integer
+        precision: 32
+        language: !<!Languages> 
+          default:
+            name: typeForid
+            description: MISSING·SCHEMA-DESCRIPTION-INTEGER
+        protocol: !<!Protocols> {}
+      required: true
+      serializedName: id
+      language: !<!Languages> 
+        default:
+          name: id
+          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: !<!StringSchema> &ref_25
+        type: string
+        apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+        language: !<!Languages> 
+          default:
+            name: PetAPString-name
+            description: MISSING·SCHEMA-DESCRIPTION-STRING
+        protocol: !<!Protocols> {}
+      required: false
+      serializedName: name
+      language: !<!Languages> 
+        default:
+          name: name
+          description: MISSING·SCHEMA-DESCRIPTION-STRING
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: !<!BooleanSchema> &ref_13
+        type: boolean
+        language: !<!Languages> 
+          default:
+            name: typeForstatus
+            description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
+        protocol: !<!Protocols> {}
+      readOnly: true
+      required: false
+      serializedName: status
+      language: !<!Languages> 
+        default:
+          name: status
+          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
+      protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: PetAPString
+        description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
+        namespace: Api100
+    protocol: !<!Protocols> {}
+  - !<!ObjectSchema> &ref_34
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: !<!NumberSchema> &ref_20
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -293,68 +355,6 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: PetAPString-name
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      required: false
-      serializedName: name
-      language: !<!Languages> 
-        default:
-          name: name
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    - !<!Property> 
-      schema: !<!BooleanSchema> &ref_11
-        type: boolean
-        language: !<!Languages> 
-          default:
-            name: typeForstatus
-            description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-        protocol: !<!Protocols> {}
-      readOnly: true
-      required: false
-      serializedName: status
-      language: !<!Languages> 
-        default:
-          name: status
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: PetAPString
-        description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
-        namespace: Api100
-    protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_36
-    type: object
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    properties:
-    - !<!Property> 
-      schema: !<!NumberSchema> &ref_18
-        type: integer
-        precision: 32
-        language: !<!Languages> 
-          default:
-            name: typeForid
-            description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        protocol: !<!Protocols> {}
-      required: true
-      serializedName: id
-      language: !<!Languages> 
-        default:
-          name: id
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    - !<!Property> 
-      schema: !<!StringSchema> &ref_27
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
             name: PetAPInProperties-name
             description: MISSING·SCHEMA-DESCRIPTION-STRING
         protocol: !<!Protocols> {}
@@ -366,7 +366,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_12
+      schema: !<!BooleanSchema> &ref_14
         type: boolean
         language: !<!Languages> 
           default:
@@ -382,9 +382,9 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_6
+      schema: !<!DictionarySchema> &ref_8
         type: dictionary
-        elementType: !<!NumberSchema> &ref_19
+        elementType: !<!NumberSchema> &ref_7
           type: number
           apiVersions:
           - !<!ApiVersion> 
@@ -413,35 +413,26 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_37
+  - !<!ObjectSchema> &ref_35
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     parents: !<!Relations> 
       all:
-      - !<!DictionarySchema> &ref_5
+      - !<!DictionarySchema> &ref_6
         type: dictionary
-        elementType: !<!StringSchema> &ref_28
-          type: string
-          apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-          language: !<!Languages> 
-            default:
-              name: string
-              description: MISSING·SCHEMA-DESCRIPTION-STRING
-          protocol: !<!Protocols> {}
+        elementType: *ref_5
         language: !<!Languages> 
           default:
             name: Dictionary of string
-            description: Dictionary of <components·schemas·petapinpropertieswithapstring·additionalproperties>
+            description: Dictionary of <components·schemas·petapstring·additionalproperties>
         protocol: !<!Protocols> {}
       immediate:
-      - *ref_5
+      - *ref_6
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_20
+      schema: !<!NumberSchema> &ref_21
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -457,7 +448,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_29
+      schema: !<!StringSchema> &ref_27
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -475,7 +466,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_13
+      schema: !<!BooleanSchema> &ref_15
         type: boolean
         language: !<!Languages> 
           default:
@@ -491,7 +482,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_30
+      schema: !<!StringSchema> &ref_28
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -509,30 +500,20 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_7
+      schema: !<!DictionarySchema> &ref_9
         type: dictionary
-        elementType: !<!NumberSchema> &ref_21
-          type: number
-          apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-          precision: 32
-          language: !<!Languages> 
-            default:
-              name: number
-              description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-          protocol: !<!Protocols> {}
+        elementType: *ref_7
         language: !<!Languages> 
           default:
             name: Dictionary of number
-            description: Dictionary of <components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties>
+            description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
         protocol: !<!Protocols> {}
       required: false
       serializedName: additionalProperties
       language: !<!Languages> 
         default:
           name: additionalProperties
-          description: Dictionary of <components·schemas·petapinpropertieswithapstring·properties·additionalproperties·additionalproperties>
+          description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -544,27 +525,26 @@ schemas: !<!Schemas>
   - *ref_2
   - *ref_3
   - *ref_4
-  - *ref_6
-  - *ref_5
-  - *ref_7
-  booleans:
   - *ref_8
+  - *ref_6
   - *ref_9
+  booleans:
   - *ref_10
   - *ref_11
   - *ref_12
   - *ref_13
-  numbers:
   - *ref_14
   - *ref_15
+  numbers:
   - *ref_16
   - *ref_17
   - *ref_18
   - *ref_19
   - *ref_20
+  - *ref_7
   - *ref_21
   strings:
-  - !<!StringSchema> &ref_31
+  - !<!StringSchema> &ref_29
     type: string
     language: !<!Languages> 
       default:
@@ -574,15 +554,14 @@ schemas: !<!Schemas>
   - *ref_22
   - *ref_23
   - *ref_24
+  - *ref_5
   - *ref_25
   - *ref_26
   - *ref_27
   - *ref_28
-  - *ref_29
-  - *ref_30
 globalParameters:
-- !<!Parameter> &ref_32
-  schema: *ref_31
+- !<!Parameter> &ref_30
+  schema: *ref_29
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -592,7 +571,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: additionalProperties
@@ -606,7 +585,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
         schema: *ref_0
         implementation: Method
@@ -627,11 +606,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/true'
+          path: /additionalProperties/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -648,7 +628,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -673,7 +653,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -694,11 +674,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/true-subclass'
+          path: /additionalProperties/true-subclass
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -715,7 +696,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -740,9 +721,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -761,14 +742,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/type/object'
+          path: /additionalProperties/type/object
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_34
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -782,7 +764,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -807,9 +789,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -828,14 +810,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/type/string'
+          path: /additionalProperties/type/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_35
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -849,7 +832,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -874,9 +857,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -895,14 +878,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/in/properties'
+          path: /additionalProperties/in/properties
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_36
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -916,7 +900,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -941,9 +925,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_32
+      - *ref_30
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -962,14 +946,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/additionalProperties/in/properties/with/additionalProperties/string'
+          path: /additionalProperties/in/properties/with/additionalProperties/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_37
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -983,7 +968,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-parameter-grouping/flattened.yaml
+++ b/modelerfour/test/outputs/azure-parameter-grouping/flattened.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_8
+  - !<!ObjectSchema> &ref_7
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -58,7 +58,7 @@ schemas: !<!Schemas>
         name: integer
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_7
+  - !<!NumberSchema> &ref_6
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -70,54 +70,6 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
   - *ref_0
-  - !<!NumberSchema> &ref_10
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   strings:
   - !<!StringSchema> &ref_2
     type: string
@@ -136,57 +88,7 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_6
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_1
-  - !<!StringSchema> &ref_9
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_11
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_3
   schema: *ref_2
@@ -199,7 +101,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-parameter-grouping
@@ -218,7 +120,7 @@ operationGroups:
         schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: &ref_8 {}
         language: !<!Languages> 
           default:
             name: customHeader
@@ -230,7 +132,7 @@ operationGroups:
         schema: *ref_5
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: &ref_9 {}
         language: !<!Languages> 
           default:
             name: query
@@ -239,7 +141,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -252,7 +154,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -272,11 +174,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/parameterGrouping/postRequired/{path}'
+          path: '/parameterGrouping/postRequired/{path}'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -289,7 +192,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -316,10 +219,10 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: *ref_8
         language: !<!Languages> 
           default:
             name: customHeader
@@ -328,10 +231,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_5
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: *ref_9
         language: !<!Languages> 
           default:
             name: query
@@ -345,8 +248,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/postOptional'
+          path: /parameterGrouping/postOptional
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -359,7 +263,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -384,10 +288,10 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_10
             name: first-parameter-group
         language: !<!Languages> 
           default:
@@ -397,10 +301,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_5
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_11
             name: first-parameter-group
         language: !<!Languages> 
           default:
@@ -410,7 +314,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_4
         implementation: Method
         extensions:
           x-ms-parameter-grouping:
@@ -423,7 +327,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_5
         implementation: Method
         extensions:
           x-ms-parameter-grouping:
@@ -441,8 +345,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/postMultipleParameterGroups'
+          path: /parameterGrouping/postMultipleParameterGroups
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -455,7 +360,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -480,11 +385,10 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            name: first-parameter-group
+          x-ms-parameter-grouping: *ref_10
         language: !<!Languages> 
           default:
             name: header-one
@@ -493,11 +397,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_5
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            name: first-parameter-group
+          x-ms-parameter-grouping: *ref_11
         language: !<!Languages> 
           default:
             name: query-one
@@ -511,8 +414,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/sharedParameterGroupObject'
+          path: /parameterGrouping/sharedParameterGroupObject
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -525,7 +429,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-parameter-grouping/modeler.yaml
+++ b/modelerfour/test/outputs/azure-parameter-grouping/modeler.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_7
+  - !<!ObjectSchema> &ref_6
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -58,7 +58,7 @@ schemas: !<!Schemas>
         name: paths·parametergrouping-postrequired-path·post·parameters·1·schema
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_6
+  - !<!NumberSchema> &ref_5
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -70,54 +70,6 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
   - *ref_0
-  - !<!NumberSchema> &ref_10
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-postoptional·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-postmultipleparametergroups·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-postmultipleparametergroups·post·parameters·3·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-sharedparametergroupobject·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   strings:
   - !<!StringSchema> &ref_2
     type: string
@@ -136,59 +88,9 @@ schemas: !<!Schemas>
         name: paths·parametergrouping-postrequired-path·post·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_5
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-postrequired-path·post·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_1
-  - !<!StringSchema> &ref_9
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-postoptional·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_11
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-postmultipleparametergroups·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-postmultipleparametergroups·post·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·parametergrouping-sharedparametergroupobject·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_8
+- !<!Parameter> &ref_7
   schema: *ref_2
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
@@ -199,7 +101,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-parameter-grouping
@@ -213,12 +115,12 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_8
+      - *ref_7
       - !<!Parameter> 
         schema: *ref_3
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: &ref_8 {}
         language: !<!Languages> 
           default:
             name: customHeader
@@ -230,7 +132,7 @@ operationGroups:
         schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: &ref_9 {}
         language: !<!Languages> 
           default:
             name: query
@@ -239,7 +141,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_5
+        schema: *ref_3
         implementation: Method
         required: true
         extensions:
@@ -252,7 +154,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_5
         implementation: Method
         required: true
         extensions:
@@ -272,11 +174,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/parameterGrouping/postRequired/{path}'
+          path: '/parameterGrouping/postRequired/{path}'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -289,7 +192,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -314,12 +217,12 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_8
+      - *ref_7
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_3
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: *ref_8
         language: !<!Languages> 
           default:
             name: customHeader
@@ -328,10 +231,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: *ref_9
         language: !<!Languages> 
           default:
             name: query
@@ -345,8 +248,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/postOptional'
+          path: /parameterGrouping/postOptional
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -359,7 +263,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -382,12 +286,12 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_8
+      - *ref_7
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_3
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_10
             name: first-parameter-group
         language: !<!Languages> 
           default:
@@ -397,10 +301,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_11
             name: first-parameter-group
         language: !<!Languages> 
           default:
@@ -410,7 +314,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_3
         implementation: Method
         extensions:
           x-ms-parameter-grouping:
@@ -423,7 +327,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_4
         implementation: Method
         extensions:
           x-ms-parameter-grouping:
@@ -441,8 +345,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/postMultipleParameterGroups'
+          path: /parameterGrouping/postMultipleParameterGroups
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -455,7 +360,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -478,13 +383,12 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_8
+      - *ref_7
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_3
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            name: first-parameter-group
+          x-ms-parameter-grouping: *ref_10
         language: !<!Languages> 
           default:
             name: header-one
@@ -493,11 +397,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            name: first-parameter-group
+          x-ms-parameter-grouping: *ref_11
         language: !<!Languages> 
           default:
             name: query-one
@@ -511,8 +414,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/sharedParameterGroupObject'
+          path: /parameterGrouping/sharedParameterGroupObject
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -525,7 +429,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-parameter-grouping/namer.yaml
+++ b/modelerfour/test/outputs/azure-parameter-grouping/namer.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_8
+  - !<!ObjectSchema> &ref_7
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -58,7 +58,7 @@ schemas: !<!Schemas>
         name: integer
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_7
+  - !<!NumberSchema> &ref_6
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -70,54 +70,6 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
   - *ref_0
-  - !<!NumberSchema> &ref_10
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   strings:
   - !<!StringSchema> &ref_2
     type: string
@@ -136,57 +88,7 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_6
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_1
-  - !<!StringSchema> &ref_9
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_11
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_3
   schema: *ref_2
@@ -199,7 +101,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-parameter-grouping
@@ -218,7 +120,7 @@ operationGroups:
         schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: &ref_8 {}
         language: !<!Languages> 
           default:
             name: customHeader
@@ -230,7 +132,7 @@ operationGroups:
         schema: *ref_5
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: &ref_9 {}
         language: !<!Languages> 
           default:
             name: query
@@ -239,7 +141,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -252,7 +154,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -272,11 +174,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/parameterGrouping/postRequired/{path}'
+          path: '/parameterGrouping/postRequired/{path}'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -289,7 +192,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -316,10 +219,10 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: *ref_8
         language: !<!Languages> 
           default:
             name: customHeader
@@ -328,10 +231,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_5
         implementation: Method
         extensions:
-          x-ms-parameter-grouping: {}
+          x-ms-parameter-grouping: *ref_9
         language: !<!Languages> 
           default:
             name: query
@@ -345,8 +248,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/postOptional'
+          path: /parameterGrouping/postOptional
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -359,7 +263,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -384,10 +288,10 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_10
             name: first-parameter-group
         language: !<!Languages> 
           default:
@@ -397,10 +301,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_5
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_11
             name: first-parameter-group
         language: !<!Languages> 
           default:
@@ -410,7 +314,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_4
         implementation: Method
         extensions:
           x-ms-parameter-grouping:
@@ -423,7 +327,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_5
         implementation: Method
         extensions:
           x-ms-parameter-grouping:
@@ -441,8 +345,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/postMultipleParameterGroups'
+          path: /parameterGrouping/postMultipleParameterGroups
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -455,7 +360,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -480,11 +385,10 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_4
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            name: first-parameter-group
+          x-ms-parameter-grouping: *ref_10
         language: !<!Languages> 
           default:
             name: header-one
@@ -493,11 +397,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_5
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            name: first-parameter-group
+          x-ms-parameter-grouping: *ref_11
         language: !<!Languages> 
           default:
             name: query-one
@@ -511,8 +414,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/parameterGrouping/sharedParameterGroupObject'
+          path: /parameterGrouping/sharedParameterGroupObject
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -525,7 +429,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-report/flattened.yaml
+++ b/modelerfour/test/outputs/azure-report/flattened.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-report
@@ -129,8 +129,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/report/azure'
+          path: /report/azure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/azure-report/modeler.yaml
+++ b/modelerfour/test/outputs/azure-report/modeler.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-report
@@ -129,8 +129,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/report/azure'
+          path: /report/azure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5

--- a/modelerfour/test/outputs/azure-report/namer.yaml
+++ b/modelerfour/test/outputs/azure-report/namer.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-report
@@ -129,8 +129,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/report/azure'
+          path: /report/azure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/azure-resource-x/flattened.yaml
+++ b/modelerfour/test/outputs/azure-resource-x/flattened.yaml
@@ -245,7 +245,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
-  - !<!ObjectSchema> &ref_21
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -300,6 +300,14 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   dictionaries:
   - *ref_3
+  - !<!DictionarySchema> &ref_21
+    type: dictionary
+    elementType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: DictionaryOfFlattenedProduct
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
   - *ref_4
   arrays:
   - !<!ArraySchema> &ref_18
@@ -356,7 +364,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: azure-resource-x
@@ -391,11 +399,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -440,8 +449,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_20
@@ -483,7 +493,7 @@ operationGroups:
       parameters:
       - *ref_17
       - !<!Parameter> 
-        schema: *ref_4
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -502,11 +512,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -551,11 +562,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_4
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -594,7 +606,7 @@ operationGroups:
       parameters:
       - *ref_17
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -613,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -662,11 +675,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-resource-x/modeler.yaml
+++ b/modelerfour/test/outputs/azure-resource-x/modeler.yaml
@@ -245,7 +245,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_8
   - *ref_10
-  - !<!ObjectSchema> &ref_21
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -300,6 +300,14 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   dictionaries:
   - *ref_11
+  - !<!DictionarySchema> &ref_21
+    type: dictionary
+    elementType: *ref_8
+    language: !<!Languages> 
+      default:
+        name: paths·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
   - *ref_12
   arrays:
   - !<!ArraySchema> &ref_17
@@ -356,7 +364,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: azure-resource-x
@@ -391,11 +399,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -440,8 +449,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_20
@@ -483,7 +493,7 @@ operationGroups:
       parameters:
       - *ref_19
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -502,11 +512,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -551,11 +562,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_12
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -594,7 +606,7 @@ operationGroups:
       parameters:
       - *ref_19
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -613,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -662,11 +675,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-resource-x/namer.yaml
+++ b/modelerfour/test/outputs/azure-resource-x/namer.yaml
@@ -245,7 +245,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
-  - !<!ObjectSchema> &ref_21
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -300,6 +300,14 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   dictionaries:
   - *ref_3
+  - !<!DictionarySchema> &ref_21
+    type: dictionary
+    elementType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: DictionaryOfFlattenedProduct
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
   - *ref_4
   arrays:
   - !<!ArraySchema> &ref_18
@@ -356,7 +364,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: azure-resource-x
@@ -391,11 +399,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -440,8 +449,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_20
@@ -483,7 +493,7 @@ operationGroups:
       parameters:
       - *ref_17
       - !<!Parameter> 
-        schema: *ref_4
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -502,11 +512,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -551,11 +562,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_4
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -594,7 +606,7 @@ operationGroups:
       parameters:
       - *ref_17
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -613,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -662,11 +675,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-resource/flattened.yaml
+++ b/modelerfour/test/outputs/azure-resource/flattened.yaml
@@ -245,7 +245,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
-  - !<!ObjectSchema> &ref_21
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -300,6 +300,14 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   dictionaries:
   - *ref_3
+  - !<!DictionarySchema> &ref_21
+    type: dictionary
+    elementType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: DictionaryOfFlattenedProduct
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
   - *ref_4
   arrays:
   - !<!ArraySchema> &ref_18
@@ -356,7 +364,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: azure-resource
@@ -391,11 +399,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -440,8 +449,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_20
@@ -483,7 +493,7 @@ operationGroups:
       parameters:
       - *ref_17
       - !<!Parameter> 
-        schema: *ref_4
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -502,11 +512,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -551,11 +562,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_4
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -594,7 +606,7 @@ operationGroups:
       parameters:
       - *ref_17
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -613,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -662,11 +675,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-resource/modeler.yaml
+++ b/modelerfour/test/outputs/azure-resource/modeler.yaml
@@ -245,7 +245,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_8
   - *ref_10
-  - !<!ObjectSchema> &ref_21
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -300,6 +300,14 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   dictionaries:
   - *ref_11
+  - !<!DictionarySchema> &ref_21
+    type: dictionary
+    elementType: *ref_8
+    language: !<!Languages> 
+      default:
+        name: paths·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
   - *ref_12
   arrays:
   - !<!ArraySchema> &ref_17
@@ -356,7 +364,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: azure-resource
@@ -391,11 +399,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -440,8 +449,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_20
@@ -483,7 +493,7 @@ operationGroups:
       parameters:
       - *ref_19
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -502,11 +512,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -551,11 +562,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_12
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -594,7 +606,7 @@ operationGroups:
       parameters:
       - *ref_19
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -613,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -662,11 +675,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-resource/namer.yaml
+++ b/modelerfour/test/outputs/azure-resource/namer.yaml
@@ -245,7 +245,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
-  - !<!ObjectSchema> &ref_21
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -300,6 +300,14 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   dictionaries:
   - *ref_3
+  - !<!DictionarySchema> &ref_21
+    type: dictionary
+    elementType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: DictionaryOfFlattenedProduct
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
   - *ref_4
   arrays:
   - !<!ArraySchema> &ref_18
@@ -356,7 +364,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: azure-resource
@@ -391,11 +399,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -440,8 +449,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/array'
+          path: /azure/resource-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_20
@@ -483,7 +493,7 @@ operationGroups:
       parameters:
       - *ref_17
       - !<!Parameter> 
-        schema: *ref_4
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -502,11 +512,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -551,11 +562,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/dictionary'
+          path: /azure/resource-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_4
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -594,7 +606,7 @@ operationGroups:
       parameters:
       - *ref_17
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -613,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -662,11 +675,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azure/resource-flatten/resourcecollection'
+          path: /azure/resource-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/azure-special-properties/flattened.yaml
+++ b/modelerfour/test/outputs/azure-special-properties/flattened.yaml
@@ -122,7 +122,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   constants:
   - *ref_0
-  - !<!ConstantSchema> &ref_11
+  - !<!ConstantSchema> &ref_10
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -137,6 +137,34 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-07-01-preview
+        description: Api Version (2015-07-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_12
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-07-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-07-01-preview
+        description: Api Version (2015-07-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_13
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-07-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
     language: !<!Languages> 
       default:
         name: ApiVersion-2015-07-01-preview
@@ -170,21 +198,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_20
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-07-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-07-01-preview
-        description: Api Version (2015-07-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
+  - !<!ConstantSchema> &ref_14
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -212,7 +226,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_22
+  - !<!ConstantSchema> &ref_15
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -240,21 +254,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-07-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-07-01-preview
-        description: Api Version (2015-07-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
+  - !<!ConstantSchema> &ref_21
     type: constant
     value: !<!ConstantValue> 
       value: path1/path2/path3
@@ -268,7 +268,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
+  - !<!ConstantSchema> &ref_23
     type: constant
     value: !<!ConstantValue> 
       value: value1&q2=value2&q3=value3
@@ -285,7 +285,7 @@ schemas: !<!Schemas>
   numbers:
   - *ref_2
   - *ref_3
-  - !<!NumberSchema> &ref_32
+  - !<!NumberSchema> &ref_24
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -308,197 +308,25 @@ schemas: !<!Schemas>
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
+        header: foo-request-id
     protocol: !<!Protocols> {}
   - *ref_5
-  - !<!StringSchema> &ref_10
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_14
+  - !<!StringSchema> &ref_11
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
+  - !<!StringSchema> &ref_20
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
+  - !<!StringSchema> &ref_22
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: foo-request-id
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: foo-request-id
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: foo-request-id
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
     language: !<!Languages> 
       default:
         name: string
@@ -517,7 +345,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-special-properties
@@ -538,8 +366,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/overwrite/x-ms-client-request-id/method/'
+          path: /azurespecials/overwrite/x-ms-client-request-id/method/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -589,8 +418,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/overwrite/x-ms-client-request-id/via-param/method/'
+          path: /azurespecials/overwrite/x-ms-client-request-id/via-param/method/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -636,7 +466,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -652,8 +482,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -691,7 +522,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -707,8 +538,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -746,7 +578,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -757,7 +589,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_10
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -773,8 +605,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -812,7 +645,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -828,8 +661,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -867,7 +701,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -883,8 +717,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -930,7 +765,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -946,8 +781,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -985,13 +821,13 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: subscriptionId
-            description: 'This should appear as a method parameter, use value null, client-side validation should prvenet the call'
+            description: 'This should appear as a method parameter, use value ''1234-5678-9012-3456'''
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1001,8 +837,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1040,7 +877,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_11
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1056,8 +893,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1095,13 +933,13 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: subscriptionId
-            description: 'The subscriptionId, which appears in the path, the value is always ''1234-5678-9012-3456'''
+            description: 'This should appear as a method parameter, use value ''1234-5678-9012-3456'''
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1111,8 +949,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1158,7 +997,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1174,8 +1013,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1213,7 +1053,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1229,8 +1069,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview'
+          path: /azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1268,7 +1109,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1284,8 +1125,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1323,7 +1165,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_15
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1339,8 +1181,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1386,7 +1229,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_16
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1402,8 +1245,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/method/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1441,7 +1285,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_17
         implementation: Client
         language: !<!Languages> 
           default:
@@ -1456,8 +1300,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/local/null'
+          path: /azurespecials/apiVersion/method/string/none/query/local/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1495,7 +1340,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_18
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1511,8 +1356,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/path/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/path/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1550,7 +1396,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_19
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1566,8 +1412,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/swagger/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/swagger/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1613,7 +1460,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -1631,8 +1478,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1670,7 +1518,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -1688,8 +1536,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1727,7 +1576,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1745,8 +1594,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1784,7 +1634,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1800,8 +1650,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/query/valid'
+          path: /azurespecials/skipUrlEncoding/method/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1839,7 +1690,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1854,8 +1705,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/query/null'
+          path: /azurespecials/skipUrlEncoding/method/query/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1893,7 +1745,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_22
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1909,8 +1761,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/path/query/valid'
+          path: /azurespecials/skipUrlEncoding/path/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1948,7 +1801,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_23
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1964,8 +1817,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/swagger/query/valid'
+          path: /azurespecials/skipUrlEncoding/swagger/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2011,7 +1865,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2021,7 +1875,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_24
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2031,7 +1885,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2046,8 +1900,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/odata/filter'
+          path: /azurespecials/odata/filter
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2095,7 +1950,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2113,8 +1968,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestId'
+          path: /azurespecials/customNamedRequestId
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2125,7 +1981,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'
@@ -2158,7 +2014,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2177,8 +2033,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestIdParamGrouping'
+          path: /azurespecials/customNamedRequestIdParamGrouping
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2189,7 +2046,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'
@@ -2222,7 +2079,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2240,8 +2097,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestIdHead'
+          path: /azurespecials/customNamedRequestIdHead
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2252,7 +2110,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'

--- a/modelerfour/test/outputs/azure-special-properties/modeler.yaml
+++ b/modelerfour/test/outputs/azure-special-properties/modeler.yaml
@@ -122,7 +122,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   constants:
   - *ref_5
-  - !<!ConstantSchema> &ref_11
+  - !<!ConstantSchema> &ref_10
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -137,6 +137,34 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-07-01-preview
+        description: Api Version (2015-07-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_12
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-07-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_6
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-07-01-preview
+        description: Api Version (2015-07-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_13
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-07-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_6
     language: !<!Languages> 
       default:
         name: ApiVersion-2015-07-01-preview
@@ -170,21 +198,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_20
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-07-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_6
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-07-01-preview
-        description: Api Version (2015-07-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
+  - !<!ConstantSchema> &ref_14
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -212,7 +226,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_22
+  - !<!ConstantSchema> &ref_15
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -240,21 +254,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-07-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_6
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-07-01-preview
-        description: Api Version (2015-07-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
+  - !<!ConstantSchema> &ref_21
     type: constant
     value: !<!ConstantValue> 
       value: path1/path2/path3
@@ -268,7 +268,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
+  - !<!ConstantSchema> &ref_23
     type: constant
     value: !<!ConstantValue> 
       value: value1&q2=value2&q3=value3
@@ -285,7 +285,7 @@ schemas: !<!Schemas>
   numbers:
   - *ref_2
   - *ref_3
-  - !<!NumberSchema> &ref_32
+  - !<!NumberSchema> &ref_24
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -306,202 +306,30 @@ schemas: !<!Schemas>
       version: 2015-07-01-preview
     language: !<!Languages> 
       default:
-        name: paths·azurespecials-overwrite-x_ms_client_request_id-via_param-method·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - *ref_0
-  - !<!StringSchema> &ref_10
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: components·parameters·globalsubscriptionid·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-subscriptionid-method-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-subscriptionid-method-string-none-path-local-null-subscriptionid·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_14
-    type: string
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-subscriptionid-swagger-string-none-path-local-1234_5678_9012_3456-subscriptionid·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-skipurlencoding-method-path-valid-unencodedpathparam·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-skipurlencoding-method-query-valid·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-skipurlencoding-method-query-null·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-odata-filter·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-odata-filter·get·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-customnamedrequestid·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
         name: paths·azurespecials-customnamedrequestid·post·responses·200·headers·foo_request_id·schema
         description: MISSING·SCHEMA-DESCRIPTION-STRING
         header: foo-request-id
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
+  - *ref_0
+  - !<!StringSchema> &ref_11
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
     language: !<!Languages> 
       default:
-        name: paths·azurespecials-customnamedrequestidparamgrouping·post·parameters·0·schema
+        name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
+  - !<!StringSchema> &ref_20
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
     language: !<!Languages> 
       default:
-        name: paths·azurespecials-customnamedrequestidparamgrouping·post·responses·200·headers·foo_request_id·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: foo-request-id
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-customnamedrequestidhead·head·parameters·0·schema
+        name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
+  - !<!StringSchema> &ref_22
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
     language: !<!Languages> 
       default:
-        name: paths·azurespecials-customnamedrequestidhead·head·responses·200·headers·foo_request_id·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: foo-request-id
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·azurespecials-apiversion-method-string-none-query-local-null·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: components·parameters·globalapiversion·schema
+        name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
   - *ref_1
@@ -517,7 +345,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-special-properties
@@ -538,8 +366,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/overwrite/x-ms-client-request-id/method/'
+          path: /azurespecials/overwrite/x-ms-client-request-id/method/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -589,8 +418,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/overwrite/x-ms-client-request-id/via-param/method/'
+          path: /azurespecials/overwrite/x-ms-client-request-id/via-param/method/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -636,7 +466,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -652,8 +482,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -691,7 +522,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -707,8 +538,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -746,7 +578,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -757,7 +589,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_10
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -773,8 +605,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -812,7 +645,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -828,8 +661,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -867,7 +701,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -883,8 +717,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -930,7 +765,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -946,8 +781,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -985,13 +821,13 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: subscriptionId
-            description: 'This should appear as a method parameter, use value null, client-side validation should prvenet the call'
+            description: 'This should appear as a method parameter, use value ''1234-5678-9012-3456'''
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1001,8 +837,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1040,7 +877,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_11
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1056,8 +893,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1095,13 +933,13 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: subscriptionId
-            description: 'The subscriptionId, which appears in the path, the value is always ''1234-5678-9012-3456'''
+            description: 'This should appear as a method parameter, use value ''1234-5678-9012-3456'''
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1111,8 +949,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1158,7 +997,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1174,8 +1013,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1213,7 +1053,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1229,8 +1069,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview'
+          path: /azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1268,7 +1109,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1284,8 +1125,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1323,7 +1165,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_15
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1339,8 +1181,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1386,7 +1229,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_16
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1402,8 +1245,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/method/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1441,7 +1285,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_17
         implementation: Client
         language: !<!Languages> 
           default:
@@ -1456,8 +1300,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/local/null'
+          path: /azurespecials/apiVersion/method/string/none/query/local/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1495,7 +1340,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_18
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1511,8 +1356,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/path/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/path/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1550,7 +1396,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_19
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1566,8 +1412,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/swagger/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/swagger/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1613,7 +1460,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -1631,8 +1478,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1670,7 +1518,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -1688,8 +1536,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1727,7 +1576,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1745,8 +1594,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1784,7 +1634,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1800,8 +1650,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/query/valid'
+          path: /azurespecials/skipUrlEncoding/method/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1839,7 +1690,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1854,8 +1705,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/query/null'
+          path: /azurespecials/skipUrlEncoding/method/query/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1893,7 +1745,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_22
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1909,8 +1761,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/path/query/valid'
+          path: /azurespecials/skipUrlEncoding/path/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1948,7 +1801,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_23
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1964,8 +1817,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/swagger/query/valid'
+          path: /azurespecials/skipUrlEncoding/swagger/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2011,7 +1865,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2021,7 +1875,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_24
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2031,7 +1885,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2046,8 +1900,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/odata/filter'
+          path: /azurespecials/odata/filter
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2095,7 +1950,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2113,8 +1968,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestId'
+          path: /azurespecials/customNamedRequestId
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2125,7 +1981,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'
@@ -2158,7 +2014,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2177,8 +2033,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestIdParamGrouping'
+          path: /azurespecials/customNamedRequestIdParamGrouping
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2189,7 +2046,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'
@@ -2222,7 +2079,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2240,8 +2097,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestIdHead'
+          path: /azurespecials/customNamedRequestIdHead
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2252,7 +2110,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'

--- a/modelerfour/test/outputs/azure-special-properties/namer.yaml
+++ b/modelerfour/test/outputs/azure-special-properties/namer.yaml
@@ -122,7 +122,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   constants:
   - *ref_0
-  - !<!ConstantSchema> &ref_11
+  - !<!ConstantSchema> &ref_10
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -137,6 +137,34 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-07-01-preview
+        description: Api Version (2015-07-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_12
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-07-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-07-01-preview
+        description: Api Version (2015-07-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_13
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-07-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
     language: !<!Languages> 
       default:
         name: ApiVersion-2015-07-01-preview
@@ -170,21 +198,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_20
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-07-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-07-01-preview
-        description: Api Version (2015-07-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
+  - !<!ConstantSchema> &ref_14
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -212,7 +226,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_22
+  - !<!ConstantSchema> &ref_15
     type: constant
     value: !<!ConstantValue> 
       value: 2015-07-01-preview
@@ -240,21 +254,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-07-01-preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-07-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-07-01-preview
-        description: Api Version (2015-07-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
+  - !<!ConstantSchema> &ref_21
     type: constant
     value: !<!ConstantValue> 
       value: path1/path2/path3
@@ -268,7 +268,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
+  - !<!ConstantSchema> &ref_23
     type: constant
     value: !<!ConstantValue> 
       value: value1&q2=value2&q3=value3
@@ -285,7 +285,7 @@ schemas: !<!Schemas>
   numbers:
   - *ref_2
   - *ref_3
-  - !<!NumberSchema> &ref_32
+  - !<!NumberSchema> &ref_24
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -308,197 +308,25 @@ schemas: !<!Schemas>
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
+        header: foo-request-id
     protocol: !<!Protocols> {}
   - *ref_5
-  - !<!StringSchema> &ref_10
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_14
+  - !<!StringSchema> &ref_11
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
+  - !<!StringSchema> &ref_20
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
+  - !<!StringSchema> &ref_22
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: foo-request-id
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: foo-request-id
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: foo-request-id
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-07-01-preview
     language: !<!Languages> 
       default:
         name: string
@@ -517,7 +345,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: azure-special-properties
@@ -538,8 +366,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/overwrite/x-ms-client-request-id/method/'
+          path: /azurespecials/overwrite/x-ms-client-request-id/method/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -589,8 +418,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/overwrite/x-ms-client-request-id/via-param/method/'
+          path: /azurespecials/overwrite/x-ms-client-request-id/via-param/method/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -636,7 +466,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -652,8 +482,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -691,7 +522,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -707,8 +538,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -746,7 +578,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -757,7 +589,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_10
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -773,8 +605,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -812,7 +645,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -828,8 +661,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -867,7 +701,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -883,8 +717,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -930,7 +765,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -946,8 +781,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -985,13 +821,13 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: subscriptionId
-            description: 'This should appear as a method parameter, use value null, client-side validation should prvenet the call'
+            description: 'This should appear as a method parameter, use value ''1234-5678-9012-3456'''
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1001,8 +837,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1040,7 +877,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_11
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1056,8 +893,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1095,13 +933,13 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: subscriptionId
-            description: 'The subscriptionId, which appears in the path, the value is always ''1234-5678-9012-3456'''
+            description: 'This should appear as a method parameter, use value ''1234-5678-9012-3456'''
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1111,8 +949,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+          path: '/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1158,7 +997,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1174,8 +1013,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1213,7 +1053,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1229,8 +1069,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview'
+          path: /azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1268,7 +1109,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1284,8 +1125,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1323,7 +1165,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_15
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1339,8 +1181,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview'
+          path: /azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1386,7 +1229,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_16
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1402,8 +1245,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/method/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1441,7 +1285,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_17
         implementation: Client
         language: !<!Languages> 
           default:
@@ -1456,8 +1300,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/method/string/none/query/local/null'
+          path: /azurespecials/apiVersion/method/string/none/query/local/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1495,7 +1340,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_18
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1511,8 +1356,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/path/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/path/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1550,7 +1396,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_19
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1566,8 +1412,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/apiVersion/swagger/string/none/query/local/2.0'
+          path: /azurespecials/apiVersion/swagger/string/none/query/local/2.0
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1613,7 +1460,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -1631,8 +1478,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1670,7 +1518,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -1688,8 +1536,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1727,7 +1576,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1745,8 +1594,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}'
+          path: '/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1784,7 +1634,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1800,8 +1650,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/query/valid'
+          path: /azurespecials/skipUrlEncoding/method/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1839,7 +1690,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1854,8 +1705,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/method/query/null'
+          path: /azurespecials/skipUrlEncoding/method/query/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1893,7 +1745,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_22
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1909,8 +1761,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/path/query/valid'
+          path: /azurespecials/skipUrlEncoding/path/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1948,7 +1801,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_23
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1964,8 +1817,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/skipUrlEncoding/swagger/query/valid'
+          path: /azurespecials/skipUrlEncoding/swagger/query/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2011,7 +1865,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2021,7 +1875,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_24
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2031,7 +1885,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2046,8 +1900,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/odata/filter'
+          path: /azurespecials/odata/filter
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2095,7 +1950,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2113,8 +1968,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestId'
+          path: /azurespecials/customNamedRequestId
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2125,7 +1981,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'
@@ -2158,7 +2014,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2177,8 +2033,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestIdParamGrouping'
+          path: /azurespecials/customNamedRequestIdParamGrouping
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2189,7 +2046,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'
@@ -2222,7 +2079,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -2240,8 +2097,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/azurespecials/customNamedRequestIdHead'
+          path: /azurespecials/customNamedRequestIdHead
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2252,7 +2110,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_8
             header: foo-request-id
           statusCodes:
           - '200'

--- a/modelerfour/test/outputs/blob-service/flattened.yaml
+++ b/modelerfour/test/outputs/blob-service/flattened.yaml
@@ -13948,7 +13948,7 @@ globalParameters:
       description: 'The URL of the service account, container, or blob that is the targe of the desired operation.'
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   title: blobservice
 operationGroups:
@@ -14037,11 +14037,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/'
+          path: /
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -14155,8 +14156,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_173
@@ -14272,8 +14274,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_187
@@ -14427,8 +14430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_198
@@ -14561,11 +14565,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/'
+          path: /
           method: post
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_206
@@ -14664,8 +14669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -14812,8 +14818,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_223
@@ -14979,8 +14986,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15103,8 +15111,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15279,8 +15288,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15434,8 +15444,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15568,8 +15579,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_280
@@ -15757,11 +15769,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15939,8 +15952,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16110,8 +16124,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16278,8 +16293,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16451,8 +16467,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16633,8 +16650,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16804,8 +16822,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_361
@@ -16989,8 +17008,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_371
@@ -17137,8 +17157,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17231,8 +17252,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17512,8 +17534,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17876,8 +17899,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -18074,8 +18098,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -18329,8 +18354,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -18743,8 +18769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: head
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19031,8 +19058,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19368,8 +19396,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19491,8 +19520,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19734,8 +19764,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19970,8 +20001,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20169,8 +20201,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20353,8 +20386,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20534,8 +20568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20729,8 +20764,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20915,8 +20951,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21150,8 +21187,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21431,8 +21469,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21707,8 +21746,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21861,8 +21901,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21999,8 +22040,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22111,8 +22153,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22267,11 +22310,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22410,8 +22454,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_20
@@ -22762,8 +22807,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23101,12 +23147,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23399,8 +23446,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23773,8 +23821,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23985,8 +24034,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_820
@@ -24220,8 +24270,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_820
@@ -24441,8 +24492,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -24636,8 +24688,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -24811,8 +24864,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25152,8 +25206,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25458,13 +25513,14 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
           - text/plain
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25829,8 +25885,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26199,12 +26256,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26448,12 +26506,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26745,8 +26804,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -27112,11 +27172,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -27294,8 +27355,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_970

--- a/modelerfour/test/outputs/blob-service/modeler.yaml
+++ b/modelerfour/test/outputs/blob-service/modeler.yaml
@@ -13948,7 +13948,7 @@ globalParameters:
       description: 'The URL of the service account, container, or blob that is the targe of the desired operation.'
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   title: blobservice
 operationGroups:
@@ -14037,11 +14037,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/'
+          path: /
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -14155,8 +14156,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_172
@@ -14272,8 +14274,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_191
@@ -14427,8 +14430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_201
@@ -14561,11 +14565,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/'
+          path: /
           method: post
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_210
@@ -14664,8 +14669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -14812,8 +14818,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_228
@@ -14979,8 +14986,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15103,8 +15111,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15279,8 +15288,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15434,8 +15444,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15568,8 +15579,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_287
@@ -15757,11 +15769,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15939,8 +15952,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16110,8 +16124,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16278,8 +16293,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16451,8 +16467,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16633,8 +16650,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16804,8 +16822,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_366
@@ -16989,8 +17008,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_376
@@ -17137,8 +17157,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17231,8 +17252,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17512,8 +17534,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17876,8 +17899,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -18074,8 +18098,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -18329,8 +18354,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -18743,8 +18769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: head
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19031,8 +19058,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19368,8 +19396,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19491,8 +19520,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19734,8 +19764,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19970,8 +20001,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20169,8 +20201,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20353,8 +20386,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20534,8 +20568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20729,8 +20764,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20915,8 +20951,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21150,8 +21187,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21431,8 +21469,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21707,8 +21746,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21861,8 +21901,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21999,8 +22040,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22111,8 +22153,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22267,11 +22310,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22410,8 +22454,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_90
@@ -22762,8 +22807,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23101,12 +23147,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23399,8 +23446,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23773,8 +23821,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23985,8 +24034,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_827
@@ -24220,8 +24270,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_827
@@ -24441,8 +24492,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -24636,8 +24688,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -24811,8 +24864,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25152,8 +25206,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25458,13 +25513,14 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
           - text/plain
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25829,8 +25885,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26199,12 +26256,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26448,12 +26506,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26745,8 +26804,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -27112,11 +27172,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -27294,8 +27355,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_978

--- a/modelerfour/test/outputs/blob-service/namer.yaml
+++ b/modelerfour/test/outputs/blob-service/namer.yaml
@@ -13948,7 +13948,7 @@ globalParameters:
       description: 'The URL of the service account, container, or blob that is the targe of the desired operation.'
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   title: blobservice
 operationGroups:
@@ -14037,11 +14037,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/'
+          path: /
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -14155,8 +14156,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_173
@@ -14272,8 +14274,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_187
@@ -14427,8 +14430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_198
@@ -14561,11 +14565,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/'
+          path: /
           method: post
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_206
@@ -14664,8 +14669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -14812,8 +14818,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/'
+          path: /
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_223
@@ -14979,8 +14986,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15103,8 +15111,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15279,8 +15288,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15434,8 +15444,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15568,8 +15579,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_280
@@ -15757,11 +15769,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -15939,8 +15952,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16110,8 +16124,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16278,8 +16293,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16451,8 +16467,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16633,8 +16650,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -16804,8 +16822,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_361
@@ -16989,8 +17008,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_371
@@ -17137,8 +17157,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17231,8 +17252,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}'
+          path: '/{containerName}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17512,8 +17534,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -17876,8 +17899,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -18074,8 +18098,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -18329,8 +18354,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -18743,8 +18769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: head
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19031,8 +19058,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: delete
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19368,8 +19396,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19491,8 +19520,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19734,8 +19764,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -19970,8 +20001,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20169,8 +20201,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20353,8 +20386,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20534,8 +20568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20729,8 +20764,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -20915,8 +20951,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21150,8 +21187,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21431,8 +21469,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21707,8 +21746,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21861,8 +21901,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -21999,8 +22040,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22111,8 +22153,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22267,11 +22310,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -22410,8 +22454,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_20
@@ -22762,8 +22807,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23101,12 +23147,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23399,8 +23446,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23773,8 +23821,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -23985,8 +24034,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_820
@@ -24220,8 +24270,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_820
@@ -24441,8 +24492,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -24636,8 +24688,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -24811,8 +24864,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25152,8 +25206,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25458,13 +25513,14 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
           - text/plain
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -25829,8 +25885,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26199,12 +26256,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26448,12 +26506,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -26745,8 +26804,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -27112,11 +27172,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{url}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -27294,8 +27355,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{url}/{containerName}/{blob}'
+          path: '/{containerName}/{blob}'
           method: get
+          url: '{url}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_970

--- a/modelerfour/test/outputs/body-array/flattened.yaml
+++ b/modelerfour/test/outputs/body-array/flattened.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_70
+  - !<!ObjectSchema> &ref_29
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_27
+      schema: !<!NumberSchema> &ref_15
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_49
+      schema: !<!StringSchema> &ref_22
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -45,14 +45,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_8
+  - !<!ObjectSchema> &ref_3
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_46
+      schema: !<!NumberSchema> &ref_20
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_55
+      schema: !<!StringSchema> &ref_24
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -90,9 +90,9 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_15
+  - !<!DictionarySchema> &ref_6
     type: dictionary
-    elementType: !<!StringSchema> &ref_62
+    elementType: !<!StringSchema> &ref_0
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -105,95 +105,10 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-null·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_16
-    type: dictionary
-    elementType: !<!StringSchema> &ref_63
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_17
-    type: dictionary
-    elementType: !<!StringSchema> &ref_64
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_18
-    type: dictionary
-    elementType: !<!StringSchema> &ref_65
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_19
-    type: dictionary
-    elementType: !<!StringSchema> &ref_66
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_20
-    type: dictionary
-    elementType: !<!StringSchema> &ref_67
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items·additionalproperties>
+        description: Dictionary of <paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items>
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_0
+  - !<!ChoiceSchema> &ref_1
     choices:
     - !<!ChoiceValue> 
       value: foo1
@@ -217,7 +132,7 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    choiceType: !<!StringSchema> &ref_1
+    choiceType: !<!StringSchema> &ref_2
       type: string
       language: !<!Languages> 
         default:
@@ -230,12 +145,12 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_69
+  - !<!ArraySchema> &ref_28
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_26
+    elementType: !<!NumberSchema> &ref_14
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -251,12 +166,12 @@ schemas: !<!Schemas>
         name: ArrayOfget-200-application-json-itemsItem
         description: The null Array value
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_71
+  - !<!ArraySchema> &ref_30
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_28
+    elementType: !<!NumberSchema> &ref_16
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -272,33 +187,12 @@ schemas: !<!Schemas>
         name: ArrayOfinteger
         description: 'The invalid Array [1, 2, 3'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_72
+  - !<!ArraySchema> &ref_31
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_29
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The empty array value []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_73
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_50
+    elementType: !<!StringSchema> &ref_23
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -313,12 +207,12 @@ schemas: !<!Schemas>
         name: ArrayOfput-content-schemaItem
         description: 'The empty array value []'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_74
+  - !<!ArraySchema> &ref_32
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_21
+    elementType: !<!BooleanSchema> &ref_7
       type: boolean
       apiVersions:
       - !<!ApiVersion> 
@@ -333,156 +227,12 @@ schemas: !<!Schemas>
         name: ArrayOfboolean
         description: 'The array value [true, false, false, true]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_75
+  - !<!ArraySchema> &ref_33
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_22
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfboolean
-        description: 'The array value [true, false, false, true]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_76
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_23
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfboolean
-        description: 'The array value [true, null, false]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_77
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_24
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfboolean
-        description: 'The array value [true, ''boolean'', false]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_78
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_30
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_79
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_31
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_80
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_32
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, null, 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_81
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_33
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, ''integer'', 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_82
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_34
+    elementType: !<!NumberSchema> &ref_17
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -498,75 +248,12 @@ schemas: !<!Schemas>
         name: ArrayOfinteger
         description: 'The array value [1, -1, 3, 300]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_83
+  - !<!ArraySchema> &ref_34
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_35
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_84
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_36
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, null, 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_85
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_37
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, ''integer'', 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_86
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_38
+    elementType: !<!NumberSchema> &ref_18
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -582,75 +269,12 @@ schemas: !<!Schemas>
         name: ArrayOfnumber
         description: 'The array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_87
+  - !<!ArraySchema> &ref_35
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_39
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [0, -0.01, 1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_88
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_40
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [0.0, null, -1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_89
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_41
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [1.0, ''number'', 0.0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_90
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_42
+    elementType: !<!NumberSchema> &ref_19
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -666,110 +290,7 @@ schemas: !<!Schemas>
         name: ArrayOfnumber
         description: 'The array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_91
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_43
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [0, -0.01, 1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_92
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_44
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [0.0, null, -1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_93
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_45
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [1.0, ''number'', 0.0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_94
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_51
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfstring
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_95
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_52
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfstring
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_96
+  - !<!ArraySchema> &ref_4
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -777,26 +298,26 @@ schemas: !<!Schemas>
     elementType: *ref_0
     language: !<!Languages> 
       default:
-        name: ArrayOfFooEnum
+        name: ArrayOfstring
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_97
+  - !<!ArraySchema> &ref_36
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_0
+    elementType: *ref_1
     language: !<!Languages> 
       default:
         name: ArrayOfFooEnum
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_98
+  - !<!ArraySchema> &ref_37
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!SealedChoiceSchema> &ref_47
+    elementType: !<!SealedChoiceSchema> &ref_21
       choices:
       - !<!ChoiceValue> 
         value: foo1
@@ -820,7 +341,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      choiceType: *ref_1
+      choiceType: *ref_2
       language: !<!Languages> 
         default:
           name: Enum0
@@ -831,92 +352,12 @@ schemas: !<!Schemas>
         name: ArrayOfEnum0
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_99
+  - !<!ArraySchema> &ref_38
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!SealedChoiceSchema> &ref_48
-      choices:
-      - !<!ChoiceValue> 
-        value: foo1
-        language:
-          default:
-            name: foo1
-            description: ''
-      - !<!ChoiceValue> 
-        value: foo2
-        language:
-          default:
-            name: foo2
-            description: ''
-      - !<!ChoiceValue> 
-        value: foo3
-        language:
-          default:
-            name: foo3
-            description: ''
-      type: sealed-choice
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      choiceType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: Enum1
-          description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfEnum1
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_100
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_53
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfstring
-        description: 'The array value [''foo'', null, ''foo2'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_101
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_54
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfstring
-        description: 'The array value [''foo'', 123, ''foo2'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_102
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!UuidSchema> &ref_2
+    elementType: !<!UuidSchema> &ref_26
       type: uuid
       apiVersions:
       - !<!ApiVersion> 
@@ -931,34 +372,12 @@ schemas: !<!Schemas>
         name: ArrayOfuuid
         description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_103
+  - !<!ArraySchema> &ref_39
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: ArrayOfuuid
-        description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_104
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: ArrayOfuuid
-        description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''foo'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_105
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateSchema> &ref_3
+    elementType: !<!DateSchema> &ref_12
       type: date
       apiVersions:
       - !<!ApiVersion> 
@@ -973,45 +392,12 @@ schemas: !<!Schemas>
         name: ArrayOfdate
         description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_106
+  - !<!ArraySchema> &ref_40
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate
-        description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_107
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate
-        description: 'The array value [''2012-01-01'', null, ''1776-07-04'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_108
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate
-        description: 'The array value [''2011-03-22'', ''date'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_109
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateTimeSchema> &ref_4
+    elementType: !<!DateTimeSchema> &ref_10
       type: date-time
       format: date-time
       apiVersions:
@@ -1027,45 +413,12 @@ schemas: !<!Schemas>
         name: ArrayOfdate-time
         description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_110
+  - !<!ArraySchema> &ref_41
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_4
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate-time
-        description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_111
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_4
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate-time
-        description: 'The array value [''2000-12-01t00:00:01z'', null]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_112
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_4
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate-time
-        description: 'The array value [''2000-12-01t00:00:01z'', ''date-time'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_113
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateTimeSchema> &ref_5
+    elementType: !<!DateTimeSchema> &ref_11
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -1081,23 +434,12 @@ schemas: !<!Schemas>
         name: ArrayOfdate-time
         description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_114
+  - !<!ArraySchema> &ref_42
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_5
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate-time
-        description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_115
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DurationSchema> &ref_6
+    elementType: !<!DurationSchema> &ref_13
       type: duration
       apiVersions:
       - !<!ApiVersion> 
@@ -1112,23 +454,12 @@ schemas: !<!Schemas>
         name: ArrayOfduration
         description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_116
+  - !<!ArraySchema> &ref_43
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_6
-    language: !<!Languages> 
-      default:
-        name: ArrayOfduration
-        description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_117
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!ByteArraySchema> &ref_7
+    elementType: !<!ByteArraySchema> &ref_8
       type: byte-array
       format: byte
       apiVersions:
@@ -1144,34 +475,12 @@ schemas: !<!Schemas>
         name: ArrayOfbyte-array
         description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_118
+  - !<!ArraySchema> &ref_44
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_7
-    language: !<!Languages> 
-      default:
-        name: ArrayOfbyte-array
-        description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_119
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_7
-    language: !<!Languages> 
-      default:
-        name: ArrayOfbyte-array
-        description: 'The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_120
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!ByteArraySchema> &ref_25
+    elementType: !<!ByteArraySchema> &ref_9
       type: byte-array
       format: base64url
       apiVersions:
@@ -1187,233 +496,34 @@ schemas: !<!Schemas>
         name: ArrayOfbyte-array
         description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_121
+  - !<!ArraySchema> &ref_45
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_8
+    elementType: *ref_3
     language: !<!Languages> 
       default:
         name: ArrayOfProduct
         description: array of complex type with null value
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_122
+  - !<!ArraySchema> &ref_46
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_8
+    elementType: *ref_4
     language: !<!Languages> 
       default:
-        name: ArrayOfProduct
-        description: 'Empty array of complex type []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_123
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_8
-    language: !<!Languages> 
-      default:
-        name: ArrayOfProduct
-        description: 'Array of complex type with null item [{''integer'': 1 ''string'': ''2''}, null, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_124
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_8
-    language: !<!Languages> 
-      default:
-        name: ArrayOfProduct
-        description: 'Array of complex type with empty item [{''integer'': 1 ''string'': ''2''}, {}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_125
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_8
-    language: !<!Languages> 
-      default:
-        name: ArrayOfProduct
-        description: 'array of complex type with [{''integer'': 1 ''string'': ''2''}, {''integer'': 3, ''string'': ''4''}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_126
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_8
-    language: !<!Languages> 
-      default:
-        name: ArrayOfProduct
-        description: 'array of complex type with [{''integer'': 1 ''string'': ''2''}, {''integer'': 3, ''string'': ''4''}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_9
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_56
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_127
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_9
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
+        name: ArrayOfArrayOfstring
         description: a null array
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_10
+  - !<!ArraySchema> &ref_5
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_57
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_128
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_10
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
-        description: 'An empty array []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_11
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_58
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_129
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_11
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], null, [''7'', ''8'', ''9'']]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_12
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_59
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_130
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_12
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], [], [''7'', ''8'', ''9'']]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_13
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_60
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_131
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_13
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_14
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_61
+    elementType: !<!StringSchema> &ref_25
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -1428,149 +538,62 @@ schemas: !<!Schemas>
         name: Array of put-content-schema-itemsItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_132
+  - !<!ArraySchema> &ref_47
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_14
+    elementType: *ref_5
     language: !<!Languages> 
       default:
         name: ArrayOfArray of put-content-schema-itemsItem
         description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_133
+  - !<!ArraySchema> &ref_48
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_15
+    elementType: *ref_6
     language: !<!Languages> 
       default:
         name: ArrayOfDictionary of string
         description: An array of Dictionaries with value null
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_134
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_16
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_135
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_17
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, null, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_136
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_18
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_137
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_19
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {''4'': ''four'', ''5'': ''five'', ''6'': ''six''}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_138
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_20
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {''4'': ''four'', ''5'': ''five'', ''6'': ''six''}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
   booleans:
+  - *ref_7
+  byteArrays:
+  - *ref_8
+  - *ref_9
+  dateTimes:
+  - *ref_10
+  - *ref_11
+  dates:
+  - *ref_12
+  durations:
+  - *ref_13
+  numbers:
+  - *ref_14
+  - *ref_15
+  - *ref_16
+  - *ref_17
+  - *ref_18
+  - *ref_19
+  - *ref_20
+  sealedChoices:
   - *ref_21
+  strings:
+  - *ref_2
   - *ref_22
   - *ref_23
+  - *ref_0
   - *ref_24
-  byteArrays:
-  - *ref_7
   - *ref_25
-  dateTimes:
-  - *ref_4
-  - *ref_5
-  dates:
-  - *ref_3
-  durations:
-  - *ref_6
-  numbers:
-  - *ref_26
-  - *ref_27
-  - *ref_28
-  - *ref_29
-  - *ref_30
-  - *ref_31
-  - *ref_32
-  - *ref_33
-  - *ref_34
-  - *ref_35
-  - *ref_36
-  - *ref_37
-  - *ref_38
-  - *ref_39
-  - *ref_40
-  - *ref_41
-  - *ref_42
-  - *ref_43
-  - *ref_44
-  - *ref_45
-  - *ref_46
-  sealedChoices:
-  - *ref_47
-  - *ref_48
-  strings:
-  - *ref_1
-  - *ref_49
-  - *ref_50
-  - *ref_51
-  - *ref_52
-  - *ref_53
-  - *ref_54
-  - *ref_55
-  - *ref_56
-  - *ref_57
-  - *ref_58
-  - *ref_59
-  - *ref_60
-  - *ref_61
-  - *ref_62
-  - *ref_63
-  - *ref_64
-  - *ref_65
-  - *ref_66
-  - *ref_67
   uuids:
-  - *ref_2
+  - *ref_26
 globalParameters:
-- !<!Parameter> &ref_68
-  schema: *ref_1
+- !<!Parameter> &ref_27
+  schema: *ref_2
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -1580,7 +603,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-array
@@ -1594,18 +617,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/null'
+          path: /array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1619,7 +643,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1642,18 +666,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/invalid'
+          path: /array/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_71
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -1667,7 +692,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1690,18 +715,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/empty'
+          path: /array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_72
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -1715,7 +741,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1738,9 +764,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_31
         implementation: Method
         required: true
         extensions:
@@ -1759,11 +785,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/empty'
+          path: /array/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1776,7 +803,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1801,18 +828,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/tfft'
+          path: /array/prim/boolean/tfft
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_74
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1826,7 +854,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1849,9 +877,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -1870,11 +898,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/boolean/tfft'
+          path: /array/prim/boolean/tfft
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1887,7 +916,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1912,18 +941,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/true.null.false'
+          path: /array/prim/boolean/true.null.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_76
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1937,7 +967,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1960,18 +990,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/true.boolean.false'
+          path: /array/prim/boolean/true.boolean.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_77
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1985,7 +1016,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2008,18 +1039,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.-1.3.300'
+          path: /array/prim/integer/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2033,7 +1065,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2056,9 +1088,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_79
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2077,11 +1109,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/integer/1.-1.3.300'
+          path: /array/prim/integer/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2094,7 +1127,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2119,18 +1152,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.null.zero'
+          path: /array/prim/integer/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_80
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2144,7 +1178,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2167,18 +1201,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.integer.0'
+          path: /array/prim/integer/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_81
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2192,7 +1227,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2215,18 +1250,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.-1.3.300'
+          path: /array/prim/long/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_82
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2240,7 +1276,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2263,9 +1299,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_83
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -2284,11 +1320,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/long/1.-1.3.300'
+          path: /array/prim/long/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2301,7 +1338,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2326,18 +1363,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.null.zero'
+          path: /array/prim/long/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_84
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2351,7 +1389,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2374,18 +1412,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.integer.0'
+          path: /array/prim/long/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_85
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2399,7 +1438,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2422,18 +1461,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/0--0.01-1.2e20'
+          path: /array/prim/float/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_86
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2447,7 +1487,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2470,9 +1510,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_87
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -2491,11 +1531,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/float/0--0.01-1.2e20'
+          path: /array/prim/float/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2508,7 +1549,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2533,18 +1574,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/0.0-null-1.2e20'
+          path: /array/prim/float/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2558,7 +1600,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2581,18 +1623,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/1.number.0'
+          path: /array/prim/float/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2606,7 +1649,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2629,18 +1672,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/0--0.01-1.2e20'
+          path: /array/prim/double/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_90
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2654,7 +1698,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2677,9 +1721,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -2698,11 +1742,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/double/0--0.01-1.2e20'
+          path: /array/prim/double/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2715,7 +1760,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2740,18 +1785,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/0.0-null-1.2e20'
+          path: /array/prim/double/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2765,7 +1811,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2788,18 +1834,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/1.number.0'
+          path: /array/prim/double/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_93
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2813,7 +1860,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2836,18 +1883,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo1.foo2.foo3'
+          path: /array/prim/string/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -2861,7 +1909,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2884,9 +1932,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_95
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -2905,11 +1953,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/string/foo1.foo2.foo3'
+          path: /array/prim/string/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2922,7 +1971,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2947,18 +1996,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/enum/foo1.foo2.foo3'
+          path: /array/prim/enum/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_96
+      schema: *ref_36
       language: !<!Languages> 
         default:
           name: ''
@@ -2972,7 +2022,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2995,9 +2045,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_97
+        schema: *ref_36
         implementation: Method
         required: true
         extensions:
@@ -3016,11 +2066,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/enum/foo1.foo2.foo3'
+          path: /array/prim/enum/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3033,7 +2084,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3058,18 +2109,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string-enum/foo1.foo2.foo3'
+          path: /array/prim/string-enum/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_98
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3083,7 +2135,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3106,9 +2158,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_99
+        schema: *ref_37
         implementation: Method
         required: true
         extensions:
@@ -3127,11 +2179,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/string-enum/foo1.foo2.foo3'
+          path: /array/prim/string-enum/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3144,7 +2197,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3169,18 +2222,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo.null.foo2'
+          path: /array/prim/string/foo.null.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_100
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -3194,7 +2248,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3217,18 +2271,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo.123.foo2'
+          path: /array/prim/string/foo.123.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_101
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -3242,7 +2297,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3265,18 +2320,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/uuid/valid'
+          path: /array/prim/uuid/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_102
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3290,7 +2346,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3313,9 +2369,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_103
+        schema: *ref_38
         implementation: Method
         required: true
         extensions:
@@ -3334,11 +2390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/uuid/valid'
+          path: /array/prim/uuid/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3351,7 +2408,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3376,18 +2433,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/uuid/invalidchars'
+          path: /array/prim/uuid/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_104
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3401,7 +2459,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3424,18 +2482,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/valid'
+          path: /array/prim/date/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_105
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3449,7 +2508,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3472,9 +2531,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_106
+        schema: *ref_39
         implementation: Method
         required: true
         extensions:
@@ -3493,11 +2552,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date/valid'
+          path: /array/prim/date/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3510,7 +2570,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3535,18 +2595,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/invalidnull'
+          path: /array/prim/date/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_107
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3560,7 +2621,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3583,18 +2644,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/invalidchars'
+          path: /array/prim/date/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_108
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3608,7 +2670,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3631,18 +2693,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/valid'
+          path: /array/prim/date-time/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_109
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3656,7 +2719,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3679,9 +2742,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_110
+        schema: *ref_40
         implementation: Method
         required: true
         extensions:
@@ -3700,11 +2763,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date-time/valid'
+          path: /array/prim/date-time/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3717,7 +2781,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3742,18 +2806,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/invalidnull'
+          path: /array/prim/date-time/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_111
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3767,7 +2832,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3790,18 +2855,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/invalidchars'
+          path: /array/prim/date-time/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_112
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3815,7 +2881,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3838,18 +2904,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time-rfc1123/valid'
+          path: /array/prim/date-time-rfc1123/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_113
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -3863,7 +2930,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3886,9 +2953,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_114
+        schema: *ref_41
         implementation: Method
         required: true
         extensions:
@@ -3907,11 +2974,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date-time-rfc1123/valid'
+          path: /array/prim/date-time-rfc1123/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3924,7 +2992,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3949,18 +3017,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/duration/valid'
+          path: /array/prim/duration/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_115
+      schema: *ref_42
       language: !<!Languages> 
         default:
           name: ''
@@ -3974,7 +3043,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3997,9 +3066,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_116
+        schema: *ref_42
         implementation: Method
         required: true
         extensions:
@@ -4018,11 +3087,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/duration/valid'
+          path: /array/prim/duration/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4035,7 +3105,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4060,18 +3130,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/byte/valid'
+          path: /array/prim/byte/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_117
+      schema: *ref_43
       language: !<!Languages> 
         default:
           name: ''
@@ -4085,7 +3156,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4108,9 +3179,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_118
+        schema: *ref_43
         implementation: Method
         required: true
         extensions:
@@ -4129,11 +3200,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/byte/valid'
+          path: /array/prim/byte/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4146,7 +3218,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4171,18 +3243,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/byte/invalidnull'
+          path: /array/prim/byte/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_119
+      schema: *ref_43
       language: !<!Languages> 
         default:
           name: ''
@@ -4196,7 +3269,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4219,18 +3292,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/base64url/valid'
+          path: /array/prim/base64url/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_120
+      schema: *ref_44
       language: !<!Languages> 
         default:
           name: ''
@@ -4244,7 +3318,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4267,18 +3341,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/null'
+          path: /array/complex/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_121
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4292,7 +3367,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4315,18 +3390,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/empty'
+          path: /array/complex/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_122
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4340,7 +3416,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4363,18 +3439,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/itemnull'
+          path: /array/complex/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_123
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4388,7 +3465,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4411,18 +3488,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/itemempty'
+          path: /array/complex/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_124
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4436,7 +3514,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4459,18 +3537,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/valid'
+          path: /array/complex/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_125
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4484,7 +3563,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4507,9 +3586,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_126
+        schema: *ref_45
         implementation: Method
         required: true
         extensions:
@@ -4528,11 +3607,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/complex/valid'
+          path: /array/complex/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4545,7 +3625,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4570,18 +3650,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/null'
+          path: /array/array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_127
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4595,7 +3676,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4618,18 +3699,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/empty'
+          path: /array/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_128
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4643,7 +3725,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4666,18 +3748,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/itemnull'
+          path: /array/array/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_129
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4691,7 +3774,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4714,18 +3797,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/itemempty'
+          path: /array/array/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_130
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4739,7 +3823,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4762,18 +3846,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/valid'
+          path: /array/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_131
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4787,7 +3872,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4810,9 +3895,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_132
+        schema: *ref_47
         implementation: Method
         required: true
         extensions:
@@ -4831,11 +3916,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/array/valid'
+          path: /array/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4848,7 +3934,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4873,18 +3959,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/null'
+          path: /array/dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_133
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4898,7 +3985,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4921,18 +4008,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/empty'
+          path: /array/dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_134
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4946,7 +4034,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4969,18 +4057,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/itemnull'
+          path: /array/dictionary/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_135
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4994,7 +4083,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -5017,18 +4106,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/itemempty'
+          path: /array/dictionary/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_136
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -5042,7 +4132,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -5065,18 +4155,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/valid'
+          path: /array/dictionary/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_137
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -5090,7 +4181,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -5113,9 +4204,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_138
+        schema: *ref_48
         implementation: Method
         required: true
         extensions:
@@ -5134,11 +4225,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/dictionary/valid'
+          path: /array/dictionary/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5151,7 +4243,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-array/modeler.yaml
+++ b/modelerfour/test/outputs/body-array/modeler.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_69
+  - !<!ObjectSchema> &ref_28
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_53
+      schema: !<!NumberSchema> &ref_13
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_54
+      schema: !<!StringSchema> &ref_14
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -45,14 +45,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_34
+  - !<!ObjectSchema> &ref_15
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_32
+      schema: !<!NumberSchema> &ref_8
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_33
+      schema: !<!StringSchema> &ref_9
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -90,110 +90,25 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_62
+  - !<!DictionarySchema> &ref_26
     type: dictionary
-    elementType: !<!StringSchema> &ref_47
+    elementType: !<!StringSchema> &ref_6
       type: string
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: paths·array-dictionary-null·get·responses·200·content·application-json·schema·items·additionalproperties
+          name: paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
         name: paths·array-dictionary-null·get·responses·200·content·application-json·schema·items
-        description: Dictionary of <paths·array-dictionary-null·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_63
-    type: dictionary
-    elementType: !<!StringSchema> &ref_48
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items
-        description: Dictionary of <paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_64
-    type: dictionary
-    elementType: !<!StringSchema> &ref_49
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items
-        description: Dictionary of <paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_65
-    type: dictionary
-    elementType: !<!StringSchema> &ref_50
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items
-        description: Dictionary of <paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_66
-    type: dictionary
-    elementType: !<!StringSchema> &ref_51
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items
-        description: Dictionary of <paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_67
-    type: dictionary
-    elementType: !<!StringSchema> &ref_52
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items
-        description: Dictionary of <paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items·additionalproperties>
+        description: Dictionary of <paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items>
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_23
+  - !<!ChoiceSchema> &ref_17
     choices:
     - !<!ChoiceValue> 
       value: foo1
@@ -217,7 +132,7 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    choiceType: !<!StringSchema> &ref_22
+    choiceType: !<!StringSchema> &ref_7
       type: string
       language: !<!Languages> 
         default:
@@ -230,7 +145,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_68
+  - !<!ArraySchema> &ref_27
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -251,7 +166,7 @@ schemas: !<!Schemas>
         name: paths·array-null·get·responses·200·content·application-json·schema
         description: The null Array value
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_71
+  - !<!ArraySchema> &ref_30
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -272,33 +187,12 @@ schemas: !<!Schemas>
         name: paths·array-invalid·get·responses·200·content·application-json·schema
         description: 'The invalid Array [1, 2, 3'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_72
+  - !<!ArraySchema> &ref_31
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_2
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·array-empty·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-empty·get·responses·200·content·application-json·schema
-        description: 'The empty array value []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_73
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_3
+    elementType: !<!StringSchema> &ref_2
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -313,12 +207,12 @@ schemas: !<!Schemas>
         name: paths·array-empty·put·requestbody·content·application-json·schema
         description: 'The empty array value []'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_74
+  - !<!ArraySchema> &ref_32
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_55
+    elementType: !<!BooleanSchema> &ref_16
       type: boolean
       apiVersions:
       - !<!ApiVersion> 
@@ -333,156 +227,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-boolean-tfft·get·responses·200·content·application-json·schema
         description: 'The array value [true, false, false, true]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_75
+  - !<!ArraySchema> &ref_33
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_56
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-boolean-tfft·put·requestbody·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-boolean-tfft·put·requestbody·content·application-json·schema
-        description: 'The array value [true, false, false, true]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_76
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_57
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-boolean-true-null-false·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-boolean-true-null-false·get·responses·200·content·application-json·schema
-        description: 'The array value [true, null, false]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_77
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_58
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema
-        description: 'The array value [true, ''boolean'', false]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_78
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_4
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_79
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_5
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_80
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_6
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-integer-1-null-zero·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-integer-1-null-zero·get·responses·200·content·application-json·schema
-        description: 'The array value [1, null, 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_81
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_7
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-integer-1-integer-0·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-integer-1-integer-0·get·responses·200·content·application-json·schema
-        description: 'The array value [1, ''integer'', 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_82
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_8
+    elementType: !<!NumberSchema> &ref_3
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -498,75 +248,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
         description: 'The array value [1, -1, 3, 300]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_83
+  - !<!ArraySchema> &ref_34
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_9
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_84
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_10
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-long-1-null-zero·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-long-1-null-zero·get·responses·200·content·application-json·schema
-        description: 'The array value [1, null, 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_85
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_11
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-long-1-integer-0·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-long-1-integer-0·get·responses·200·content·application-json·schema
-        description: 'The array value [1, ''integer'', 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_86
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_12
+    elementType: !<!NumberSchema> &ref_4
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -582,75 +269,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
         description: 'The array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_87
+  - !<!ArraySchema> &ref_35
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_13
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema
-        description: 'The array value [0, -0.01, 1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_88
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_14
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema
-        description: 'The array value [0.0, null, -1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_89
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_15
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-float-1-number-0·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-float-1-number-0·get·responses·200·content·application-json·schema
-        description: 'The array value [1.0, ''number'', 0.0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_90
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_16
+    elementType: !<!NumberSchema> &ref_5
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -666,137 +290,34 @@ schemas: !<!Schemas>
         name: paths·array-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
         description: 'The array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_91
+  - !<!ArraySchema> &ref_10
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_17
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema
-        description: 'The array value [0, -0.01, 1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_92
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_18
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema
-        description: 'The array value [0.0, null, -1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_93
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_19
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-double-1-number-0·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-double-1-number-0·get·responses·200·content·application-json·schema
-        description: 'The array value [1.0, ''number'', 0.0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_94
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_20
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
+    elementType: *ref_6
     language: !<!Languages> 
       default:
         name: paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_95
+  - !<!ArraySchema> &ref_36
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_21
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_96
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_23
+    elementType: *ref_17
     language: !<!Languages> 
       default:
         name: paths·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_97
+  - !<!ArraySchema> &ref_37
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_98
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!SealedChoiceSchema> &ref_59
+    elementType: !<!SealedChoiceSchema> &ref_18
       choices:
       - !<!ChoiceValue> 
         value: foo1
@@ -820,7 +341,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      choiceType: *ref_22
+      choiceType: *ref_7
       language: !<!Languages> 
         default:
           name: paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items
@@ -831,92 +352,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_99
+  - !<!ArraySchema> &ref_38
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!SealedChoiceSchema> &ref_60
-      choices:
-      - !<!ChoiceValue> 
-        value: foo1
-        language:
-          default:
-            name: foo1
-            description: ''
-      - !<!ChoiceValue> 
-        value: foo2
-        language:
-          default:
-            name: foo2
-            description: ''
-      - !<!ChoiceValue> 
-        value: foo3
-        language:
-          default:
-            name: foo3
-            description: ''
-      type: sealed-choice
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      choiceType: *ref_22
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-string_enum-foo1-foo2-foo3·put·requestbody·content·application-json·schema
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_100
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_24
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema
-        description: 'The array value [''foo'', null, ''foo2'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_101
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_25
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema
-        description: 'The array value [''foo'', 123, ''foo2'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_102
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!UuidSchema> &ref_26
+    elementType: !<!UuidSchema> &ref_19
       type: uuid
       apiVersions:
       - !<!ApiVersion> 
@@ -931,34 +372,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-uuid-valid·get·responses·200·content·application-json·schema
         description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_103
+  - !<!ArraySchema> &ref_39
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_26
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-uuid-valid·put·requestbody·content·application-json·schema
-        description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_104
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_26
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-uuid-invalidchars·get·responses·200·content·application-json·schema
-        description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''foo'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_105
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateSchema> &ref_27
+    elementType: !<!DateSchema> &ref_20
       type: date
       apiVersions:
       - !<!ApiVersion> 
@@ -973,45 +392,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-date-valid·get·responses·200·content·application-json·schema
         description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_106
+  - !<!ArraySchema> &ref_40
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_27
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-date-valid·put·requestbody·content·application-json·schema
-        description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_107
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_27
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-date-invalidnull·get·responses·200·content·application-json·schema
-        description: 'The array value [''2012-01-01'', null, ''1776-07-04'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_108
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_27
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-date-invalidchars·get·responses·200·content·application-json·schema
-        description: 'The array value [''2011-03-22'', ''date'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_109
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateTimeSchema> &ref_28
+    elementType: !<!DateTimeSchema> &ref_21
       type: date-time
       format: date-time
       apiVersions:
@@ -1027,45 +413,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-date_time-valid·get·responses·200·content·application-json·schema
         description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_110
+  - !<!ArraySchema> &ref_41
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_28
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-date_time-valid·put·requestbody·content·application-json·schema
-        description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_111
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_28
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-date_time-invalidnull·get·responses·200·content·application-json·schema
-        description: 'The array value [''2000-12-01t00:00:01z'', null]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_112
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_28
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-date_time-invalidchars·get·responses·200·content·application-json·schema
-        description: 'The array value [''2000-12-01t00:00:01z'', ''date-time'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_113
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateTimeSchema> &ref_29
+    elementType: !<!DateTimeSchema> &ref_22
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -1081,23 +434,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
         description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_114
+  - !<!ArraySchema> &ref_42
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_29
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-date_time_rfc1123-valid·put·requestbody·content·application-json·schema
-        description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_115
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DurationSchema> &ref_30
+    elementType: !<!DurationSchema> &ref_23
       type: duration
       apiVersions:
       - !<!ApiVersion> 
@@ -1112,23 +454,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-duration-valid·get·responses·200·content·application-json·schema
         description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_116
+  - !<!ArraySchema> &ref_43
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_30
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-duration-valid·put·requestbody·content·application-json·schema
-        description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_117
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!ByteArraySchema> &ref_31
+    elementType: !<!ByteArraySchema> &ref_24
       type: byte-array
       format: byte
       apiVersions:
@@ -1144,34 +475,12 @@ schemas: !<!Schemas>
         name: paths·array-prim-byte-valid·get·responses·200·content·application-json·schema
         description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_118
+  - !<!ArraySchema> &ref_44
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_31
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-byte-valid·put·requestbody·content·application-json·schema
-        description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_119
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_31
-    language: !<!Languages> 
-      default:
-        name: paths·array-prim-byte-invalidnull·get·responses·200·content·application-json·schema
-        description: 'The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_120
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!ByteArraySchema> &ref_61
+    elementType: !<!ByteArraySchema> &ref_25
       type: byte-array
       format: base64url
       apiVersions:
@@ -1187,233 +496,34 @@ schemas: !<!Schemas>
         name: paths·array-prim-base64url-valid·get·responses·200·content·application-json·schema
         description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_121
+  - !<!ArraySchema> &ref_45
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_34
+    elementType: *ref_15
     language: !<!Languages> 
       default:
         name: paths·array-complex-null·get·responses·200·content·application-json·schema
         description: array of complex type with null value
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_122
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_34
-    language: !<!Languages> 
-      default:
-        name: paths·array-complex-empty·get·responses·200·content·application-json·schema
-        description: 'Empty array of complex type []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_123
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_34
-    language: !<!Languages> 
-      default:
-        name: paths·array-complex-itemnull·get·responses·200·content·application-json·schema
-        description: 'Array of complex type with null item [{''integer'': 1 ''string'': ''2''}, null, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_124
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_34
-    language: !<!Languages> 
-      default:
-        name: paths·array-complex-itemempty·get·responses·200·content·application-json·schema
-        description: 'Array of complex type with empty item [{''integer'': 1 ''string'': ''2''}, {}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_125
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_34
-    language: !<!Languages> 
-      default:
-        name: paths·array-complex-valid·get·responses·200·content·application-json·schema
-        description: 'array of complex type with [{''integer'': 1 ''string'': ''2''}, {''integer'': 3, ''string'': ''4''}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_126
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_34
-    language: !<!Languages> 
-      default:
-        name: paths·array-complex-valid·put·requestbody·content·application-json·schema
-        description: 'array of complex type with [{''integer'': 1 ''string'': ''2''}, {''integer'': 3, ''string'': ''4''}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_36
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_35
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-array-null·get·responses·200·content·application-json·schema·items·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-null·get·responses·200·content·application-json·schema·items
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_127
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_36
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-null·get·responses·200·content·application-json·schema
-        description: a null array
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_38
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_37
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-array-empty·get·responses·200·content·application-json·schema·items·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-empty·get·responses·200·content·application-json·schema·items
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_128
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_38
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-empty·get·responses·200·content·application-json·schema
-        description: 'An empty array []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_40
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_39
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-array-itemnull·get·responses·200·content·application-json·schema·items·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-itemnull·get·responses·200·content·application-json·schema·items
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_129
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_40
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-itemnull·get·responses·200·content·application-json·schema
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], null, [''7'', ''8'', ''9'']]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_42
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_41
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-array-itemempty·get·responses·200·content·application-json·schema·items·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-itemempty·get·responses·200·content·application-json·schema·items
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_130
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_42
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-itemempty·get·responses·200·content·application-json·schema
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], [], [''7'', ''8'', ''9'']]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_44
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_43
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·array-array-valid·get·responses·200·content·application-json·schema·items·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-valid·get·responses·200·content·application-json·schema·items
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_131
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_44
-    language: !<!Languages> 
-      default:
-        name: paths·array-array-valid·get·responses·200·content·application-json·schema
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_46
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_45
+    elementType: *ref_10
+    language: !<!Languages> 
+      default:
+        name: paths·array-array-null·get·responses·200·content·application-json·schema
+        description: a null array
+    protocol: !<!Protocols> {}
+  - !<!ArraySchema> &ref_12
+    type: array
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    elementType: !<!StringSchema> &ref_11
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -1428,149 +538,62 @@ schemas: !<!Schemas>
         name: paths·array-array-valid·put·requestbody·content·application-json·schema·items
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_132
+  - !<!ArraySchema> &ref_47
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_46
+    elementType: *ref_12
     language: !<!Languages> 
       default:
         name: paths·array-array-valid·put·requestbody·content·application-json·schema
         description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_133
+  - !<!ArraySchema> &ref_48
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_62
+    elementType: *ref_26
     language: !<!Languages> 
       default:
         name: paths·array-dictionary-null·get·responses·200·content·application-json·schema
         description: An array of Dictionaries with value null
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_134
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_63
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-empty·get·responses·200·content·application-json·schema
-        description: 'An array of Dictionaries of type <string, string> with value []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_135
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_64
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, null, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_136
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_65
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_137
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_66
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-valid·get·responses·200·content·application-json·schema
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {''4'': ''four'', ''5'': ''five'', ''6'': ''six''}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_138
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_67
-    language: !<!Languages> 
-      default:
-        name: paths·array-dictionary-valid·put·requestbody·content·application-json·schema
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {''4'': ''four'', ''5'': ''five'', ''6'': ''six''}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
   booleans:
-  - *ref_55
-  - *ref_56
-  - *ref_57
-  - *ref_58
-  byteArrays:
-  - *ref_31
-  - *ref_61
-  dateTimes:
-  - *ref_28
-  - *ref_29
-  dates:
-  - *ref_27
-  durations:
-  - *ref_30
-  numbers:
-  - *ref_0
-  - *ref_53
-  - *ref_1
-  - *ref_2
-  - *ref_4
-  - *ref_5
-  - *ref_6
-  - *ref_7
-  - *ref_8
-  - *ref_9
-  - *ref_10
-  - *ref_11
-  - *ref_12
-  - *ref_13
-  - *ref_14
-  - *ref_15
   - *ref_16
-  - *ref_17
-  - *ref_18
-  - *ref_19
-  - *ref_32
-  sealedChoices:
-  - *ref_59
-  - *ref_60
-  strings:
-  - *ref_22
-  - *ref_54
-  - *ref_3
-  - *ref_20
-  - *ref_21
+  byteArrays:
   - *ref_24
   - *ref_25
-  - *ref_33
-  - *ref_35
-  - *ref_37
-  - *ref_39
-  - *ref_41
-  - *ref_43
-  - *ref_45
-  - *ref_47
-  - *ref_48
-  - *ref_49
-  - *ref_50
-  - *ref_51
-  - *ref_52
+  dateTimes:
+  - *ref_21
+  - *ref_22
+  dates:
+  - *ref_20
+  durations:
+  - *ref_23
+  numbers:
+  - *ref_0
+  - *ref_13
+  - *ref_1
+  - *ref_3
+  - *ref_4
+  - *ref_5
+  - *ref_8
+  sealedChoices:
+  - *ref_18
+  strings:
+  - *ref_7
+  - *ref_14
+  - *ref_2
+  - *ref_6
+  - *ref_9
+  - *ref_11
   uuids:
-  - *ref_26
+  - *ref_19
 globalParameters:
-- !<!Parameter> &ref_70
-  schema: *ref_22
+- !<!Parameter> &ref_29
+  schema: *ref_7
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -1580,7 +603,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-array
@@ -1594,18 +617,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/null'
+          path: /array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_68
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1619,7 +643,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1642,18 +666,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/invalid'
+          path: /array/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_71
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -1667,7 +692,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1690,18 +715,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/empty'
+          path: /array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_72
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -1715,7 +741,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1738,9 +764,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_31
         implementation: Method
         required: true
         extensions:
@@ -1759,11 +785,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/empty'
+          path: /array/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1776,7 +803,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1801,18 +828,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/tfft'
+          path: /array/prim/boolean/tfft
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_74
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1826,7 +854,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1849,9 +877,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -1870,11 +898,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/boolean/tfft'
+          path: /array/prim/boolean/tfft
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1887,7 +916,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1912,18 +941,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/true.null.false'
+          path: /array/prim/boolean/true.null.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_76
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1937,7 +967,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1960,18 +990,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/true.boolean.false'
+          path: /array/prim/boolean/true.boolean.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_77
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1985,7 +1016,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2008,18 +1039,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.-1.3.300'
+          path: /array/prim/integer/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2033,7 +1065,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2056,9 +1088,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_79
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2077,11 +1109,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/integer/1.-1.3.300'
+          path: /array/prim/integer/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2094,7 +1127,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2119,18 +1152,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.null.zero'
+          path: /array/prim/integer/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_80
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2144,7 +1178,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2167,18 +1201,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.integer.0'
+          path: /array/prim/integer/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_81
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2192,7 +1227,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2215,18 +1250,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.-1.3.300'
+          path: /array/prim/long/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_82
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2240,7 +1276,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2263,9 +1299,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_83
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -2284,11 +1320,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/long/1.-1.3.300'
+          path: /array/prim/long/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2301,7 +1338,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2326,18 +1363,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.null.zero'
+          path: /array/prim/long/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_84
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2351,7 +1389,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2374,18 +1412,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.integer.0'
+          path: /array/prim/long/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_85
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2399,7 +1438,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2422,18 +1461,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/0--0.01-1.2e20'
+          path: /array/prim/float/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_86
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2447,7 +1487,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2470,9 +1510,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_87
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -2491,11 +1531,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/float/0--0.01-1.2e20'
+          path: /array/prim/float/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2508,7 +1549,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2533,18 +1574,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/0.0-null-1.2e20'
+          path: /array/prim/float/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2558,7 +1600,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2581,18 +1623,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/1.number.0'
+          path: /array/prim/float/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2606,7 +1649,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2629,18 +1672,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/0--0.01-1.2e20'
+          path: /array/prim/double/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_90
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2654,7 +1698,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2677,9 +1721,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -2698,11 +1742,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/double/0--0.01-1.2e20'
+          path: /array/prim/double/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2715,7 +1760,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2740,18 +1785,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/0.0-null-1.2e20'
+          path: /array/prim/double/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2765,7 +1811,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2788,18 +1834,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/1.number.0'
+          path: /array/prim/double/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_93
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2813,7 +1860,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2836,18 +1883,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo1.foo2.foo3'
+          path: /array/prim/string/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -2861,7 +1909,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2884,9 +1932,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_95
+        schema: *ref_10
         implementation: Method
         required: true
         extensions:
@@ -2905,11 +1953,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/string/foo1.foo2.foo3'
+          path: /array/prim/string/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2922,7 +1971,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2947,18 +1996,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/enum/foo1.foo2.foo3'
+          path: /array/prim/enum/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_96
+      schema: *ref_36
       language: !<!Languages> 
         default:
           name: ''
@@ -2972,7 +2022,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2995,9 +2045,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_97
+        schema: *ref_36
         implementation: Method
         required: true
         extensions:
@@ -3016,11 +2066,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/enum/foo1.foo2.foo3'
+          path: /array/prim/enum/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3033,7 +2084,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3058,18 +2109,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string-enum/foo1.foo2.foo3'
+          path: /array/prim/string-enum/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_98
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3083,7 +2135,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3106,9 +2158,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_99
+        schema: *ref_37
         implementation: Method
         required: true
         extensions:
@@ -3127,11 +2179,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/string-enum/foo1.foo2.foo3'
+          path: /array/prim/string-enum/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3144,7 +2197,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3169,18 +2222,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo.null.foo2'
+          path: /array/prim/string/foo.null.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_100
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -3194,7 +2248,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3217,18 +2271,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo.123.foo2'
+          path: /array/prim/string/foo.123.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_101
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -3242,7 +2297,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3265,18 +2320,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/uuid/valid'
+          path: /array/prim/uuid/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_102
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3290,7 +2346,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3313,9 +2369,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_103
+        schema: *ref_38
         implementation: Method
         required: true
         extensions:
@@ -3334,11 +2390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/uuid/valid'
+          path: /array/prim/uuid/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3351,7 +2408,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3376,18 +2433,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/uuid/invalidchars'
+          path: /array/prim/uuid/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_104
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3401,7 +2459,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3424,18 +2482,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/valid'
+          path: /array/prim/date/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_105
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3449,7 +2508,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3472,9 +2531,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_106
+        schema: *ref_39
         implementation: Method
         required: true
         extensions:
@@ -3493,11 +2552,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date/valid'
+          path: /array/prim/date/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3510,7 +2570,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3535,18 +2595,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/invalidnull'
+          path: /array/prim/date/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_107
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3560,7 +2621,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3583,18 +2644,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/invalidchars'
+          path: /array/prim/date/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_108
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3608,7 +2670,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3631,18 +2693,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/valid'
+          path: /array/prim/date-time/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_109
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3656,7 +2719,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3679,9 +2742,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_110
+        schema: *ref_40
         implementation: Method
         required: true
         extensions:
@@ -3700,11 +2763,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date-time/valid'
+          path: /array/prim/date-time/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3717,7 +2781,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3742,18 +2806,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/invalidnull'
+          path: /array/prim/date-time/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_111
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3767,7 +2832,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3790,18 +2855,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/invalidchars'
+          path: /array/prim/date-time/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_112
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3815,7 +2881,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3838,18 +2904,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time-rfc1123/valid'
+          path: /array/prim/date-time-rfc1123/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_113
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -3863,7 +2930,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3886,9 +2953,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_114
+        schema: *ref_41
         implementation: Method
         required: true
         extensions:
@@ -3907,11 +2974,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date-time-rfc1123/valid'
+          path: /array/prim/date-time-rfc1123/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3924,7 +2992,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3949,18 +3017,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/duration/valid'
+          path: /array/prim/duration/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_115
+      schema: *ref_42
       language: !<!Languages> 
         default:
           name: ''
@@ -3974,7 +3043,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -3997,9 +3066,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_116
+        schema: *ref_42
         implementation: Method
         required: true
         extensions:
@@ -4018,11 +3087,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/duration/valid'
+          path: /array/prim/duration/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4035,7 +3105,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4060,18 +3130,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/byte/valid'
+          path: /array/prim/byte/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_117
+      schema: *ref_43
       language: !<!Languages> 
         default:
           name: ''
@@ -4085,7 +3156,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4108,9 +3179,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_118
+        schema: *ref_43
         implementation: Method
         required: true
         extensions:
@@ -4129,11 +3200,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/byte/valid'
+          path: /array/prim/byte/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4146,7 +3218,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4171,18 +3243,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/byte/invalidnull'
+          path: /array/prim/byte/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_119
+      schema: *ref_43
       language: !<!Languages> 
         default:
           name: ''
@@ -4196,7 +3269,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4219,18 +3292,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/base64url/valid'
+          path: /array/prim/base64url/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_120
+      schema: *ref_44
       language: !<!Languages> 
         default:
           name: ''
@@ -4244,7 +3318,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4267,18 +3341,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/null'
+          path: /array/complex/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_121
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4292,7 +3367,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4315,18 +3390,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/empty'
+          path: /array/complex/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_122
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4340,7 +3416,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4363,18 +3439,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/itemnull'
+          path: /array/complex/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_123
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4388,7 +3465,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4411,18 +3488,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/itemempty'
+          path: /array/complex/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_124
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4436,7 +3514,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4459,18 +3537,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/valid'
+          path: /array/complex/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_125
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4484,7 +3563,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4507,9 +3586,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_126
+        schema: *ref_45
         implementation: Method
         required: true
         extensions:
@@ -4528,11 +3607,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/complex/valid'
+          path: /array/complex/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4545,7 +3625,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4570,18 +3650,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/null'
+          path: /array/array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_127
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4595,7 +3676,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4618,18 +3699,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/empty'
+          path: /array/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_128
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4643,7 +3725,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4666,18 +3748,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/itemnull'
+          path: /array/array/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_129
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4691,7 +3774,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4714,18 +3797,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/itemempty'
+          path: /array/array/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_130
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4739,7 +3823,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4762,18 +3846,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/valid'
+          path: /array/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_131
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4787,7 +3872,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4810,9 +3895,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_132
+        schema: *ref_47
         implementation: Method
         required: true
         extensions:
@@ -4831,11 +3916,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/array/valid'
+          path: /array/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4848,7 +3934,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4873,18 +3959,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/null'
+          path: /array/dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_133
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4898,7 +3985,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4921,18 +4008,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/empty'
+          path: /array/dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_134
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4946,7 +4034,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -4969,18 +4057,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/itemnull'
+          path: /array/dictionary/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_135
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4994,7 +4083,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -5017,18 +4106,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/itemempty'
+          path: /array/dictionary/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_136
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -5042,7 +4132,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -5065,18 +4155,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/valid'
+          path: /array/dictionary/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_137
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -5090,7 +4181,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -5113,9 +4204,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_70
+      - *ref_29
       - !<!Parameter> 
-        schema: *ref_138
+        schema: *ref_48
         implementation: Method
         required: true
         extensions:
@@ -5134,11 +4225,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/dictionary/valid'
+          path: /array/dictionary/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5151,7 +4243,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-array/namer.yaml
+++ b/modelerfour/test/outputs/body-array/namer.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_70
+  - !<!ObjectSchema> &ref_29
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_27
+      schema: !<!NumberSchema> &ref_15
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_49
+      schema: !<!StringSchema> &ref_22
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -45,14 +45,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_8
+  - !<!ObjectSchema> &ref_3
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_46
+      schema: !<!NumberSchema> &ref_20
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_55
+      schema: !<!StringSchema> &ref_24
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -90,9 +90,9 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_15
+  - !<!DictionarySchema> &ref_6
     type: dictionary
-    elementType: !<!StringSchema> &ref_62
+    elementType: !<!StringSchema> &ref_0
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -105,95 +105,10 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-null·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_16
-    type: dictionary
-    elementType: !<!StringSchema> &ref_63
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-empty·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_17
-    type: dictionary
-    elementType: !<!StringSchema> &ref_64
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-itemnull·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_18
-    type: dictionary
-    elementType: !<!StringSchema> &ref_65
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-itemempty·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_19
-    type: dictionary
-    elementType: !<!StringSchema> &ref_66
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-valid·get·responses·200·content·application-json·schema·items·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_20
-    type: dictionary
-    elementType: !<!StringSchema> &ref_67
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-dictionary-valid·put·requestbody·content·application-json·schema·items·additionalproperties>
+        description: Dictionary of <paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items>
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_0
+  - !<!ChoiceSchema> &ref_1
     choices:
     - !<!ChoiceValue> 
       value: foo1
@@ -217,7 +132,7 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    choiceType: !<!StringSchema> &ref_1
+    choiceType: !<!StringSchema> &ref_2
       type: string
       language: !<!Languages> 
         default:
@@ -230,12 +145,12 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_69
+  - !<!ArraySchema> &ref_28
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_26
+    elementType: !<!NumberSchema> &ref_14
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -251,12 +166,12 @@ schemas: !<!Schemas>
         name: ArrayOfget-200-application-json-itemsItem
         description: The null Array value
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_71
+  - !<!ArraySchema> &ref_30
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_28
+    elementType: !<!NumberSchema> &ref_16
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -272,33 +187,12 @@ schemas: !<!Schemas>
         name: ArrayOfinteger
         description: 'The invalid Array [1, 2, 3'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_72
+  - !<!ArraySchema> &ref_31
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_29
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The empty array value []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_73
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_50
+    elementType: !<!StringSchema> &ref_23
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -313,12 +207,12 @@ schemas: !<!Schemas>
         name: ArrayOfput-content-schemaItem
         description: 'The empty array value []'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_74
+  - !<!ArraySchema> &ref_32
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_21
+    elementType: !<!BooleanSchema> &ref_7
       type: boolean
       apiVersions:
       - !<!ApiVersion> 
@@ -333,156 +227,12 @@ schemas: !<!Schemas>
         name: ArrayOfboolean
         description: 'The array value [true, false, false, true]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_75
+  - !<!ArraySchema> &ref_33
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_22
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfboolean
-        description: 'The array value [true, false, false, true]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_76
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_23
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfboolean
-        description: 'The array value [true, null, false]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_77
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!BooleanSchema> &ref_24
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfboolean
-        description: 'The array value [true, ''boolean'', false]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_78
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_30
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_79
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_31
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_80
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_32
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, null, 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_81
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_33
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, ''integer'', 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_82
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_34
+    elementType: !<!NumberSchema> &ref_17
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -498,75 +248,12 @@ schemas: !<!Schemas>
         name: ArrayOfinteger
         description: 'The array value [1, -1, 3, 300]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_83
+  - !<!ArraySchema> &ref_34
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_35
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, -1, 3, 300]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_84
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_36
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, null, 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_85
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_37
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfinteger
-        description: 'The array value [1, ''integer'', 0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_86
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_38
+    elementType: !<!NumberSchema> &ref_18
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -582,75 +269,12 @@ schemas: !<!Schemas>
         name: ArrayOfnumber
         description: 'The array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_87
+  - !<!ArraySchema> &ref_35
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!NumberSchema> &ref_39
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [0, -0.01, 1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_88
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_40
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [0.0, null, -1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_89
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_41
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [1.0, ''number'', 0.0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_90
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_42
+    elementType: !<!NumberSchema> &ref_19
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -666,110 +290,7 @@ schemas: !<!Schemas>
         name: ArrayOfnumber
         description: 'The array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_91
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_43
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [0, -0.01, 1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_92
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_44
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [0.0, null, -1.2e20]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_93
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!NumberSchema> &ref_45
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfnumber
-        description: 'The array value [1.0, ''number'', 0.0]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_94
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_51
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfstring
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_95
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_52
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfstring
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_96
+  - !<!ArraySchema> &ref_4
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -777,26 +298,26 @@ schemas: !<!Schemas>
     elementType: *ref_0
     language: !<!Languages> 
       default:
-        name: ArrayOfFooEnum
+        name: ArrayOfstring
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_97
+  - !<!ArraySchema> &ref_36
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_0
+    elementType: *ref_1
     language: !<!Languages> 
       default:
         name: ArrayOfFooEnum
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_98
+  - !<!ArraySchema> &ref_37
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!SealedChoiceSchema> &ref_47
+    elementType: !<!SealedChoiceSchema> &ref_21
       choices:
       - !<!ChoiceValue> 
         value: foo1
@@ -820,7 +341,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      choiceType: *ref_1
+      choiceType: *ref_2
       language: !<!Languages> 
         default:
           name: Enum0
@@ -831,92 +352,12 @@ schemas: !<!Schemas>
         name: ArrayOfEnum0
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_99
+  - !<!ArraySchema> &ref_38
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!SealedChoiceSchema> &ref_48
-      choices:
-      - !<!ChoiceValue> 
-        value: foo1
-        language:
-          default:
-            name: foo1
-            description: ''
-      - !<!ChoiceValue> 
-        value: foo2
-        language:
-          default:
-            name: foo2
-            description: ''
-      - !<!ChoiceValue> 
-        value: foo3
-        language:
-          default:
-            name: foo3
-            description: ''
-      type: sealed-choice
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      choiceType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: Enum1
-          description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfEnum1
-        description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_100
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_53
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfstring
-        description: 'The array value [''foo'', null, ''foo2'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_101
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_54
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: ArrayOfstring
-        description: 'The array value [''foo'', 123, ''foo2'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_102
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!UuidSchema> &ref_2
+    elementType: !<!UuidSchema> &ref_26
       type: uuid
       apiVersions:
       - !<!ApiVersion> 
@@ -931,34 +372,12 @@ schemas: !<!Schemas>
         name: ArrayOfuuid
         description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_103
+  - !<!ArraySchema> &ref_39
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: ArrayOfuuid
-        description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_104
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: ArrayOfuuid
-        description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''foo'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_105
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateSchema> &ref_3
+    elementType: !<!DateSchema> &ref_12
       type: date
       apiVersions:
       - !<!ApiVersion> 
@@ -973,45 +392,12 @@ schemas: !<!Schemas>
         name: ArrayOfdate
         description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_106
+  - !<!ArraySchema> &ref_40
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate
-        description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_107
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate
-        description: 'The array value [''2012-01-01'', null, ''1776-07-04'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_108
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate
-        description: 'The array value [''2011-03-22'', ''date'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_109
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateTimeSchema> &ref_4
+    elementType: !<!DateTimeSchema> &ref_10
       type: date-time
       format: date-time
       apiVersions:
@@ -1027,45 +413,12 @@ schemas: !<!Schemas>
         name: ArrayOfdate-time
         description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_110
+  - !<!ArraySchema> &ref_41
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_4
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate-time
-        description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_111
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_4
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate-time
-        description: 'The array value [''2000-12-01t00:00:01z'', null]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_112
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_4
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate-time
-        description: 'The array value [''2000-12-01t00:00:01z'', ''date-time'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_113
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DateTimeSchema> &ref_5
+    elementType: !<!DateTimeSchema> &ref_11
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -1081,23 +434,12 @@ schemas: !<!Schemas>
         name: ArrayOfdate-time
         description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_114
+  - !<!ArraySchema> &ref_42
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_5
-    language: !<!Languages> 
-      default:
-        name: ArrayOfdate-time
-        description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_115
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!DurationSchema> &ref_6
+    elementType: !<!DurationSchema> &ref_13
       type: duration
       apiVersions:
       - !<!ApiVersion> 
@@ -1112,23 +454,12 @@ schemas: !<!Schemas>
         name: ArrayOfduration
         description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_116
+  - !<!ArraySchema> &ref_43
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_6
-    language: !<!Languages> 
-      default:
-        name: ArrayOfduration
-        description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_117
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!ByteArraySchema> &ref_7
+    elementType: !<!ByteArraySchema> &ref_8
       type: byte-array
       format: byte
       apiVersions:
@@ -1144,34 +475,12 @@ schemas: !<!Schemas>
         name: ArrayOfbyte-array
         description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_118
+  - !<!ArraySchema> &ref_44
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_7
-    language: !<!Languages> 
-      default:
-        name: ArrayOfbyte-array
-        description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_119
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_7
-    language: !<!Languages> 
-      default:
-        name: ArrayOfbyte-array
-        description: 'The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_120
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!ByteArraySchema> &ref_25
+    elementType: !<!ByteArraySchema> &ref_9
       type: byte-array
       format: base64url
       apiVersions:
@@ -1187,233 +496,34 @@ schemas: !<!Schemas>
         name: ArrayOfbyte-array
         description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_121
+  - !<!ArraySchema> &ref_45
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_8
+    elementType: *ref_3
     language: !<!Languages> 
       default:
         name: ArrayOfProduct
         description: array of complex type with null value
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_122
+  - !<!ArraySchema> &ref_46
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_8
+    elementType: *ref_4
     language: !<!Languages> 
       default:
-        name: ArrayOfProduct
-        description: 'Empty array of complex type []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_123
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_8
-    language: !<!Languages> 
-      default:
-        name: ArrayOfProduct
-        description: 'Array of complex type with null item [{''integer'': 1 ''string'': ''2''}, null, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_124
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_8
-    language: !<!Languages> 
-      default:
-        name: ArrayOfProduct
-        description: 'Array of complex type with empty item [{''integer'': 1 ''string'': ''2''}, {}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_125
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_8
-    language: !<!Languages> 
-      default:
-        name: ArrayOfProduct
-        description: 'array of complex type with [{''integer'': 1 ''string'': ''2''}, {''integer'': 3, ''string'': ''4''}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_126
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_8
-    language: !<!Languages> 
-      default:
-        name: ArrayOfProduct
-        description: 'array of complex type with [{''integer'': 1 ''string'': ''2''}, {''integer'': 3, ''string'': ''4''}, {''integer'': 5, ''string'': ''6''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_9
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_56
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_127
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_9
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
+        name: ArrayOfArrayOfstring
         description: a null array
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_10
+  - !<!ArraySchema> &ref_5
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_57
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_128
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_10
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
-        description: 'An empty array []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_11
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_58
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_129
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_11
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], null, [''7'', ''8'', ''9'']]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_12
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_59
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_130
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_12
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], [], [''7'', ''8'', ''9'']]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_13
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_60
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_131
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_13
-    language: !<!Languages> 
-      default:
-        name: ArrayOfArray of string
-        description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_14
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_61
+    elementType: !<!StringSchema> &ref_25
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -1428,149 +538,62 @@ schemas: !<!Schemas>
         name: Array of put-content-schema-itemsItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_132
+  - !<!ArraySchema> &ref_47
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_14
+    elementType: *ref_5
     language: !<!Languages> 
       default:
         name: ArrayOfArray of put-content-schema-itemsItem
         description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_133
+  - !<!ArraySchema> &ref_48
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_15
+    elementType: *ref_6
     language: !<!Languages> 
       default:
         name: ArrayOfDictionary of string
         description: An array of Dictionaries with value null
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_134
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_16
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value []'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_135
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_17
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, null, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_136
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_18
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_137
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_19
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {''4'': ''four'', ''5'': ''five'', ''6'': ''six''}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_138
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_20
-    language: !<!Languages> 
-      default:
-        name: ArrayOfDictionary of string
-        description: 'An array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {''4'': ''four'', ''5'': ''five'', ''6'': ''six''}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
-    protocol: !<!Protocols> {}
   booleans:
+  - *ref_7
+  byteArrays:
+  - *ref_8
+  - *ref_9
+  dateTimes:
+  - *ref_10
+  - *ref_11
+  dates:
+  - *ref_12
+  durations:
+  - *ref_13
+  numbers:
+  - *ref_14
+  - *ref_15
+  - *ref_16
+  - *ref_17
+  - *ref_18
+  - *ref_19
+  - *ref_20
+  sealedChoices:
   - *ref_21
+  strings:
+  - *ref_2
   - *ref_22
   - *ref_23
+  - *ref_0
   - *ref_24
-  byteArrays:
-  - *ref_7
   - *ref_25
-  dateTimes:
-  - *ref_4
-  - *ref_5
-  dates:
-  - *ref_3
-  durations:
-  - *ref_6
-  numbers:
-  - *ref_26
-  - *ref_27
-  - *ref_28
-  - *ref_29
-  - *ref_30
-  - *ref_31
-  - *ref_32
-  - *ref_33
-  - *ref_34
-  - *ref_35
-  - *ref_36
-  - *ref_37
-  - *ref_38
-  - *ref_39
-  - *ref_40
-  - *ref_41
-  - *ref_42
-  - *ref_43
-  - *ref_44
-  - *ref_45
-  - *ref_46
-  sealedChoices:
-  - *ref_47
-  - *ref_48
-  strings:
-  - *ref_1
-  - *ref_49
-  - *ref_50
-  - *ref_51
-  - *ref_52
-  - *ref_53
-  - *ref_54
-  - *ref_55
-  - *ref_56
-  - *ref_57
-  - *ref_58
-  - *ref_59
-  - *ref_60
-  - *ref_61
-  - *ref_62
-  - *ref_63
-  - *ref_64
-  - *ref_65
-  - *ref_66
-  - *ref_67
   uuids:
-  - *ref_2
+  - *ref_26
 globalParameters:
-- !<!Parameter> &ref_68
-  schema: *ref_1
+- !<!Parameter> &ref_27
+  schema: *ref_2
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -1580,7 +603,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-array
@@ -1594,18 +617,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/null'
+          path: /array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_69
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1619,7 +643,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1642,18 +666,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/invalid'
+          path: /array/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_71
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -1667,7 +692,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1690,18 +715,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/empty'
+          path: /array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_72
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -1715,7 +741,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1738,9 +764,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_31
         implementation: Method
         required: true
         extensions:
@@ -1759,11 +785,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/empty'
+          path: /array/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1776,7 +803,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1801,18 +828,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/tfft'
+          path: /array/prim/boolean/tfft
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_74
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1826,7 +854,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1849,9 +877,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -1870,11 +898,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/boolean/tfft'
+          path: /array/prim/boolean/tfft
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1887,7 +916,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1912,18 +941,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/true.null.false'
+          path: /array/prim/boolean/true.null.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_76
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1937,7 +967,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -1960,18 +990,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/boolean/true.boolean.false'
+          path: /array/prim/boolean/true.boolean.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_77
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -1985,7 +1016,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2008,18 +1039,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.-1.3.300'
+          path: /array/prim/integer/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2033,7 +1065,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2056,9 +1088,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_79
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2077,11 +1109,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/integer/1.-1.3.300'
+          path: /array/prim/integer/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2094,7 +1127,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2119,18 +1152,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.null.zero'
+          path: /array/prim/integer/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_80
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2144,7 +1178,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2167,18 +1201,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/integer/1.integer.0'
+          path: /array/prim/integer/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_81
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2192,7 +1227,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2215,18 +1250,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.-1.3.300'
+          path: /array/prim/long/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_82
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2240,7 +1276,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2263,9 +1299,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_83
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -2284,11 +1320,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/long/1.-1.3.300'
+          path: /array/prim/long/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2301,7 +1338,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2326,18 +1363,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.null.zero'
+          path: /array/prim/long/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_84
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2351,7 +1389,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2374,18 +1412,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/long/1.integer.0'
+          path: /array/prim/long/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_85
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2399,7 +1438,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2422,18 +1461,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/0--0.01-1.2e20'
+          path: /array/prim/float/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_86
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2447,7 +1487,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2470,9 +1510,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_87
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -2491,11 +1531,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/float/0--0.01-1.2e20'
+          path: /array/prim/float/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2508,7 +1549,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2533,18 +1574,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/0.0-null-1.2e20'
+          path: /array/prim/float/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2558,7 +1600,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2581,18 +1623,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/float/1.number.0'
+          path: /array/prim/float/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -2606,7 +1649,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2629,18 +1672,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/0--0.01-1.2e20'
+          path: /array/prim/double/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_90
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2654,7 +1698,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2677,9 +1721,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -2698,11 +1742,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/double/0--0.01-1.2e20'
+          path: /array/prim/double/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2715,7 +1760,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2740,18 +1785,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/0.0-null-1.2e20'
+          path: /array/prim/double/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2765,7 +1811,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2788,18 +1834,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/double/1.number.0'
+          path: /array/prim/double/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_93
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -2813,7 +1860,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2836,18 +1883,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo1.foo2.foo3'
+          path: /array/prim/string/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -2861,7 +1909,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2884,9 +1932,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_95
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -2905,11 +1953,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/string/foo1.foo2.foo3'
+          path: /array/prim/string/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2922,7 +1971,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2947,18 +1996,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/enum/foo1.foo2.foo3'
+          path: /array/prim/enum/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_96
+      schema: *ref_36
       language: !<!Languages> 
         default:
           name: ''
@@ -2972,7 +2022,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2995,9 +2045,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_97
+        schema: *ref_36
         implementation: Method
         required: true
         extensions:
@@ -3016,11 +2066,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/enum/foo1.foo2.foo3'
+          path: /array/prim/enum/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3033,7 +2084,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3058,18 +2109,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string-enum/foo1.foo2.foo3'
+          path: /array/prim/string-enum/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_98
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3083,7 +2135,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3106,9 +2158,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_99
+        schema: *ref_37
         implementation: Method
         required: true
         extensions:
@@ -3127,11 +2179,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/string-enum/foo1.foo2.foo3'
+          path: /array/prim/string-enum/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3144,7 +2197,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3169,18 +2222,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo.null.foo2'
+          path: /array/prim/string/foo.null.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_100
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -3194,7 +2248,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3217,18 +2271,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/string/foo.123.foo2'
+          path: /array/prim/string/foo.123.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_101
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -3242,7 +2297,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3265,18 +2320,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/uuid/valid'
+          path: /array/prim/uuid/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_102
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3290,7 +2346,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3313,9 +2369,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_103
+        schema: *ref_38
         implementation: Method
         required: true
         extensions:
@@ -3334,11 +2390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/uuid/valid'
+          path: /array/prim/uuid/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3351,7 +2408,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3376,18 +2433,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/uuid/invalidchars'
+          path: /array/prim/uuid/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_104
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3401,7 +2459,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3424,18 +2482,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/valid'
+          path: /array/prim/date/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_105
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3449,7 +2508,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3472,9 +2531,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_106
+        schema: *ref_39
         implementation: Method
         required: true
         extensions:
@@ -3493,11 +2552,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date/valid'
+          path: /array/prim/date/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3510,7 +2570,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3535,18 +2595,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/invalidnull'
+          path: /array/prim/date/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_107
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3560,7 +2621,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3583,18 +2644,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date/invalidchars'
+          path: /array/prim/date/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_108
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3608,7 +2670,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3631,18 +2693,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/valid'
+          path: /array/prim/date-time/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_109
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3656,7 +2719,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3679,9 +2742,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_110
+        schema: *ref_40
         implementation: Method
         required: true
         extensions:
@@ -3700,11 +2763,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date-time/valid'
+          path: /array/prim/date-time/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3717,7 +2781,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3742,18 +2806,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/invalidnull'
+          path: /array/prim/date-time/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_111
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3767,7 +2832,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3790,18 +2855,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time/invalidchars'
+          path: /array/prim/date-time/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_112
+      schema: *ref_40
       language: !<!Languages> 
         default:
           name: ''
@@ -3815,7 +2881,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3838,18 +2904,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/date-time-rfc1123/valid'
+          path: /array/prim/date-time-rfc1123/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_113
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -3863,7 +2930,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3886,9 +2953,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_114
+        schema: *ref_41
         implementation: Method
         required: true
         extensions:
@@ -3907,11 +2974,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/date-time-rfc1123/valid'
+          path: /array/prim/date-time-rfc1123/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3924,7 +2992,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3949,18 +3017,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/duration/valid'
+          path: /array/prim/duration/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_115
+      schema: *ref_42
       language: !<!Languages> 
         default:
           name: ''
@@ -3974,7 +3043,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3997,9 +3066,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_116
+        schema: *ref_42
         implementation: Method
         required: true
         extensions:
@@ -4018,11 +3087,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/duration/valid'
+          path: /array/prim/duration/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4035,7 +3105,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4060,18 +3130,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/byte/valid'
+          path: /array/prim/byte/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_117
+      schema: *ref_43
       language: !<!Languages> 
         default:
           name: ''
@@ -4085,7 +3156,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4108,9 +3179,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_118
+        schema: *ref_43
         implementation: Method
         required: true
         extensions:
@@ -4129,11 +3200,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/prim/byte/valid'
+          path: /array/prim/byte/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4146,7 +3218,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4171,18 +3243,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/byte/invalidnull'
+          path: /array/prim/byte/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_119
+      schema: *ref_43
       language: !<!Languages> 
         default:
           name: ''
@@ -4196,7 +3269,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4219,18 +3292,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/prim/base64url/valid'
+          path: /array/prim/base64url/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_120
+      schema: *ref_44
       language: !<!Languages> 
         default:
           name: ''
@@ -4244,7 +3318,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4267,18 +3341,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/null'
+          path: /array/complex/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_121
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4292,7 +3367,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4315,18 +3390,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/empty'
+          path: /array/complex/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_122
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4340,7 +3416,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4363,18 +3439,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/itemnull'
+          path: /array/complex/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_123
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4388,7 +3465,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4411,18 +3488,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/itemempty'
+          path: /array/complex/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_124
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4436,7 +3514,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4459,18 +3537,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/complex/valid'
+          path: /array/complex/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_125
+      schema: *ref_45
       language: !<!Languages> 
         default:
           name: ''
@@ -4484,7 +3563,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4507,9 +3586,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_126
+        schema: *ref_45
         implementation: Method
         required: true
         extensions:
@@ -4528,11 +3607,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/complex/valid'
+          path: /array/complex/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4545,7 +3625,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4570,18 +3650,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/null'
+          path: /array/array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_127
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4595,7 +3676,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4618,18 +3699,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/empty'
+          path: /array/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_128
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4643,7 +3725,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4666,18 +3748,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/itemnull'
+          path: /array/array/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_129
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4691,7 +3774,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4714,18 +3797,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/itemempty'
+          path: /array/array/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_130
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4739,7 +3823,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4762,18 +3846,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/array/valid'
+          path: /array/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_131
+      schema: *ref_46
       language: !<!Languages> 
         default:
           name: ''
@@ -4787,7 +3872,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4810,9 +3895,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_132
+        schema: *ref_47
         implementation: Method
         required: true
         extensions:
@@ -4831,11 +3916,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/array/valid'
+          path: /array/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4848,7 +3934,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4873,18 +3959,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/null'
+          path: /array/dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_133
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4898,7 +3985,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4921,18 +4008,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/empty'
+          path: /array/dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_134
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4946,7 +4034,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4969,18 +4057,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/itemnull'
+          path: /array/dictionary/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_135
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -4994,7 +4083,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -5017,18 +4106,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/itemempty'
+          path: /array/dictionary/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_136
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -5042,7 +4132,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -5065,18 +4155,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/array/dictionary/valid'
+          path: /array/dictionary/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_137
+      schema: *ref_48
       language: !<!Languages> 
         default:
           name: ''
@@ -5090,7 +4181,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -5113,9 +4204,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_68
+      - *ref_27
       - !<!Parameter> 
-        schema: *ref_138
+        schema: *ref_48
         implementation: Method
         required: true
         extensions:
@@ -5134,11 +4225,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/array/dictionary/valid'
+          path: /array/dictionary/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5151,7 +4243,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-boolean.quirks/flattened.yaml
+++ b/modelerfour/test/outputs/body-boolean.quirks/flattened.yaml
@@ -56,56 +56,6 @@ schemas: !<!Schemas>
         name: boolean
         description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_6
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_7
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_8
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_9
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_10
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
   numbers:
   - *ref_0
   strings:
@@ -129,7 +79,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-boolean.quirks
@@ -150,8 +100,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -193,7 +144,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -212,11 +163,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -261,11 +213,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -304,7 +257,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -323,11 +276,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -372,11 +326,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/null'
+          path: /bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -420,11 +375,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/invalid'
+          path: /bool/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-boolean.quirks/modeler.yaml
+++ b/modelerfour/test/outputs/body-boolean.quirks/modeler.yaml
@@ -56,56 +56,6 @@ schemas: !<!Schemas>
         name: paths·bool-true·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_6
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·bool-true·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_7
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·bool-false·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_8
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·bool-false·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_9
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·bool-null·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_10
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·bool-invalid·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
   numbers:
   - *ref_1
   strings:
@@ -129,7 +79,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-boolean.quirks
@@ -150,8 +100,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -193,7 +144,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_3
         implementation: Method
         required: true
         extensions:
@@ -212,11 +163,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -261,11 +213,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_3
       language: !<!Languages> 
         default:
           name: ''
@@ -304,7 +257,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_3
         implementation: Method
         required: true
         extensions:
@@ -323,11 +276,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -372,11 +326,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/null'
+          path: /bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_3
       language: !<!Languages> 
         default:
           name: ''
@@ -420,11 +375,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/invalid'
+          path: /bool/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_3
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-boolean.quirks/namer.yaml
+++ b/modelerfour/test/outputs/body-boolean.quirks/namer.yaml
@@ -56,56 +56,6 @@ schemas: !<!Schemas>
         name: boolean
         description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_6
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_7
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_8
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_9
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_10
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
   numbers:
   - *ref_0
   strings:
@@ -129,7 +79,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-boolean.quirks
@@ -150,8 +100,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -193,7 +144,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -212,11 +163,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -261,11 +213,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -304,7 +257,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -323,11 +276,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -372,11 +326,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/null'
+          path: /bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -420,11 +375,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/invalid'
+          path: /bool/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-boolean/flattened.yaml
+++ b/modelerfour/test/outputs/body-boolean/flattened.yaml
@@ -53,17 +53,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_10
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_11
+  - !<!BooleanSchema> &ref_8
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -97,7 +87,6 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: true
       language:
         default:
           name: ''
@@ -106,38 +95,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: Constant1
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_8
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant2
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_9
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   numbers:
@@ -163,7 +120,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-boolean
@@ -184,8 +141,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -227,7 +185,7 @@ operationGroups:
       parameters:
       - *ref_4
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_5
         implementation: Method
         required: true
         extensions:
@@ -246,11 +204,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -295,11 +254,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -338,7 +298,7 @@ operationGroups:
       parameters:
       - *ref_4
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -357,11 +317,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -406,11 +367,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/null'
+          path: /bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -454,11 +416,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/invalid'
+          path: /bool/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-boolean/modeler.yaml
+++ b/modelerfour/test/outputs/body-boolean/modeler.yaml
@@ -53,7 +53,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_10
+  - !<!BooleanSchema> &ref_8
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -61,16 +61,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: paths·bool-null·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_11
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·bool-invalid·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
     protocol: !<!Protocols> {}
   constants:
@@ -97,23 +87,6 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·bool-true·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_8
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
       language:
         default:
           name: ''
@@ -122,22 +95,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: paths·bool-false·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_9
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·bool-false·put·requestbody·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   numbers:
@@ -163,7 +120,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-boolean
@@ -184,8 +141,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -227,7 +185,7 @@ operationGroups:
       parameters:
       - *ref_6
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -246,11 +204,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -295,11 +254,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -338,7 +298,7 @@ operationGroups:
       parameters:
       - *ref_6
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -357,11 +317,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -406,11 +367,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/null'
+          path: /bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -454,11 +416,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/invalid'
+          path: /bool/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-boolean/namer.yaml
+++ b/modelerfour/test/outputs/body-boolean/namer.yaml
@@ -53,17 +53,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_10
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_11
+  - !<!BooleanSchema> &ref_8
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -97,7 +87,6 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: true
       language:
         default:
           name: ''
@@ -106,38 +95,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: Constant1
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_8
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant2
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_9
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   numbers:
@@ -163,7 +120,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-boolean
@@ -184,8 +141,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -227,7 +185,7 @@ operationGroups:
       parameters:
       - *ref_4
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_5
         implementation: Method
         required: true
         extensions:
@@ -246,11 +204,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/true'
+          path: /bool/true
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -295,11 +254,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -338,7 +298,7 @@ operationGroups:
       parameters:
       - *ref_4
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -357,11 +317,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/bool/false'
+          path: /bool/false
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -406,11 +367,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/null'
+          path: /bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -454,11 +416,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/bool/invalid'
+          path: /bool/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-byte/flattened.yaml
+++ b/modelerfour/test/outputs/body-byte/flattened.yaml
@@ -113,7 +113,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-byte
@@ -134,8 +134,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/null'
+          path: /byte/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -182,8 +183,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/empty'
+          path: /byte/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -230,8 +232,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/nonAscii'
+          path: /byte/nonAscii
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -292,11 +295,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/byte/nonAscii'
+          path: /byte/nonAscii
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -341,8 +345,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/invalid'
+          path: /byte/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7

--- a/modelerfour/test/outputs/body-byte/modeler.yaml
+++ b/modelerfour/test/outputs/body-byte/modeler.yaml
@@ -113,7 +113,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-byte
@@ -134,8 +134,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/null'
+          path: /byte/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -182,8 +183,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/empty'
+          path: /byte/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -230,8 +232,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/nonAscii'
+          path: /byte/nonAscii
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -292,11 +295,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/byte/nonAscii'
+          path: /byte/nonAscii
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -341,8 +345,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/invalid'
+          path: /byte/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7

--- a/modelerfour/test/outputs/body-byte/namer.yaml
+++ b/modelerfour/test/outputs/body-byte/namer.yaml
@@ -113,7 +113,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-byte
@@ -134,8 +134,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/null'
+          path: /byte/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -182,8 +183,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/empty'
+          path: /byte/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -230,8 +232,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/nonAscii'
+          path: /byte/nonAscii
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -292,11 +295,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/byte/nonAscii'
+          path: /byte/nonAscii
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -341,8 +345,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/byte/invalid'
+          path: /byte/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7

--- a/modelerfour/test/outputs/body-complex/flattened.yaml
+++ b/modelerfour/test/outputs/body-complex/flattened.yaml
@@ -1742,7 +1742,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-complex
@@ -1763,8 +1763,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/valid'
+          path: /complex/basic/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -1836,11 +1837,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/basic/valid'
+          path: /complex/basic/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1885,8 +1887,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/invalid'
+          path: /complex/basic/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -1933,8 +1936,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/empty'
+          path: /complex/basic/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -1981,8 +1985,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/null'
+          path: /complex/basic/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -2029,8 +2034,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/notprovided'
+          path: /complex/basic/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -2085,8 +2091,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/integer'
+          path: /complex/primitive/integer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_85
@@ -2147,11 +2154,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/integer'
+          path: /complex/primitive/integer
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2196,8 +2204,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/long'
+          path: /complex/primitive/long
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_86
@@ -2258,11 +2267,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/long'
+          path: /complex/primitive/long
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2307,8 +2317,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/float'
+          path: /complex/primitive/float
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_87
@@ -2369,11 +2380,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/float'
+          path: /complex/primitive/float
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2418,8 +2430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/double'
+          path: /complex/primitive/double
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_88
@@ -2480,11 +2493,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/double'
+          path: /complex/primitive/double
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2529,8 +2543,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/bool'
+          path: /complex/primitive/bool
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_89
@@ -2591,11 +2606,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/bool'
+          path: /complex/primitive/bool
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2640,8 +2656,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/string'
+          path: /complex/primitive/string
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_90
@@ -2702,11 +2719,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/string'
+          path: /complex/primitive/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2751,8 +2769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/date'
+          path: /complex/primitive/date
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_91
@@ -2813,11 +2832,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/date'
+          path: /complex/primitive/date
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2862,8 +2882,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/datetime'
+          path: /complex/primitive/datetime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_92
@@ -2924,11 +2945,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/datetime'
+          path: /complex/primitive/datetime
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2973,8 +2995,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/datetimerfc1123'
+          path: /complex/primitive/datetimerfc1123
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_93
@@ -3035,11 +3058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/datetimerfc1123'
+          path: /complex/primitive/datetimerfc1123
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3084,8 +3108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/duration'
+          path: /complex/primitive/duration
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_94
@@ -3146,11 +3171,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/duration'
+          path: /complex/primitive/duration
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3195,8 +3221,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/byte'
+          path: /complex/primitive/byte
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_95
@@ -3257,11 +3284,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/byte'
+          path: /complex/primitive/byte
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3314,8 +3342,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/valid'
+          path: /complex/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3376,11 +3405,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/array/valid'
+          path: /complex/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3425,8 +3455,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/empty'
+          path: /complex/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3476,7 +3507,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: complexBody
-            description: Please put an empty array
+            description: 'Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3487,11 +3518,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/array/empty'
+          path: /complex/array/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3536,8 +3568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/notprovided'
+          path: /complex/array/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3592,8 +3625,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/valid'
+          path: /complex/dictionary/typed/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3654,11 +3688,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/dictionary/typed/valid'
+          path: /complex/dictionary/typed/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3703,8 +3738,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/empty'
+          path: /complex/dictionary/typed/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3754,7 +3790,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: complexBody
-            description: Please put an empty dictionary
+            description: 'Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3765,11 +3801,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/dictionary/typed/empty'
+          path: /complex/dictionary/typed/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3814,8 +3851,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/null'
+          path: /complex/dictionary/typed/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3862,8 +3900,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/notprovided'
+          path: /complex/dictionary/typed/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3918,8 +3957,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/inheritance/valid'
+          path: /complex/inheritance/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_2
@@ -3980,11 +4020,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/inheritance/valid'
+          path: /complex/inheritance/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4037,8 +4078,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/valid'
+          path: /complex/polymorphism/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -4132,11 +4174,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/valid'
+          path: /complex/polymorphism/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4181,8 +4224,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/dotsyntax'
+          path: /complex/polymorphism/dotsyntax
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_14
@@ -4229,8 +4273,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/composedWithDiscriminator'
+          path: /complex/polymorphism/composedWithDiscriminator
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_98
@@ -4277,8 +4322,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/composedWithoutDiscriminator'
+          path: /complex/polymorphism/composedWithoutDiscriminator
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_98
@@ -4325,8 +4371,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/complicated'
+          path: /complex/polymorphism/complicated
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -4387,11 +4434,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/complicated'
+          path: /complex/polymorphism/complicated
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4450,11 +4498,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/missingdiscriminator'
+          path: /complex/polymorphism/missingdiscriminator
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -4507,32 +4556,39 @@ operationGroups:
           default:
             name: complexBody
             description: |-
-              Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
+              Please put a salmon that looks like this:
               {
-                  "fishtype": "sawshark",
-                  "species": "snaggle toothed",
-                  "length": 18.5,
-                  "age": 2,
-                  "birthday": "2013-06-01T01:00:00Z",
-                  "location": "alaska",
-                  "picture": base64(FF FF FF FF FE),
-                  "siblings": [
-                      {
-                          "fishtype": "shark",
-                          "species": "predator",
-                          "birthday": "2012-01-05T01:00:00Z",
-                          "length": 20,
-                          "age": 6
-                      },
-                      {
-                          "fishtype": "sawshark",
-                          "species": "dangerous",
-                          "picture": base64(FF FF FF FF FE),
-                          "length": 10,
-                          "age": 105
-                      }
-                  ]
-              }
+                      'fishtype':'Salmon',
+                      'location':'alaska',
+                      'iswild':true,
+                      'species':'king',
+                      'length':1.0,
+                      'siblings':[
+                        {
+                          'fishtype':'Shark',
+                          'age':6,
+                          'birthday': '2012-01-05T01:00:00Z',
+                          'length':20.0,
+                          'species':'predator',
+                        },
+                        {
+                          'fishtype':'Sawshark',
+                          'age':105,
+                          'birthday': '1900-01-05T01:00:00Z',
+                          'length':10.0,
+                          'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                          'species':'dangerous',
+                        },
+                        {
+                          'fishtype': 'goblin',
+                          'age': 1,
+                          'birthday': '2015-08-08T00:00:00Z',
+                          'length': 30.0,
+                          'species': 'scary',
+                          'jawsize': 5
+                        }
+                      ]
+                    };
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -4543,11 +4599,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/missingrequired/invalid'
+          path: /complex/polymorphism/missingrequired/invalid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4600,8 +4657,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphicrecursive/valid'
+          path: /complex/polymorphicrecursive/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -4654,57 +4712,37 @@ operationGroups:
             description: |-
               Please put a salmon that looks like this:
               {
-                  "fishtype": "salmon",
-                  "species": "king",
-                  "length": 1,
-                  "age": 1,
-                  "location": "alaska",
-                  "iswild": true,
-                  "siblings": [
-                      {
-                          "fishtype": "shark",
-                          "species": "predator",
-                          "length": 20,
-                          "age": 6,
-                          "siblings": [
-                              {
-                                  "fishtype": "salmon",
-                                  "species": "coho",
-                                  "length": 2,
-                                  "age": 2,
-                                  "location": "atlantic",
-                                  "iswild": true,
-                                  "siblings": [
-                                      {
-                                          "fishtype": "shark",
-                                          "species": "predator",
-                                          "length": 20,
-                                          "age": 6
-                                      },
-                                      {
-                                          "fishtype": "sawshark",
-                                          "species": "dangerous",
-                                          "length": 10,
-                                          "age": 105
-                                      }
-                                  ]
-                              },
-                              {
-                                  "fishtype": "sawshark",
-                                  "species": "dangerous",
-                                  "length": 10,
-                                  "age": 105
-                              }
-                          ]
-                      },
-                      {
-                          "fishtype": "sawshark",
-                          "species": "dangerous",
-                          "length": 10,
-                          "age": 105
-                      }
-                  ]
-              }
+                      'fishtype':'Salmon',
+                      'location':'alaska',
+                      'iswild':true,
+                      'species':'king',
+                      'length':1.0,
+                      'siblings':[
+                        {
+                          'fishtype':'Shark',
+                          'age':6,
+                          'birthday': '2012-01-05T01:00:00Z',
+                          'length':20.0,
+                          'species':'predator',
+                        },
+                        {
+                          'fishtype':'Sawshark',
+                          'age':105,
+                          'birthday': '1900-01-05T01:00:00Z',
+                          'length':10.0,
+                          'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                          'species':'dangerous',
+                        },
+                        {
+                          'fishtype': 'goblin',
+                          'age': 1,
+                          'birthday': '2015-08-08T00:00:00Z',
+                          'length': 30.0,
+                          'species': 'scary',
+                          'jawsize': 5
+                        }
+                      ]
+                    };
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -4715,11 +4753,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphicrecursive/valid'
+          path: /complex/polymorphicrecursive/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4772,8 +4811,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/readonlyproperty/valid'
+          path: /complex/readonlyproperty/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_99
@@ -4834,11 +4874,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/readonlyproperty/valid'
+          path: /complex/readonlyproperty/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4891,8 +4932,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/flatten/valid'
+          path: /complex/flatten/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_17

--- a/modelerfour/test/outputs/body-complex/modeler.yaml
+++ b/modelerfour/test/outputs/body-complex/modeler.yaml
@@ -1742,7 +1742,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-complex
@@ -1763,8 +1763,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/valid'
+          path: /complex/basic/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_81
@@ -1836,11 +1837,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/basic/valid'
+          path: /complex/basic/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1885,8 +1887,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/invalid'
+          path: /complex/basic/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_81
@@ -1933,8 +1936,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/empty'
+          path: /complex/basic/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_81
@@ -1981,8 +1985,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/null'
+          path: /complex/basic/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_81
@@ -2029,8 +2034,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/notprovided'
+          path: /complex/basic/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_81
@@ -2085,8 +2091,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/integer'
+          path: /complex/primitive/integer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_85
@@ -2147,11 +2154,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/integer'
+          path: /complex/primitive/integer
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2196,8 +2204,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/long'
+          path: /complex/primitive/long
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_86
@@ -2258,11 +2267,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/long'
+          path: /complex/primitive/long
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2307,8 +2317,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/float'
+          path: /complex/primitive/float
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_87
@@ -2369,11 +2380,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/float'
+          path: /complex/primitive/float
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2418,8 +2430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/double'
+          path: /complex/primitive/double
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_88
@@ -2480,11 +2493,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/double'
+          path: /complex/primitive/double
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2529,8 +2543,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/bool'
+          path: /complex/primitive/bool
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_89
@@ -2591,11 +2606,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/bool'
+          path: /complex/primitive/bool
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2640,8 +2656,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/string'
+          path: /complex/primitive/string
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_90
@@ -2702,11 +2719,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/string'
+          path: /complex/primitive/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2751,8 +2769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/date'
+          path: /complex/primitive/date
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_91
@@ -2813,11 +2832,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/date'
+          path: /complex/primitive/date
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2862,8 +2882,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/datetime'
+          path: /complex/primitive/datetime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_92
@@ -2924,11 +2945,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/datetime'
+          path: /complex/primitive/datetime
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2973,8 +2995,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/datetimerfc1123'
+          path: /complex/primitive/datetimerfc1123
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_93
@@ -3035,11 +3058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/datetimerfc1123'
+          path: /complex/primitive/datetimerfc1123
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3084,8 +3108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/duration'
+          path: /complex/primitive/duration
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_94
@@ -3146,11 +3171,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/duration'
+          path: /complex/primitive/duration
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3195,8 +3221,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/byte'
+          path: /complex/primitive/byte
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_95
@@ -3257,11 +3284,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/byte'
+          path: /complex/primitive/byte
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3314,8 +3342,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/valid'
+          path: /complex/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3376,11 +3405,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/array/valid'
+          path: /complex/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3425,8 +3455,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/empty'
+          path: /complex/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3476,7 +3507,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: complexBody
-            description: Please put an empty array
+            description: 'Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3487,11 +3518,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/array/empty'
+          path: /complex/array/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3536,8 +3568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/notprovided'
+          path: /complex/array/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3592,8 +3625,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/valid'
+          path: /complex/dictionary/typed/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3654,11 +3688,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/dictionary/typed/valid'
+          path: /complex/dictionary/typed/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3703,8 +3738,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/empty'
+          path: /complex/dictionary/typed/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3754,7 +3790,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: complexBody
-            description: Please put an empty dictionary
+            description: 'Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3765,11 +3801,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/dictionary/typed/empty'
+          path: /complex/dictionary/typed/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3814,8 +3851,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/null'
+          path: /complex/dictionary/typed/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3862,8 +3900,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/notprovided'
+          path: /complex/dictionary/typed/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3918,8 +3957,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/inheritance/valid'
+          path: /complex/inheritance/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_15
@@ -3980,11 +4020,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/inheritance/valid'
+          path: /complex/inheritance/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4037,8 +4078,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/valid'
+          path: /complex/polymorphism/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_18
@@ -4132,11 +4174,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/valid'
+          path: /complex/polymorphism/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4181,8 +4224,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/dotsyntax'
+          path: /complex/polymorphism/dotsyntax
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_33
@@ -4229,8 +4273,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/composedWithDiscriminator'
+          path: /complex/polymorphism/composedWithDiscriminator
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_98
@@ -4277,8 +4322,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/composedWithoutDiscriminator'
+          path: /complex/polymorphism/composedWithoutDiscriminator
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_98
@@ -4325,8 +4371,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/complicated'
+          path: /complex/polymorphism/complicated
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_22
@@ -4387,11 +4434,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/complicated'
+          path: /complex/polymorphism/complicated
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4450,11 +4498,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/missingdiscriminator'
+          path: /complex/polymorphism/missingdiscriminator
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_22
@@ -4507,32 +4556,39 @@ operationGroups:
           default:
             name: complexBody
             description: |-
-              Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
+              Please put a salmon that looks like this:
               {
-                  "fishtype": "sawshark",
-                  "species": "snaggle toothed",
-                  "length": 18.5,
-                  "age": 2,
-                  "birthday": "2013-06-01T01:00:00Z",
-                  "location": "alaska",
-                  "picture": base64(FF FF FF FF FE),
-                  "siblings": [
-                      {
-                          "fishtype": "shark",
-                          "species": "predator",
-                          "birthday": "2012-01-05T01:00:00Z",
-                          "length": 20,
-                          "age": 6
-                      },
-                      {
-                          "fishtype": "sawshark",
-                          "species": "dangerous",
-                          "picture": base64(FF FF FF FF FE),
-                          "length": 10,
-                          "age": 105
-                      }
-                  ]
-              }
+                      'fishtype':'Salmon',
+                      'location':'alaska',
+                      'iswild':true,
+                      'species':'king',
+                      'length':1.0,
+                      'siblings':[
+                        {
+                          'fishtype':'Shark',
+                          'age':6,
+                          'birthday': '2012-01-05T01:00:00Z',
+                          'length':20.0,
+                          'species':'predator',
+                        },
+                        {
+                          'fishtype':'Sawshark',
+                          'age':105,
+                          'birthday': '1900-01-05T01:00:00Z',
+                          'length':10.0,
+                          'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                          'species':'dangerous',
+                        },
+                        {
+                          'fishtype': 'goblin',
+                          'age': 1,
+                          'birthday': '2015-08-08T00:00:00Z',
+                          'length': 30.0,
+                          'species': 'scary',
+                          'jawsize': 5
+                        }
+                      ]
+                    };
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -4543,11 +4599,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/missingrequired/invalid'
+          path: /complex/polymorphism/missingrequired/invalid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4600,8 +4657,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphicrecursive/valid'
+          path: /complex/polymorphicrecursive/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_18
@@ -4654,57 +4712,37 @@ operationGroups:
             description: |-
               Please put a salmon that looks like this:
               {
-                  "fishtype": "salmon",
-                  "species": "king",
-                  "length": 1,
-                  "age": 1,
-                  "location": "alaska",
-                  "iswild": true,
-                  "siblings": [
-                      {
-                          "fishtype": "shark",
-                          "species": "predator",
-                          "length": 20,
-                          "age": 6,
-                          "siblings": [
-                              {
-                                  "fishtype": "salmon",
-                                  "species": "coho",
-                                  "length": 2,
-                                  "age": 2,
-                                  "location": "atlantic",
-                                  "iswild": true,
-                                  "siblings": [
-                                      {
-                                          "fishtype": "shark",
-                                          "species": "predator",
-                                          "length": 20,
-                                          "age": 6
-                                      },
-                                      {
-                                          "fishtype": "sawshark",
-                                          "species": "dangerous",
-                                          "length": 10,
-                                          "age": 105
-                                      }
-                                  ]
-                              },
-                              {
-                                  "fishtype": "sawshark",
-                                  "species": "dangerous",
-                                  "length": 10,
-                                  "age": 105
-                              }
-                          ]
-                      },
-                      {
-                          "fishtype": "sawshark",
-                          "species": "dangerous",
-                          "length": 10,
-                          "age": 105
-                      }
-                  ]
-              }
+                      'fishtype':'Salmon',
+                      'location':'alaska',
+                      'iswild':true,
+                      'species':'king',
+                      'length':1.0,
+                      'siblings':[
+                        {
+                          'fishtype':'Shark',
+                          'age':6,
+                          'birthday': '2012-01-05T01:00:00Z',
+                          'length':20.0,
+                          'species':'predator',
+                        },
+                        {
+                          'fishtype':'Sawshark',
+                          'age':105,
+                          'birthday': '1900-01-05T01:00:00Z',
+                          'length':10.0,
+                          'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                          'species':'dangerous',
+                        },
+                        {
+                          'fishtype': 'goblin',
+                          'age': 1,
+                          'birthday': '2015-08-08T00:00:00Z',
+                          'length': 30.0,
+                          'species': 'scary',
+                          'jawsize': 5
+                        }
+                      ]
+                    };
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -4715,11 +4753,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphicrecursive/valid'
+          path: /complex/polymorphicrecursive/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4772,8 +4811,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/readonlyproperty/valid'
+          path: /complex/readonlyproperty/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_99
@@ -4834,11 +4874,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/readonlyproperty/valid'
+          path: /complex/readonlyproperty/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4891,8 +4932,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/flatten/valid'
+          path: /complex/flatten/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_40

--- a/modelerfour/test/outputs/body-complex/namer.yaml
+++ b/modelerfour/test/outputs/body-complex/namer.yaml
@@ -1742,7 +1742,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-complex
@@ -1763,8 +1763,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/valid'
+          path: /complex/basic/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -1836,11 +1837,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/basic/valid'
+          path: /complex/basic/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1885,8 +1887,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/invalid'
+          path: /complex/basic/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -1933,8 +1936,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/empty'
+          path: /complex/basic/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -1981,8 +1985,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/null'
+          path: /complex/basic/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -2029,8 +2034,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/basic/notprovided'
+          path: /complex/basic/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_82
@@ -2085,8 +2091,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/integer'
+          path: /complex/primitive/integer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_85
@@ -2147,11 +2154,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/integer'
+          path: /complex/primitive/integer
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2196,8 +2204,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/long'
+          path: /complex/primitive/long
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_86
@@ -2258,11 +2267,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/long'
+          path: /complex/primitive/long
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2307,8 +2317,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/float'
+          path: /complex/primitive/float
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_87
@@ -2369,11 +2380,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/float'
+          path: /complex/primitive/float
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2418,8 +2430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/double'
+          path: /complex/primitive/double
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_88
@@ -2480,11 +2493,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/double'
+          path: /complex/primitive/double
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2529,8 +2543,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/bool'
+          path: /complex/primitive/bool
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_89
@@ -2591,11 +2606,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/bool'
+          path: /complex/primitive/bool
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2640,8 +2656,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/string'
+          path: /complex/primitive/string
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_90
@@ -2702,11 +2719,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/string'
+          path: /complex/primitive/string
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2751,8 +2769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/date'
+          path: /complex/primitive/date
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_91
@@ -2813,11 +2832,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/date'
+          path: /complex/primitive/date
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2862,8 +2882,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/datetime'
+          path: /complex/primitive/datetime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_92
@@ -2924,11 +2945,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/datetime'
+          path: /complex/primitive/datetime
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2973,8 +2995,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/datetimerfc1123'
+          path: /complex/primitive/datetimerfc1123
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_93
@@ -3035,11 +3058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/datetimerfc1123'
+          path: /complex/primitive/datetimerfc1123
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3084,8 +3108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/duration'
+          path: /complex/primitive/duration
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_94
@@ -3146,11 +3171,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/duration'
+          path: /complex/primitive/duration
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3195,8 +3221,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/primitive/byte'
+          path: /complex/primitive/byte
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_95
@@ -3257,11 +3284,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/primitive/byte'
+          path: /complex/primitive/byte
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3314,8 +3342,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/valid'
+          path: /complex/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3376,11 +3405,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/array/valid'
+          path: /complex/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3425,8 +3455,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/empty'
+          path: /complex/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3476,7 +3507,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: complexBody
-            description: Please put an empty array
+            description: 'Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3487,11 +3518,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/array/empty'
+          path: /complex/array/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3536,8 +3568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/array/notprovided'
+          path: /complex/array/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_96
@@ -3592,8 +3625,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/valid'
+          path: /complex/dictionary/typed/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3654,11 +3688,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/dictionary/typed/valid'
+          path: /complex/dictionary/typed/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3703,8 +3738,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/empty'
+          path: /complex/dictionary/typed/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3754,7 +3790,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: complexBody
-            description: Please put an empty dictionary
+            description: 'Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3765,11 +3801,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/dictionary/typed/empty'
+          path: /complex/dictionary/typed/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3814,8 +3851,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/null'
+          path: /complex/dictionary/typed/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3862,8 +3900,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/dictionary/typed/notprovided'
+          path: /complex/dictionary/typed/notprovided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_97
@@ -3918,8 +3957,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/inheritance/valid'
+          path: /complex/inheritance/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_2
@@ -3980,11 +4020,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/inheritance/valid'
+          path: /complex/inheritance/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4037,8 +4078,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/valid'
+          path: /complex/polymorphism/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -4132,11 +4174,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/valid'
+          path: /complex/polymorphism/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4181,8 +4224,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/dotsyntax'
+          path: /complex/polymorphism/dotsyntax
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_14
@@ -4229,8 +4273,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/composedWithDiscriminator'
+          path: /complex/polymorphism/composedWithDiscriminator
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_98
@@ -4277,8 +4322,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/composedWithoutDiscriminator'
+          path: /complex/polymorphism/composedWithoutDiscriminator
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_98
@@ -4325,8 +4371,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphism/complicated'
+          path: /complex/polymorphism/complicated
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -4387,11 +4434,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/complicated'
+          path: /complex/polymorphism/complicated
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4450,11 +4498,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/missingdiscriminator'
+          path: /complex/polymorphism/missingdiscriminator
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -4507,32 +4556,39 @@ operationGroups:
           default:
             name: complexBody
             description: |-
-              Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
+              Please put a salmon that looks like this:
               {
-                  "fishtype": "sawshark",
-                  "species": "snaggle toothed",
-                  "length": 18.5,
-                  "age": 2,
-                  "birthday": "2013-06-01T01:00:00Z",
-                  "location": "alaska",
-                  "picture": base64(FF FF FF FF FE),
-                  "siblings": [
-                      {
-                          "fishtype": "shark",
-                          "species": "predator",
-                          "birthday": "2012-01-05T01:00:00Z",
-                          "length": 20,
-                          "age": 6
-                      },
-                      {
-                          "fishtype": "sawshark",
-                          "species": "dangerous",
-                          "picture": base64(FF FF FF FF FE),
-                          "length": 10,
-                          "age": 105
-                      }
-                  ]
-              }
+                      'fishtype':'Salmon',
+                      'location':'alaska',
+                      'iswild':true,
+                      'species':'king',
+                      'length':1.0,
+                      'siblings':[
+                        {
+                          'fishtype':'Shark',
+                          'age':6,
+                          'birthday': '2012-01-05T01:00:00Z',
+                          'length':20.0,
+                          'species':'predator',
+                        },
+                        {
+                          'fishtype':'Sawshark',
+                          'age':105,
+                          'birthday': '1900-01-05T01:00:00Z',
+                          'length':10.0,
+                          'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                          'species':'dangerous',
+                        },
+                        {
+                          'fishtype': 'goblin',
+                          'age': 1,
+                          'birthday': '2015-08-08T00:00:00Z',
+                          'length': 30.0,
+                          'species': 'scary',
+                          'jawsize': 5
+                        }
+                      ]
+                    };
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -4543,11 +4599,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphism/missingrequired/invalid'
+          path: /complex/polymorphism/missingrequired/invalid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4600,8 +4657,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/polymorphicrecursive/valid'
+          path: /complex/polymorphicrecursive/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -4654,57 +4712,37 @@ operationGroups:
             description: |-
               Please put a salmon that looks like this:
               {
-                  "fishtype": "salmon",
-                  "species": "king",
-                  "length": 1,
-                  "age": 1,
-                  "location": "alaska",
-                  "iswild": true,
-                  "siblings": [
-                      {
-                          "fishtype": "shark",
-                          "species": "predator",
-                          "length": 20,
-                          "age": 6,
-                          "siblings": [
-                              {
-                                  "fishtype": "salmon",
-                                  "species": "coho",
-                                  "length": 2,
-                                  "age": 2,
-                                  "location": "atlantic",
-                                  "iswild": true,
-                                  "siblings": [
-                                      {
-                                          "fishtype": "shark",
-                                          "species": "predator",
-                                          "length": 20,
-                                          "age": 6
-                                      },
-                                      {
-                                          "fishtype": "sawshark",
-                                          "species": "dangerous",
-                                          "length": 10,
-                                          "age": 105
-                                      }
-                                  ]
-                              },
-                              {
-                                  "fishtype": "sawshark",
-                                  "species": "dangerous",
-                                  "length": 10,
-                                  "age": 105
-                              }
-                          ]
-                      },
-                      {
-                          "fishtype": "sawshark",
-                          "species": "dangerous",
-                          "length": 10,
-                          "age": 105
-                      }
-                  ]
-              }
+                      'fishtype':'Salmon',
+                      'location':'alaska',
+                      'iswild':true,
+                      'species':'king',
+                      'length':1.0,
+                      'siblings':[
+                        {
+                          'fishtype':'Shark',
+                          'age':6,
+                          'birthday': '2012-01-05T01:00:00Z',
+                          'length':20.0,
+                          'species':'predator',
+                        },
+                        {
+                          'fishtype':'Sawshark',
+                          'age':105,
+                          'birthday': '1900-01-05T01:00:00Z',
+                          'length':10.0,
+                          'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                          'species':'dangerous',
+                        },
+                        {
+                          'fishtype': 'goblin',
+                          'age': 1,
+                          'birthday': '2015-08-08T00:00:00Z',
+                          'length': 30.0,
+                          'species': 'scary',
+                          'jawsize': 5
+                        }
+                      ]
+                    };
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -4715,11 +4753,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/polymorphicrecursive/valid'
+          path: /complex/polymorphicrecursive/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4772,8 +4811,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/readonlyproperty/valid'
+          path: /complex/readonlyproperty/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_99
@@ -4834,11 +4874,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/complex/readonlyproperty/valid'
+          path: /complex/readonlyproperty/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4891,8 +4932,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/complex/flatten/valid'
+          path: /complex/flatten/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_17

--- a/modelerfour/test/outputs/body-date/flattened.yaml
+++ b/modelerfour/test/outputs/body-date/flattened.yaml
@@ -97,7 +97,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-date
@@ -118,8 +118,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/null'
+          path: /date/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -166,8 +167,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/invaliddate'
+          path: /date/invaliddate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -214,8 +216,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/overflowdate'
+          path: /date/overflowdate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -262,8 +265,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/underflowdate'
+          path: /date/underflowdate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -324,11 +328,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/date/max'
+          path: /date/max
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -373,8 +378,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/max'
+          path: /date/max
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -435,11 +441,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/date/min'
+          path: /date/min
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -484,8 +491,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/min'
+          path: /date/min
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/body-date/modeler.yaml
+++ b/modelerfour/test/outputs/body-date/modeler.yaml
@@ -97,7 +97,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-date
@@ -118,8 +118,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/null'
+          path: /date/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -166,8 +167,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/invaliddate'
+          path: /date/invaliddate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -214,8 +216,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/overflowdate'
+          path: /date/overflowdate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -262,8 +265,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/underflowdate'
+          path: /date/underflowdate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -324,11 +328,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/date/max'
+          path: /date/max
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -373,8 +378,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/max'
+          path: /date/max
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -435,11 +441,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/date/min'
+          path: /date/min
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -484,8 +491,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/min'
+          path: /date/min
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/body-date/namer.yaml
+++ b/modelerfour/test/outputs/body-date/namer.yaml
@@ -97,7 +97,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-date
@@ -118,8 +118,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/null'
+          path: /date/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -166,8 +167,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/invaliddate'
+          path: /date/invaliddate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -214,8 +216,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/overflowdate'
+          path: /date/overflowdate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -262,8 +265,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/underflowdate'
+          path: /date/underflowdate
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -324,11 +328,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/date/max'
+          path: /date/max
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -373,8 +378,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/max'
+          path: /date/max
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -435,11 +441,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/date/min'
+          path: /date/min
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -484,8 +491,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/date/min'
+          path: /date/min
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/body-datetime-rfc1123/flattened.yaml
+++ b/modelerfour/test/outputs/body-datetime-rfc1123/flattened.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-datetime-rfc1123
@@ -119,8 +119,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/null'
+          path: /datetimerfc1123/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -167,8 +168,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/invalid'
+          path: /datetimerfc1123/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -215,8 +217,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/overflow'
+          path: /datetimerfc1123/overflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -263,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/underflow'
+          path: /datetimerfc1123/underflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -325,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetimerfc1123/max'
+          path: /datetimerfc1123/max
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -374,8 +379,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/max/lowercase'
+          path: /datetimerfc1123/max/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -422,8 +428,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/max/uppercase'
+          path: /datetimerfc1123/max/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -484,11 +491,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetimerfc1123/min'
+          path: /datetimerfc1123/min
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -533,8 +541,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/min'
+          path: /datetimerfc1123/min
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/body-datetime-rfc1123/modeler.yaml
+++ b/modelerfour/test/outputs/body-datetime-rfc1123/modeler.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-datetime-rfc1123
@@ -119,8 +119,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/null'
+          path: /datetimerfc1123/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -167,8 +168,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/invalid'
+          path: /datetimerfc1123/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -215,8 +217,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/overflow'
+          path: /datetimerfc1123/overflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -263,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/underflow'
+          path: /datetimerfc1123/underflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -325,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetimerfc1123/max'
+          path: /datetimerfc1123/max
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -374,8 +379,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/max/lowercase'
+          path: /datetimerfc1123/max/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -422,8 +428,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/max/uppercase'
+          path: /datetimerfc1123/max/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -484,11 +491,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetimerfc1123/min'
+          path: /datetimerfc1123/min
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -533,8 +541,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/min'
+          path: /datetimerfc1123/min
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/body-datetime-rfc1123/namer.yaml
+++ b/modelerfour/test/outputs/body-datetime-rfc1123/namer.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-datetime-rfc1123
@@ -119,8 +119,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/null'
+          path: /datetimerfc1123/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -167,8 +168,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/invalid'
+          path: /datetimerfc1123/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -215,8 +217,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/overflow'
+          path: /datetimerfc1123/overflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -263,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/underflow'
+          path: /datetimerfc1123/underflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -325,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetimerfc1123/max'
+          path: /datetimerfc1123/max
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -374,8 +379,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/max/lowercase'
+          path: /datetimerfc1123/max/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -422,8 +428,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/max/uppercase'
+          path: /datetimerfc1123/max/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -484,11 +491,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetimerfc1123/min'
+          path: /datetimerfc1123/min
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -533,8 +541,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetimerfc1123/min'
+          path: /datetimerfc1123/min
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/body-datetime/flattened.yaml
+++ b/modelerfour/test/outputs/body-datetime/flattened.yaml
@@ -115,7 +115,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-datetime
@@ -136,8 +136,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/null'
+          path: /datetime/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -184,8 +185,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/invalid'
+          path: /datetime/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -232,8 +234,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/overflow'
+          path: /datetime/overflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -280,8 +283,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/underflow'
+          path: /datetime/underflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -342,11 +346,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/utc'
+          path: /datetime/max/utc
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -391,8 +396,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/utc/lowercase'
+          path: /datetime/max/utc/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -439,8 +445,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/utc/uppercase'
+          path: /datetime/max/utc/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -501,11 +508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset'
+          path: /datetime/max/localpositiveoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -550,8 +558,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset/lowercase'
+          path: /datetime/max/localpositiveoffset/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -598,8 +607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset/uppercase'
+          path: /datetime/max/localpositiveoffset/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -660,11 +670,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset'
+          path: /datetime/max/localnegativeoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -709,8 +720,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset/uppercase'
+          path: /datetime/max/localnegativeoffset/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -757,8 +769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset/lowercase'
+          path: /datetime/max/localnegativeoffset/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -819,11 +832,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/utc'
+          path: /datetime/min/utc
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -868,8 +882,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/utc'
+          path: /datetime/min/utc
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -930,11 +945,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/localpositiveoffset'
+          path: /datetime/min/localpositiveoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -979,8 +995,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/localpositiveoffset'
+          path: /datetime/min/localpositiveoffset
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1041,11 +1058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/localnegativeoffset'
+          path: /datetime/min/localnegativeoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1090,8 +1108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/localnegativeoffset'
+          path: /datetime/min/localnegativeoffset
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7

--- a/modelerfour/test/outputs/body-datetime/modeler.yaml
+++ b/modelerfour/test/outputs/body-datetime/modeler.yaml
@@ -115,7 +115,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-datetime
@@ -136,8 +136,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/null'
+          path: /datetime/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -184,8 +185,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/invalid'
+          path: /datetime/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -232,8 +234,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/overflow'
+          path: /datetime/overflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -280,8 +283,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/underflow'
+          path: /datetime/underflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -342,11 +346,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/utc'
+          path: /datetime/max/utc
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -391,8 +396,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/utc/lowercase'
+          path: /datetime/max/utc/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -439,8 +445,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/utc/uppercase'
+          path: /datetime/max/utc/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -501,11 +508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset'
+          path: /datetime/max/localpositiveoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -550,8 +558,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset/lowercase'
+          path: /datetime/max/localpositiveoffset/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -598,8 +607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset/uppercase'
+          path: /datetime/max/localpositiveoffset/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -660,11 +670,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset'
+          path: /datetime/max/localnegativeoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -709,8 +720,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset/uppercase'
+          path: /datetime/max/localnegativeoffset/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -757,8 +769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset/lowercase'
+          path: /datetime/max/localnegativeoffset/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -819,11 +832,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/utc'
+          path: /datetime/min/utc
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -868,8 +882,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/utc'
+          path: /datetime/min/utc
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -930,11 +945,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/localpositiveoffset'
+          path: /datetime/min/localpositiveoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -979,8 +995,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/localpositiveoffset'
+          path: /datetime/min/localpositiveoffset
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1041,11 +1058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/localnegativeoffset'
+          path: /datetime/min/localnegativeoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1090,8 +1108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/localnegativeoffset'
+          path: /datetime/min/localnegativeoffset
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7

--- a/modelerfour/test/outputs/body-datetime/namer.yaml
+++ b/modelerfour/test/outputs/body-datetime/namer.yaml
@@ -115,7 +115,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-datetime
@@ -136,8 +136,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/null'
+          path: /datetime/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -184,8 +185,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/invalid'
+          path: /datetime/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -232,8 +234,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/overflow'
+          path: /datetime/overflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -280,8 +283,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/underflow'
+          path: /datetime/underflow
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -342,11 +346,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/utc'
+          path: /datetime/max/utc
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -391,8 +396,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/utc/lowercase'
+          path: /datetime/max/utc/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -439,8 +445,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/utc/uppercase'
+          path: /datetime/max/utc/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -501,11 +508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset'
+          path: /datetime/max/localpositiveoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -550,8 +558,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset/lowercase'
+          path: /datetime/max/localpositiveoffset/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -598,8 +607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localpositiveoffset/uppercase'
+          path: /datetime/max/localpositiveoffset/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -660,11 +670,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset'
+          path: /datetime/max/localnegativeoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -709,8 +720,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset/uppercase'
+          path: /datetime/max/localnegativeoffset/uppercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -757,8 +769,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/max/localnegativeoffset/lowercase'
+          path: /datetime/max/localnegativeoffset/lowercase
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -819,11 +832,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/utc'
+          path: /datetime/min/utc
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -868,8 +882,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/utc'
+          path: /datetime/min/utc
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -930,11 +945,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/localpositiveoffset'
+          path: /datetime/min/localpositiveoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -979,8 +995,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/localpositiveoffset'
+          path: /datetime/min/localpositiveoffset
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1041,11 +1058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/datetime/min/localnegativeoffset'
+          path: /datetime/min/localnegativeoffset
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1090,8 +1108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/datetime/min/localnegativeoffset'
+          path: /datetime/min/localnegativeoffset
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7

--- a/modelerfour/test/outputs/body-dictionary/flattened.yaml
+++ b/modelerfour/test/outputs/body-dictionary/flattened.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_57
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_18
+      schema: !<!NumberSchema> &ref_13
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_37
+      schema: !<!StringSchema> &ref_18
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -52,7 +52,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_36
+      schema: !<!NumberSchema> &ref_17
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_47
+      schema: !<!StringSchema> &ref_19
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -90,9 +90,9 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_56
+  - !<!DictionarySchema> &ref_24
     type: dictionary
-    elementType: !<!NumberSchema> &ref_17
+    elementType: !<!NumberSchema> &ref_12
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -108,44 +108,9 @@ schemas: !<!Schemas>
         name: DictionaryOfinteger
         description: The null dictionary value
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_58
+  - !<!DictionarySchema> &ref_26
     type: dictionary
-    elementType: !<!NumberSchema> &ref_19
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The empty dictionary value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_59
-    type: dictionary
-    elementType: !<!StringSchema> &ref_38
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The empty dictionary value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_60
-    type: dictionary
-    elementType: !<!StringSchema> &ref_39
+    elementType: !<!StringSchema> &ref_1
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -160,60 +125,9 @@ schemas: !<!Schemas>
         name: Dictionary of string
         description: Dictionary of <paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties>
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_61
+  - !<!DictionarySchema> &ref_27
     type: dictionary
-    elementType: !<!StringSchema> &ref_40
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·dictionary-nullkey·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_62
-    type: dictionary
-    elementType: !<!StringSchema> &ref_41
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_63
-    type: dictionary
-    elementType: !<!StringSchema> &ref_42
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·dictionary-invalid·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_64
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_7
+    elementType: !<!BooleanSchema> &ref_5
       type: boolean
       apiVersions:
       - !<!ApiVersion> 
@@ -228,132 +142,9 @@ schemas: !<!Schemas>
         name: DictionaryOfboolean
         description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_65
+  - !<!DictionarySchema> &ref_28
     type: dictionary
-    elementType: !<!BooleanSchema> &ref_8
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfboolean
-        description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_66
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_9
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfboolean
-        description: 'The dictionary value {"0": true, "1": null, "2": false }'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_67
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_10
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfboolean
-        description: 'The dictionary value [true, ''boolean'', false]'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_68
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_20
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_69
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_21
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_70
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_22
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": null, "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_71
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_23
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": "integer", "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_72
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_24
+    elementType: !<!NumberSchema> &ref_14
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -369,63 +160,9 @@ schemas: !<!Schemas>
         name: DictionaryOfinteger
         description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_73
+  - !<!DictionarySchema> &ref_29
     type: dictionary
-    elementType: !<!NumberSchema> &ref_25
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_74
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_26
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": null, "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_75
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_27
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": "integer", "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_76
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_28
+    elementType: !<!NumberSchema> &ref_15
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -441,63 +178,9 @@ schemas: !<!Schemas>
         name: DictionaryOfnumber
         description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_77
+  - !<!DictionarySchema> &ref_30
     type: dictionary
-    elementType: !<!NumberSchema> &ref_29
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_78
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_30
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_79
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_31
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 1.0, "1": "number", "2": 0.0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_80
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_32
+    elementType: !<!NumberSchema> &ref_16
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -513,131 +196,9 @@ schemas: !<!Schemas>
         name: DictionaryOfnumber
         description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_81
+  - !<!DictionarySchema> &ref_31
     type: dictionary
-    elementType: !<!NumberSchema> &ref_33
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_82
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_34
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_83
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_35
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 1.0, "1": "number", "2": 0.0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_84
-    type: dictionary
-    elementType: !<!StringSchema> &ref_43
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_85
-    type: dictionary
-    elementType: !<!StringSchema> &ref_44
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_86
-    type: dictionary
-    elementType: !<!StringSchema> &ref_45
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The dictionary value {"0": "foo", "1": null, "2": "foo2"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_87
-    type: dictionary
-    elementType: !<!StringSchema> &ref_46
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The dictionary value {"0": "foo", "1": 123, "2": "foo2"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_88
-    type: dictionary
-    elementType: !<!DateSchema> &ref_15
+    elementType: !<!DateSchema> &ref_10
       type: date
       apiVersions:
       - !<!ApiVersion> 
@@ -652,9 +213,9 @@ schemas: !<!Schemas>
         name: DictionaryOfdate
         description: 'The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_89
+  - !<!DictionarySchema> &ref_32
     type: dictionary
-    elementType: !<!DateTimeSchema> &ref_13
+    elementType: !<!DateTimeSchema> &ref_8
       type: date-time
       format: date-time
       apiVersions:
@@ -670,9 +231,9 @@ schemas: !<!Schemas>
         name: DictionaryOfdate-time
         description: 'The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_90
+  - !<!DictionarySchema> &ref_33
     type: dictionary
-    elementType: !<!DateTimeSchema> &ref_14
+    elementType: !<!DateTimeSchema> &ref_9
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -688,9 +249,9 @@ schemas: !<!Schemas>
         name: DictionaryOfdate-time
         description: 'The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_91
+  - !<!DictionarySchema> &ref_34
     type: dictionary
-    elementType: !<!DurationSchema> &ref_16
+    elementType: !<!DurationSchema> &ref_11
       type: duration
       apiVersions:
       - !<!ApiVersion> 
@@ -705,9 +266,9 @@ schemas: !<!Schemas>
         name: DictionaryOfduration
         description: 'The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_92
+  - !<!DictionarySchema> &ref_35
     type: dictionary
-    elementType: !<!ByteArraySchema> &ref_11
+    elementType: !<!ByteArraySchema> &ref_6
       type: byte-array
       format: byte
       apiVersions:
@@ -723,9 +284,9 @@ schemas: !<!Schemas>
         name: DictionaryOfbyte-array
         description: 'The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_93
+  - !<!DictionarySchema> &ref_36
     type: dictionary
-    elementType: !<!ByteArraySchema> &ref_12
+    elementType: !<!ByteArraySchema> &ref_7
       type: byte-array
       format: base64url
       apiVersions:
@@ -741,7 +302,7 @@ schemas: !<!Schemas>
         name: DictionaryOfbyte-array
         description: 'The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_94
+  - !<!DictionarySchema> &ref_37
     type: dictionary
     elementType: *ref_0
     language: !<!Languages> 
@@ -749,14 +310,14 @@ schemas: !<!Schemas>
         name: DictionaryOfWidget
         description: Dictionary of complex type with null value
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_95
+  - !<!DictionarySchema> &ref_38
     type: dictionary
-    elementType: !<!ArraySchema> &ref_1
+    elementType: !<!ArraySchema> &ref_2
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_48
+      elementType: !<!StringSchema> &ref_20
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -776,23 +337,14 @@ schemas: !<!Schemas>
         name: DictionaryOfpaths·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
         description: a null array
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_96
+  - !<!DictionarySchema> &ref_39
     type: dictionary
-    elementType: !<!ArraySchema> &ref_2
+    elementType: !<!ArraySchema> &ref_3
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_49
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: string
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: Array of string
@@ -803,95 +355,14 @@ schemas: !<!Schemas>
         name: DictionaryOfpaths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
         description: 'An empty dictionary {}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_97
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_3
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_50
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: string
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: Array of string
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfpaths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_98
+  - !<!DictionarySchema> &ref_40
     type: dictionary
     elementType: !<!ArraySchema> &ref_4
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_51
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: string
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: Array of string
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfpaths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_99
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_5
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_52
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: string
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: Array of string
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfpaths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_100
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_6
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_53
+      elementType: !<!StringSchema> &ref_21
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -911,7 +382,7 @@ schemas: !<!Schemas>
         name: DictionaryOfpaths·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
         description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_101
+  - !<!DictionarySchema> &ref_41
     type: dictionary
     elementType: !<!AnySchema> 
       type: any
@@ -925,207 +396,45 @@ schemas: !<!Schemas>
         name: DictionaryOfany
         description: An dictionaries of dictionaries with value null
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_102
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_103
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_104
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_105
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_106
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
   arrays:
-  - *ref_1
   - *ref_2
   - *ref_3
   - *ref_4
-  - *ref_5
-  - *ref_6
   booleans:
+  - *ref_5
+  byteArrays:
+  - *ref_6
   - *ref_7
+  dateTimes:
   - *ref_8
   - *ref_9
+  dates:
   - *ref_10
-  byteArrays:
+  durations:
   - *ref_11
+  numbers:
   - *ref_12
-  dateTimes:
   - *ref_13
   - *ref_14
-  dates:
   - *ref_15
-  durations:
   - *ref_16
-  numbers:
   - *ref_17
-  - *ref_18
-  - *ref_19
-  - *ref_20
-  - *ref_21
-  - *ref_22
-  - *ref_23
-  - *ref_24
-  - *ref_25
-  - *ref_26
-  - *ref_27
-  - *ref_28
-  - *ref_29
-  - *ref_30
-  - *ref_31
-  - *ref_32
-  - *ref_33
-  - *ref_34
-  - *ref_35
-  - *ref_36
   strings:
-  - !<!StringSchema> &ref_54
+  - !<!StringSchema> &ref_22
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: simple string
     protocol: !<!Protocols> {}
-  - *ref_37
-  - *ref_38
-  - *ref_39
-  - *ref_40
-  - *ref_41
-  - *ref_42
-  - *ref_43
-  - *ref_44
-  - *ref_45
-  - *ref_46
-  - *ref_47
-  - *ref_48
-  - *ref_49
-  - *ref_50
-  - *ref_51
-  - *ref_52
-  - *ref_53
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_18
+  - *ref_1
+  - *ref_19
+  - *ref_20
+  - *ref_21
 globalParameters:
-- !<!Parameter> &ref_55
-  schema: *ref_54
+- !<!Parameter> &ref_23
+  schema: *ref_22
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -1135,7 +444,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-dictionary
@@ -1149,18 +458,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/null'
+          path: /dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1174,7 +484,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1197,18 +507,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/empty'
+          path: /dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_58
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1222,7 +533,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1245,9 +556,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -1266,11 +577,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/empty'
+          path: /dictionary/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1283,7 +595,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1308,18 +620,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/nullvalue'
+          path: /dictionary/nullvalue
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_60
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1333,7 +646,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1356,18 +669,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/nullkey'
+          path: /dictionary/nullkey
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_61
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1381,7 +695,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1404,18 +718,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/keyemptystring'
+          path: /dictionary/keyemptystring
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_62
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1429,7 +744,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1452,18 +767,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/invalid'
+          path: /dictionary/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_63
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1477,7 +793,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1500,18 +816,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/tfft'
+          path: /dictionary/prim/boolean/tfft
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_64
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1525,7 +842,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1548,9 +865,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_27
         implementation: Method
         required: true
         extensions:
@@ -1569,11 +886,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/boolean/tfft'
+          path: /dictionary/prim/boolean/tfft
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1586,7 +904,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1611,18 +929,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/true.null.false'
+          path: /dictionary/prim/boolean/true.null.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_66
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1636,7 +955,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1659,18 +978,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/true.boolean.false'
+          path: /dictionary/prim/boolean/true.boolean.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1684,7 +1004,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1707,18 +1027,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.-1.3.300'
+          path: /dictionary/prim/integer/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_68
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1732,7 +1053,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1755,9 +1076,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_24
         implementation: Method
         required: true
         extensions:
@@ -1776,11 +1097,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/integer/1.-1.3.300'
+          path: /dictionary/prim/integer/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1793,7 +1115,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1818,18 +1140,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.null.zero'
+          path: /dictionary/prim/integer/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1843,7 +1166,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1866,18 +1189,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.integer.0'
+          path: /dictionary/prim/integer/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_71
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1891,7 +1215,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1914,18 +1238,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.-1.3.300'
+          path: /dictionary/prim/long/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_72
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1939,7 +1264,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1962,9 +1287,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_28
         implementation: Method
         required: true
         extensions:
@@ -1983,11 +1308,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/long/1.-1.3.300'
+          path: /dictionary/prim/long/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2000,7 +1326,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2025,18 +1351,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.null.zero'
+          path: /dictionary/prim/long/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_74
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2050,7 +1377,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2073,18 +1400,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.integer.0'
+          path: /dictionary/prim/long/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_75
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2098,7 +1426,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2121,18 +1449,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/0--0.01-1.2e20'
+          path: /dictionary/prim/float/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_76
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2146,7 +1475,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2169,9 +1498,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -2190,11 +1519,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/float/0--0.01-1.2e20'
+          path: /dictionary/prim/float/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2207,7 +1537,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2232,18 +1562,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/0.0-null-1.2e20'
+          path: /dictionary/prim/float/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2257,7 +1588,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2280,18 +1611,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/1.number.0'
+          path: /dictionary/prim/float/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2305,7 +1637,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2328,18 +1660,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/0--0.01-1.2e20'
+          path: /dictionary/prim/double/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_80
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2353,7 +1686,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2376,9 +1709,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_81
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2397,11 +1730,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/double/0--0.01-1.2e20'
+          path: /dictionary/prim/double/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2414,7 +1748,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2439,18 +1773,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/0.0-null-1.2e20'
+          path: /dictionary/prim/double/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_82
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2464,7 +1799,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2487,18 +1822,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/1.number.0'
+          path: /dictionary/prim/double/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_83
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2512,7 +1848,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2535,18 +1871,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo1.foo2.foo3'
+          path: /dictionary/prim/string/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_84
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2560,7 +1897,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2583,9 +1920,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_85
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -2604,11 +1941,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/string/foo1.foo2.foo3'
+          path: /dictionary/prim/string/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2621,7 +1959,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2646,18 +1984,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo.null.foo2'
+          path: /dictionary/prim/string/foo.null.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_86
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2671,7 +2010,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2694,18 +2033,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo.123.foo2'
+          path: /dictionary/prim/string/foo.123.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_87
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2719,7 +2059,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2742,18 +2082,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/valid'
+          path: /dictionary/prim/date/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2767,7 +2108,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2790,9 +2131,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_88
+        schema: *ref_31
         implementation: Method
         required: true
         extensions:
@@ -2811,11 +2152,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date/valid'
+          path: /dictionary/prim/date/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2828,7 +2170,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2853,18 +2195,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/invalidnull'
+          path: /dictionary/prim/date/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2878,7 +2221,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2901,18 +2244,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/invalidchars'
+          path: /dictionary/prim/date/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2926,7 +2270,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2949,18 +2293,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/valid'
+          path: /dictionary/prim/date-time/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -2974,7 +2319,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2997,9 +2342,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_89
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -3018,11 +2363,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date-time/valid'
+          path: /dictionary/prim/date-time/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3035,7 +2381,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3060,18 +2406,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/invalidnull'
+          path: /dictionary/prim/date-time/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -3085,7 +2432,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3108,18 +2455,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/invalidchars'
+          path: /dictionary/prim/date-time/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -3133,7 +2481,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3156,18 +2504,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time-rfc1123/valid'
+          path: /dictionary/prim/date-time-rfc1123/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_90
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -3181,7 +2530,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3204,9 +2553,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_90
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -3225,11 +2574,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date-time-rfc1123/valid'
+          path: /dictionary/prim/date-time-rfc1123/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3242,7 +2592,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3267,18 +2617,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/duration/valid'
+          path: /dictionary/prim/duration/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_91
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -3292,7 +2643,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3315,9 +2666,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -3336,11 +2687,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/duration/valid'
+          path: /dictionary/prim/duration/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3353,7 +2705,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3378,18 +2730,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/byte/valid'
+          path: /dictionary/prim/byte/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -3403,7 +2756,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3426,9 +2779,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_92
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -3447,11 +2800,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/byte/valid'
+          path: /dictionary/prim/byte/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3464,7 +2818,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3489,18 +2843,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/byte/invalidnull'
+          path: /dictionary/prim/byte/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -3514,7 +2869,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3537,18 +2892,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/base64url/valid'
+          path: /dictionary/prim/base64url/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_93
+      schema: *ref_36
       language: !<!Languages> 
         default:
           name: ''
@@ -3562,7 +2918,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3585,18 +2941,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/null'
+          path: /dictionary/complex/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3610,7 +2967,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3633,18 +2990,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/empty'
+          path: /dictionary/complex/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3658,7 +3016,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3681,18 +3039,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/itemnull'
+          path: /dictionary/complex/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3706,7 +3065,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3729,18 +3088,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/itemempty'
+          path: /dictionary/complex/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3754,7 +3114,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3777,18 +3137,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/valid'
+          path: /dictionary/complex/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3802,7 +3163,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3825,9 +3186,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_94
+        schema: *ref_37
         implementation: Method
         required: true
         extensions:
@@ -3846,11 +3207,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/complex/valid'
+          path: /dictionary/complex/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3863,7 +3225,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3888,18 +3250,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/null'
+          path: /dictionary/array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_95
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3913,7 +3276,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3936,18 +3299,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/empty'
+          path: /dictionary/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_96
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3961,7 +3325,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3984,18 +3348,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/itemnull'
+          path: /dictionary/array/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_97
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4009,7 +3374,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4032,18 +3397,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/itemempty'
+          path: /dictionary/array/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_98
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4057,7 +3423,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4080,18 +3446,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/valid'
+          path: /dictionary/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_99
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4105,7 +3472,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4128,9 +3495,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_100
+        schema: *ref_40
         implementation: Method
         required: true
         extensions:
@@ -4149,11 +3516,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/array/valid'
+          path: /dictionary/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4166,7 +3534,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4191,18 +3559,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/null'
+          path: /dictionary/dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_101
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4216,7 +3585,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4239,18 +3608,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/empty'
+          path: /dictionary/dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_102
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4264,7 +3634,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4287,18 +3657,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/itemnull'
+          path: /dictionary/dictionary/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_103
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4312,7 +3683,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4335,18 +3706,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/itemempty'
+          path: /dictionary/dictionary/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_104
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4360,7 +3732,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4383,18 +3755,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/valid'
+          path: /dictionary/dictionary/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_105
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4408,7 +3781,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4431,9 +3804,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_106
+        schema: *ref_41
         implementation: Method
         required: true
         extensions:
@@ -4452,11 +3825,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/dictionary/valid'
+          path: /dictionary/dictionary/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4469,7 +3843,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-dictionary/modeler.yaml
+++ b/modelerfour/test/outputs/body-dictionary/modeler.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_56
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_35
+      schema: !<!NumberSchema> &ref_9
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_36
+      schema: !<!StringSchema> &ref_10
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -45,14 +45,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_37
+  - !<!ObjectSchema> &ref_11
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_27
+      schema: !<!NumberSchema> &ref_5
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_28
+      schema: !<!StringSchema> &ref_6
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_55
+  - !<!DictionarySchema> &ref_23
     type: dictionary
     elementType: !<!NumberSchema> &ref_0
       type: integer
@@ -108,44 +108,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-null·get·responses·200·content·application-json·schema
         description: The null dictionary value
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_58
+  - !<!DictionarySchema> &ref_26
     type: dictionary
-    elementType: !<!NumberSchema> &ref_1
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-empty·get·responses·200·content·application-json·schema
-        description: 'The empty dictionary value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_59
-    type: dictionary
-    elementType: !<!StringSchema> &ref_2
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-empty·put·requestbody·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-empty·put·requestbody·content·application-json·schema
-        description: 'The empty dictionary value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_60
-    type: dictionary
-    elementType: !<!StringSchema> &ref_3
+    elementType: !<!StringSchema> &ref_1
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -160,60 +125,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-nullvalue·get·responses·200·content·application-json·schema
         description: Dictionary of <paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties>
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_61
+  - !<!DictionarySchema> &ref_27
     type: dictionary
-    elementType: !<!StringSchema> &ref_4
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-nullkey·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-nullkey·get·responses·200·content·application-json·schema
-        description: Dictionary of <paths·dictionary-nullkey·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_62
-    type: dictionary
-    elementType: !<!StringSchema> &ref_5
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema
-        description: Dictionary of <paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_63
-    type: dictionary
-    elementType: !<!StringSchema> &ref_6
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-invalid·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-invalid·get·responses·200·content·application-json·schema
-        description: Dictionary of <paths·dictionary-invalid·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_64
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_38
+    elementType: !<!BooleanSchema> &ref_12
       type: boolean
       apiVersions:
       - !<!ApiVersion> 
@@ -228,132 +142,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_65
+  - !<!DictionarySchema> &ref_28
     type: dictionary
-    elementType: !<!BooleanSchema> &ref_39
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-boolean-tfft·put·requestbody·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-boolean-tfft·put·requestbody·content·application-json·schema
-        description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_66
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_40
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-boolean-true-null-false·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-boolean-true-null-false·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": true, "1": null, "2": false }'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_67
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_41
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-boolean-true-boolean-false·get·responses·200·content·application-json·schema
-        description: 'The dictionary value [true, ''boolean'', false]'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_68
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_7
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-integer-1-_1-3-300·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_69
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_8
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-integer-1-_1-3-300·put·requestbody·content·application-json·schema
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_70
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_9
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-integer-1-null-zero·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-integer-1-null-zero·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 1, "1": null, "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_71
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_10
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-integer-1-integer-0·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-integer-1-integer-0·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 1, "1": "integer", "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_72
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_11
+    elementType: !<!NumberSchema> &ref_2
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -369,63 +160,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_73
+  - !<!DictionarySchema> &ref_29
     type: dictionary
-    elementType: !<!NumberSchema> &ref_12
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-long-1-_1-3-300·put·requestbody·content·application-json·schema
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_74
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_13
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-long-1-null-zero·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-long-1-null-zero·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 1, "1": null, "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_75
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_14
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-long-1-integer-0·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-long-1-integer-0·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 1, "1": "integer", "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_76
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_15
+    elementType: !<!NumberSchema> &ref_3
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -441,63 +178,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_77
+  - !<!DictionarySchema> &ref_30
     type: dictionary
-    elementType: !<!NumberSchema> &ref_16
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-float-0_0-01_1-2e20·put·requestbody·content·application-json·schema
-        description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_78
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_17
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-float-0-0_null_1-2e20·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_79
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_18
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-float-1-number-0·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-float-1-number-0·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 1.0, "1": "number", "2": 0.0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_80
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_19
+    elementType: !<!NumberSchema> &ref_4
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -513,131 +196,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_81
+  - !<!DictionarySchema> &ref_31
     type: dictionary
-    elementType: !<!NumberSchema> &ref_20
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-double-0_0-01_1-2e20·put·requestbody·content·application-json·schema
-        description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_82
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_21
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-double-0-0_null_1-2e20·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_83
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_22
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-double-1-number-0·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-double-1-number-0·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": 1.0, "1": "number", "2": 0.0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_84
-    type: dictionary
-    elementType: !<!StringSchema> &ref_23
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_85
-    type: dictionary
-    elementType: !<!StringSchema> &ref_24
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-string-foo1-foo2-foo3·put·requestbody·content·application-json·schema
-        description: 'The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_86
-    type: dictionary
-    elementType: !<!StringSchema> &ref_25
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-string-foo-null-foo2·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": "foo", "1": null, "2": "foo2"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_87
-    type: dictionary
-    elementType: !<!StringSchema> &ref_26
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-prim-string-foo-123-foo2·get·responses·200·content·application-json·schema
-        description: 'The dictionary value {"0": "foo", "1": 123, "2": "foo2"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_88
-    type: dictionary
-    elementType: !<!DateSchema> &ref_42
+    elementType: !<!DateSchema> &ref_13
       type: date
       apiVersions:
       - !<!ApiVersion> 
@@ -652,9 +213,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_89
+  - !<!DictionarySchema> &ref_32
     type: dictionary
-    elementType: !<!DateTimeSchema> &ref_43
+    elementType: !<!DateTimeSchema> &ref_14
       type: date-time
       format: date-time
       apiVersions:
@@ -670,9 +231,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_90
+  - !<!DictionarySchema> &ref_33
     type: dictionary
-    elementType: !<!DateTimeSchema> &ref_44
+    elementType: !<!DateTimeSchema> &ref_15
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -688,9 +249,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_91
+  - !<!DictionarySchema> &ref_34
     type: dictionary
-    elementType: !<!DurationSchema> &ref_45
+    elementType: !<!DurationSchema> &ref_16
       type: duration
       apiVersions:
       - !<!ApiVersion> 
@@ -705,9 +266,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_92
+  - !<!DictionarySchema> &ref_35
     type: dictionary
-    elementType: !<!ByteArraySchema> &ref_46
+    elementType: !<!ByteArraySchema> &ref_17
       type: byte-array
       format: byte
       apiVersions:
@@ -723,9 +284,9 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
         description: 'The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_93
+  - !<!DictionarySchema> &ref_36
     type: dictionary
-    elementType: !<!ByteArraySchema> &ref_47
+    elementType: !<!ByteArraySchema> &ref_18
       type: byte-array
       format: base64url
       apiVersions:
@@ -741,22 +302,22 @@ schemas: !<!Schemas>
         name: paths·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
         description: 'The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_94
+  - !<!DictionarySchema> &ref_37
     type: dictionary
-    elementType: *ref_37
+    elementType: *ref_11
     language: !<!Languages> 
       default:
         name: paths·dictionary-complex-null·get·responses·200·content·application-json·schema
         description: Dictionary of complex type with null value
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_95
+  - !<!DictionarySchema> &ref_38
     type: dictionary
-    elementType: !<!ArraySchema> &ref_48
+    elementType: !<!ArraySchema> &ref_19
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_29
+      elementType: !<!StringSchema> &ref_7
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -776,23 +337,14 @@ schemas: !<!Schemas>
         name: paths·dictionary-array-null·get·responses·200·content·application-json·schema
         description: a null array
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_96
+  - !<!DictionarySchema> &ref_39
     type: dictionary
-    elementType: !<!ArraySchema> &ref_49
+    elementType: !<!ArraySchema> &ref_20
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_30
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: paths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties·items
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
@@ -803,95 +355,14 @@ schemas: !<!Schemas>
         name: paths·dictionary-array-empty·get·responses·200·content·application-json·schema
         description: 'An empty dictionary {}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_97
+  - !<!DictionarySchema> &ref_40
     type: dictionary
-    elementType: !<!ArraySchema> &ref_50
+    elementType: !<!ArraySchema> &ref_21
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_31
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties·items
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-array-itemnull·get·responses·200·content·application-json·schema
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_98
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_51
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_32
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties·items
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-array-itemempty·get·responses·200·content·application-json·schema
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_99
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_52
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_33
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: paths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties·items
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: paths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-array-valid·get·responses·200·content·application-json·schema
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_100
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_53
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_34
+      elementType: !<!StringSchema> &ref_8
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -911,7 +382,7 @@ schemas: !<!Schemas>
         name: paths·dictionary-array-valid·put·requestbody·content·application-json·schema
         description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_101
+  - !<!DictionarySchema> &ref_41
     type: dictionary
     elementType: !<!AnySchema> 
       type: any
@@ -925,207 +396,45 @@ schemas: !<!Schemas>
         name: paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema
         description: An dictionaries of dictionaries with value null
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_102
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema
-        description: 'An dictionaries of dictionaries of type <string, string> with value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_103
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_104
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_105
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_106
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
   arrays:
-  - *ref_48
-  - *ref_49
-  - *ref_50
-  - *ref_51
-  - *ref_52
-  - *ref_53
-  booleans:
-  - *ref_38
-  - *ref_39
-  - *ref_40
-  - *ref_41
-  byteArrays:
-  - *ref_46
-  - *ref_47
-  dateTimes:
-  - *ref_43
-  - *ref_44
-  dates:
-  - *ref_42
-  durations:
-  - *ref_45
-  numbers:
-  - *ref_0
-  - *ref_35
-  - *ref_1
-  - *ref_7
-  - *ref_8
-  - *ref_9
-  - *ref_10
-  - *ref_11
-  - *ref_12
-  - *ref_13
-  - *ref_14
-  - *ref_15
-  - *ref_16
-  - *ref_17
-  - *ref_18
   - *ref_19
   - *ref_20
   - *ref_21
-  - *ref_22
-  - *ref_27
+  booleans:
+  - *ref_12
+  byteArrays:
+  - *ref_17
+  - *ref_18
+  dateTimes:
+  - *ref_14
+  - *ref_15
+  dates:
+  - *ref_13
+  durations:
+  - *ref_16
+  numbers:
+  - *ref_0
+  - *ref_9
+  - *ref_2
+  - *ref_3
+  - *ref_4
+  - *ref_5
   strings:
-  - !<!StringSchema> &ref_54
+  - !<!StringSchema> &ref_22
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: simple string
     protocol: !<!Protocols> {}
-  - *ref_36
-  - *ref_2
-  - *ref_3
-  - *ref_4
-  - *ref_5
+  - *ref_10
+  - *ref_1
   - *ref_6
-  - *ref_23
-  - *ref_24
-  - *ref_25
-  - *ref_26
-  - *ref_28
-  - *ref_29
-  - *ref_30
-  - *ref_31
-  - *ref_32
-  - *ref_33
-  - *ref_34
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-null·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-empty·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-itemnull·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-itemempty·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-valid·get·responses·200·content·application-json·schema·additionalproperties·additionalproperties
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·dictionary-dictionary-valid·put·requestbody·content·application-json·schema·additionalproperties·additionalproperties
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_7
+  - *ref_8
 globalParameters:
-- !<!Parameter> &ref_57
-  schema: *ref_54
+- !<!Parameter> &ref_25
+  schema: *ref_22
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -1135,7 +444,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-dictionary
@@ -1149,18 +458,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/null'
+          path: /dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_55
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1174,7 +484,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1197,18 +507,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/empty'
+          path: /dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_58
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1222,7 +533,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1245,9 +556,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -1266,11 +577,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/empty'
+          path: /dictionary/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1283,7 +595,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1308,18 +620,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/nullvalue'
+          path: /dictionary/nullvalue
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_60
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1333,7 +646,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1356,18 +669,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/nullkey'
+          path: /dictionary/nullkey
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_61
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1381,7 +695,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1404,18 +718,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/keyemptystring'
+          path: /dictionary/keyemptystring
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_62
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1429,7 +744,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1452,18 +767,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/invalid'
+          path: /dictionary/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_63
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1477,7 +793,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1500,18 +816,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/tfft'
+          path: /dictionary/prim/boolean/tfft
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_64
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1525,7 +842,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1548,9 +865,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_27
         implementation: Method
         required: true
         extensions:
@@ -1569,11 +886,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/boolean/tfft'
+          path: /dictionary/prim/boolean/tfft
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1586,7 +904,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1611,18 +929,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/true.null.false'
+          path: /dictionary/prim/boolean/true.null.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_66
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1636,7 +955,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1659,18 +978,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/true.boolean.false'
+          path: /dictionary/prim/boolean/true.boolean.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1684,7 +1004,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1707,18 +1027,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.-1.3.300'
+          path: /dictionary/prim/integer/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_68
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1732,7 +1053,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1755,9 +1076,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_23
         implementation: Method
         required: true
         extensions:
@@ -1776,11 +1097,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/integer/1.-1.3.300'
+          path: /dictionary/prim/integer/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1793,7 +1115,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1818,18 +1140,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.null.zero'
+          path: /dictionary/prim/integer/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1843,7 +1166,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1866,18 +1189,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.integer.0'
+          path: /dictionary/prim/integer/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_71
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1891,7 +1215,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1914,18 +1238,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.-1.3.300'
+          path: /dictionary/prim/long/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_72
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1939,7 +1264,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1962,9 +1287,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_28
         implementation: Method
         required: true
         extensions:
@@ -1983,11 +1308,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/long/1.-1.3.300'
+          path: /dictionary/prim/long/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2000,7 +1326,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2025,18 +1351,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.null.zero'
+          path: /dictionary/prim/long/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_74
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2050,7 +1377,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2073,18 +1400,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.integer.0'
+          path: /dictionary/prim/long/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_75
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2098,7 +1426,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2121,18 +1449,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/0--0.01-1.2e20'
+          path: /dictionary/prim/float/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_76
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2146,7 +1475,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2169,9 +1498,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -2190,11 +1519,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/float/0--0.01-1.2e20'
+          path: /dictionary/prim/float/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2207,7 +1537,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2232,18 +1562,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/0.0-null-1.2e20'
+          path: /dictionary/prim/float/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2257,7 +1588,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2280,18 +1611,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/1.number.0'
+          path: /dictionary/prim/float/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2305,7 +1637,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2328,18 +1660,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/0--0.01-1.2e20'
+          path: /dictionary/prim/double/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_80
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2353,7 +1686,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2376,9 +1709,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_81
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2397,11 +1730,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/double/0--0.01-1.2e20'
+          path: /dictionary/prim/double/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2414,7 +1748,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2439,18 +1773,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/0.0-null-1.2e20'
+          path: /dictionary/prim/double/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_82
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2464,7 +1799,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2487,18 +1822,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/1.number.0'
+          path: /dictionary/prim/double/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_83
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2512,7 +1848,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2535,18 +1871,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo1.foo2.foo3'
+          path: /dictionary/prim/string/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_84
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2560,7 +1897,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2583,9 +1920,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_85
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -2604,11 +1941,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/string/foo1.foo2.foo3'
+          path: /dictionary/prim/string/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2621,7 +1959,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2646,18 +1984,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo.null.foo2'
+          path: /dictionary/prim/string/foo.null.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_86
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2671,7 +2010,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2694,18 +2033,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo.123.foo2'
+          path: /dictionary/prim/string/foo.123.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_87
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2719,7 +2059,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2742,18 +2082,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/valid'
+          path: /dictionary/prim/date/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2767,7 +2108,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2790,9 +2131,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_88
+        schema: *ref_31
         implementation: Method
         required: true
         extensions:
@@ -2811,11 +2152,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date/valid'
+          path: /dictionary/prim/date/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2828,7 +2170,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2853,18 +2195,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/invalidnull'
+          path: /dictionary/prim/date/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2878,7 +2221,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2901,18 +2244,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/invalidchars'
+          path: /dictionary/prim/date/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2926,7 +2270,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2949,18 +2293,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/valid'
+          path: /dictionary/prim/date-time/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -2974,7 +2319,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2997,9 +2342,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_89
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -3018,11 +2363,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date-time/valid'
+          path: /dictionary/prim/date-time/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3035,7 +2381,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3060,18 +2406,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/invalidnull'
+          path: /dictionary/prim/date-time/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -3085,7 +2432,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3108,18 +2455,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/invalidchars'
+          path: /dictionary/prim/date-time/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -3133,7 +2481,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3156,18 +2504,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time-rfc1123/valid'
+          path: /dictionary/prim/date-time-rfc1123/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_90
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -3181,7 +2530,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3204,9 +2553,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_90
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -3225,11 +2574,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date-time-rfc1123/valid'
+          path: /dictionary/prim/date-time-rfc1123/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3242,7 +2592,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3267,18 +2617,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/duration/valid'
+          path: /dictionary/prim/duration/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_91
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -3292,7 +2643,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3315,9 +2666,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -3336,11 +2687,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/duration/valid'
+          path: /dictionary/prim/duration/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3353,7 +2705,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3378,18 +2730,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/byte/valid'
+          path: /dictionary/prim/byte/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -3403,7 +2756,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3426,9 +2779,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_92
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -3447,11 +2800,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/byte/valid'
+          path: /dictionary/prim/byte/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3464,7 +2818,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3489,18 +2843,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/byte/invalidnull'
+          path: /dictionary/prim/byte/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -3514,7 +2869,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3537,18 +2892,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/base64url/valid'
+          path: /dictionary/prim/base64url/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_93
+      schema: *ref_36
       language: !<!Languages> 
         default:
           name: ''
@@ -3562,7 +2918,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3585,18 +2941,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/null'
+          path: /dictionary/complex/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3610,7 +2967,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3633,18 +2990,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/empty'
+          path: /dictionary/complex/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3658,7 +3016,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3681,18 +3039,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/itemnull'
+          path: /dictionary/complex/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3706,7 +3065,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3729,18 +3088,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/itemempty'
+          path: /dictionary/complex/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3754,7 +3114,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3777,18 +3137,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/valid'
+          path: /dictionary/complex/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3802,7 +3163,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3825,9 +3186,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_94
+        schema: *ref_37
         implementation: Method
         required: true
         extensions:
@@ -3846,11 +3207,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/complex/valid'
+          path: /dictionary/complex/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3863,7 +3225,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3888,18 +3250,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/null'
+          path: /dictionary/array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_95
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3913,7 +3276,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3936,18 +3299,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/empty'
+          path: /dictionary/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_96
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3961,7 +3325,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3984,18 +3348,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/itemnull'
+          path: /dictionary/array/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_97
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4009,7 +3374,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4032,18 +3397,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/itemempty'
+          path: /dictionary/array/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_98
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4057,7 +3423,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4080,18 +3446,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/valid'
+          path: /dictionary/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_99
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4105,7 +3472,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4128,9 +3495,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_100
+        schema: *ref_40
         implementation: Method
         required: true
         extensions:
@@ -4149,11 +3516,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/array/valid'
+          path: /dictionary/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4166,7 +3534,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4191,18 +3559,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/null'
+          path: /dictionary/dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_101
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4216,7 +3585,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4239,18 +3608,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/empty'
+          path: /dictionary/dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_102
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4264,7 +3634,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4287,18 +3657,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/itemnull'
+          path: /dictionary/dictionary/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_103
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4312,7 +3683,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4335,18 +3706,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/itemempty'
+          path: /dictionary/dictionary/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_104
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4360,7 +3732,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4383,18 +3755,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/valid'
+          path: /dictionary/dictionary/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_105
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4408,7 +3781,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4431,9 +3804,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_57
+      - *ref_25
       - !<!Parameter> 
-        schema: *ref_106
+        schema: *ref_41
         implementation: Method
         required: true
         extensions:
@@ -4452,11 +3825,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/dictionary/valid'
+          path: /dictionary/dictionary/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4469,7 +3843,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-dictionary/namer.yaml
+++ b/modelerfour/test/outputs/body-dictionary/namer.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_57
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_18
+      schema: !<!NumberSchema> &ref_13
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_37
+      schema: !<!StringSchema> &ref_18
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -52,7 +52,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_36
+      schema: !<!NumberSchema> &ref_17
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_47
+      schema: !<!StringSchema> &ref_19
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -90,9 +90,9 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_56
+  - !<!DictionarySchema> &ref_24
     type: dictionary
-    elementType: !<!NumberSchema> &ref_17
+    elementType: !<!NumberSchema> &ref_12
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -108,44 +108,9 @@ schemas: !<!Schemas>
         name: DictionaryOfinteger
         description: The null dictionary value
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_58
+  - !<!DictionarySchema> &ref_26
     type: dictionary
-    elementType: !<!NumberSchema> &ref_19
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The empty dictionary value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_59
-    type: dictionary
-    elementType: !<!StringSchema> &ref_38
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The empty dictionary value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_60
-    type: dictionary
-    elementType: !<!StringSchema> &ref_39
+    elementType: !<!StringSchema> &ref_1
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -160,60 +125,9 @@ schemas: !<!Schemas>
         name: Dictionary of string
         description: Dictionary of <paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties>
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_61
+  - !<!DictionarySchema> &ref_27
     type: dictionary
-    elementType: !<!StringSchema> &ref_40
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·dictionary-nullkey·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_62
-    type: dictionary
-    elementType: !<!StringSchema> &ref_41
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·dictionary-keyemptystring·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_63
-    type: dictionary
-    elementType: !<!StringSchema> &ref_42
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Dictionary of string
-        description: Dictionary of <paths·dictionary-invalid·get·responses·200·content·application-json·schema·additionalproperties>
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_64
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_7
+    elementType: !<!BooleanSchema> &ref_5
       type: boolean
       apiVersions:
       - !<!ApiVersion> 
@@ -228,132 +142,9 @@ schemas: !<!Schemas>
         name: DictionaryOfboolean
         description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_65
+  - !<!DictionarySchema> &ref_28
     type: dictionary
-    elementType: !<!BooleanSchema> &ref_8
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfboolean
-        description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_66
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_9
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfboolean
-        description: 'The dictionary value {"0": true, "1": null, "2": false }'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_67
-    type: dictionary
-    elementType: !<!BooleanSchema> &ref_10
-      type: boolean
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: boolean
-          description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfboolean
-        description: 'The dictionary value [true, ''boolean'', false]'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_68
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_20
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_69
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_21
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_70
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_22
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": null, "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_71
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_23
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": "integer", "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_72
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_24
+    elementType: !<!NumberSchema> &ref_14
       type: integer
       apiVersions:
       - !<!ApiVersion> 
@@ -369,63 +160,9 @@ schemas: !<!Schemas>
         name: DictionaryOfinteger
         description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_73
+  - !<!DictionarySchema> &ref_29
     type: dictionary
-    elementType: !<!NumberSchema> &ref_25
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_74
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_26
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": null, "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_75
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_27
-      type: integer
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfinteger
-        description: 'The dictionary value {"0": 1, "1": "integer", "2": 0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_76
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_28
+    elementType: !<!NumberSchema> &ref_15
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -441,63 +178,9 @@ schemas: !<!Schemas>
         name: DictionaryOfnumber
         description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_77
+  - !<!DictionarySchema> &ref_30
     type: dictionary
-    elementType: !<!NumberSchema> &ref_29
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_78
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_30
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_79
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_31
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 1.0, "1": "number", "2": 0.0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_80
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_32
+    elementType: !<!NumberSchema> &ref_16
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -513,131 +196,9 @@ schemas: !<!Schemas>
         name: DictionaryOfnumber
         description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_81
+  - !<!DictionarySchema> &ref_31
     type: dictionary
-    elementType: !<!NumberSchema> &ref_33
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_82
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_34
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_83
-    type: dictionary
-    elementType: !<!NumberSchema> &ref_35
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfnumber
-        description: 'The dictionary value {"0": 1.0, "1": "number", "2": 0.0}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_84
-    type: dictionary
-    elementType: !<!StringSchema> &ref_43
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_85
-    type: dictionary
-    elementType: !<!StringSchema> &ref_44
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_86
-    type: dictionary
-    elementType: !<!StringSchema> &ref_45
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The dictionary value {"0": "foo", "1": null, "2": "foo2"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_87
-    type: dictionary
-    elementType: !<!StringSchema> &ref_46
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfstring
-        description: 'The dictionary value {"0": "foo", "1": 123, "2": "foo2"}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_88
-    type: dictionary
-    elementType: !<!DateSchema> &ref_15
+    elementType: !<!DateSchema> &ref_10
       type: date
       apiVersions:
       - !<!ApiVersion> 
@@ -652,9 +213,9 @@ schemas: !<!Schemas>
         name: DictionaryOfdate
         description: 'The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_89
+  - !<!DictionarySchema> &ref_32
     type: dictionary
-    elementType: !<!DateTimeSchema> &ref_13
+    elementType: !<!DateTimeSchema> &ref_8
       type: date-time
       format: date-time
       apiVersions:
@@ -670,9 +231,9 @@ schemas: !<!Schemas>
         name: DictionaryOfdate-time
         description: 'The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_90
+  - !<!DictionarySchema> &ref_33
     type: dictionary
-    elementType: !<!DateTimeSchema> &ref_14
+    elementType: !<!DateTimeSchema> &ref_9
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -688,9 +249,9 @@ schemas: !<!Schemas>
         name: DictionaryOfdate-time
         description: 'The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_91
+  - !<!DictionarySchema> &ref_34
     type: dictionary
-    elementType: !<!DurationSchema> &ref_16
+    elementType: !<!DurationSchema> &ref_11
       type: duration
       apiVersions:
       - !<!ApiVersion> 
@@ -705,9 +266,9 @@ schemas: !<!Schemas>
         name: DictionaryOfduration
         description: 'The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_92
+  - !<!DictionarySchema> &ref_35
     type: dictionary
-    elementType: !<!ByteArraySchema> &ref_11
+    elementType: !<!ByteArraySchema> &ref_6
       type: byte-array
       format: byte
       apiVersions:
@@ -723,9 +284,9 @@ schemas: !<!Schemas>
         name: DictionaryOfbyte-array
         description: 'The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_93
+  - !<!DictionarySchema> &ref_36
     type: dictionary
-    elementType: !<!ByteArraySchema> &ref_12
+    elementType: !<!ByteArraySchema> &ref_7
       type: byte-array
       format: base64url
       apiVersions:
@@ -741,7 +302,7 @@ schemas: !<!Schemas>
         name: DictionaryOfbyte-array
         description: 'The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_94
+  - !<!DictionarySchema> &ref_37
     type: dictionary
     elementType: *ref_0
     language: !<!Languages> 
@@ -749,14 +310,14 @@ schemas: !<!Schemas>
         name: DictionaryOfWidget
         description: Dictionary of complex type with null value
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_95
+  - !<!DictionarySchema> &ref_38
     type: dictionary
-    elementType: !<!ArraySchema> &ref_1
+    elementType: !<!ArraySchema> &ref_2
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_48
+      elementType: !<!StringSchema> &ref_20
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -776,23 +337,14 @@ schemas: !<!Schemas>
         name: DictionaryOfpaths·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
         description: a null array
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_96
+  - !<!DictionarySchema> &ref_39
     type: dictionary
-    elementType: !<!ArraySchema> &ref_2
+    elementType: !<!ArraySchema> &ref_3
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_49
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: string
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: Array of string
@@ -803,95 +355,14 @@ schemas: !<!Schemas>
         name: DictionaryOfpaths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
         description: 'An empty dictionary {}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_97
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_3
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_50
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: string
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: Array of string
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfpaths·dictionary-array-itemnull·get·responses·200·content·application-json·schema·additionalproperties
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_98
+  - !<!DictionarySchema> &ref_40
     type: dictionary
     elementType: !<!ArraySchema> &ref_4
       type: array
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      elementType: !<!StringSchema> &ref_51
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: string
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: Array of string
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfpaths·dictionary-array-itemempty·get·responses·200·content·application-json·schema·additionalproperties
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_99
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_5
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_52
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-        language: !<!Languages> 
-          default:
-            name: string
-            description: MISSING·SCHEMA-DESCRIPTION-STRING
-        protocol: !<!Protocols> {}
-      language: !<!Languages> 
-        default:
-          name: Array of string
-          description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfpaths·dictionary-array-valid·get·responses·200·content·application-json·schema·additionalproperties
-        description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_100
-    type: dictionary
-    elementType: !<!ArraySchema> &ref_6
-      type: array
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      elementType: !<!StringSchema> &ref_53
+      elementType: !<!StringSchema> &ref_21
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -911,7 +382,7 @@ schemas: !<!Schemas>
         name: DictionaryOfpaths·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
         description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_101
+  - !<!DictionarySchema> &ref_41
     type: dictionary
     elementType: !<!AnySchema> 
       type: any
@@ -925,207 +396,45 @@ schemas: !<!Schemas>
         name: DictionaryOfany
         description: An dictionaries of dictionaries with value null
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_102
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_103
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_104
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_105
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_106
-    type: dictionary
-    elementType: !<!AnySchema> 
-      type: any
-      language: !<!Languages> 
-        default:
-          name: any
-          description: <Any object>
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: DictionaryOfany
-        description: 'An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
-    protocol: !<!Protocols> {}
   arrays:
-  - *ref_1
   - *ref_2
   - *ref_3
   - *ref_4
-  - *ref_5
-  - *ref_6
   booleans:
+  - *ref_5
+  byteArrays:
+  - *ref_6
   - *ref_7
+  dateTimes:
   - *ref_8
   - *ref_9
+  dates:
   - *ref_10
-  byteArrays:
+  durations:
   - *ref_11
+  numbers:
   - *ref_12
-  dateTimes:
   - *ref_13
   - *ref_14
-  dates:
   - *ref_15
-  durations:
   - *ref_16
-  numbers:
   - *ref_17
-  - *ref_18
-  - *ref_19
-  - *ref_20
-  - *ref_21
-  - *ref_22
-  - *ref_23
-  - *ref_24
-  - *ref_25
-  - *ref_26
-  - *ref_27
-  - *ref_28
-  - *ref_29
-  - *ref_30
-  - *ref_31
-  - *ref_32
-  - *ref_33
-  - *ref_34
-  - *ref_35
-  - *ref_36
   strings:
-  - !<!StringSchema> &ref_54
+  - !<!StringSchema> &ref_22
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: simple string
     protocol: !<!Protocols> {}
-  - *ref_37
-  - *ref_38
-  - *ref_39
-  - *ref_40
-  - *ref_41
-  - *ref_42
-  - *ref_43
-  - *ref_44
-  - *ref_45
-  - *ref_46
-  - *ref_47
-  - *ref_48
-  - *ref_49
-  - *ref_50
-  - *ref_51
-  - *ref_52
-  - *ref_53
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_18
+  - *ref_1
+  - *ref_19
+  - *ref_20
+  - *ref_21
 globalParameters:
-- !<!Parameter> &ref_55
-  schema: *ref_54
+- !<!Parameter> &ref_23
+  schema: *ref_22
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -1135,7 +444,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-dictionary
@@ -1149,18 +458,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/null'
+          path: /dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_56
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1174,7 +484,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1197,18 +507,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/empty'
+          path: /dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_58
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1222,7 +533,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1245,9 +556,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -1266,11 +577,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/empty'
+          path: /dictionary/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1283,7 +595,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1308,18 +620,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/nullvalue'
+          path: /dictionary/nullvalue
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_60
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1333,7 +646,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1356,18 +669,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/nullkey'
+          path: /dictionary/nullkey
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_61
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1381,7 +695,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1404,18 +718,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/keyemptystring'
+          path: /dictionary/keyemptystring
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_62
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1429,7 +744,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1452,18 +767,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/invalid'
+          path: /dictionary/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_63
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1477,7 +793,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1500,18 +816,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/tfft'
+          path: /dictionary/prim/boolean/tfft
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_64
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1525,7 +842,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1548,9 +865,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_27
         implementation: Method
         required: true
         extensions:
@@ -1569,11 +886,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/boolean/tfft'
+          path: /dictionary/prim/boolean/tfft
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1586,7 +904,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1611,18 +929,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/true.null.false'
+          path: /dictionary/prim/boolean/true.null.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_66
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1636,7 +955,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1659,18 +978,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/boolean/true.boolean.false'
+          path: /dictionary/prim/boolean/true.boolean.false
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1684,7 +1004,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1707,18 +1027,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.-1.3.300'
+          path: /dictionary/prim/integer/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_68
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1732,7 +1053,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1755,9 +1076,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_24
         implementation: Method
         required: true
         extensions:
@@ -1776,11 +1097,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/integer/1.-1.3.300'
+          path: /dictionary/prim/integer/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1793,7 +1115,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1818,18 +1140,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.null.zero'
+          path: /dictionary/prim/integer/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_70
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1843,7 +1166,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1866,18 +1189,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/integer/1.integer.0'
+          path: /dictionary/prim/integer/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_71
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1891,7 +1215,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1914,18 +1238,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.-1.3.300'
+          path: /dictionary/prim/long/1.-1.3.300
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_72
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1939,7 +1264,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1962,9 +1287,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_28
         implementation: Method
         required: true
         extensions:
@@ -1983,11 +1308,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/long/1.-1.3.300'
+          path: /dictionary/prim/long/1.-1.3.300
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2000,7 +1326,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2025,18 +1351,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.null.zero'
+          path: /dictionary/prim/long/1.null.zero
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_74
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2050,7 +1377,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2073,18 +1400,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/long/1.integer.0'
+          path: /dictionary/prim/long/1.integer.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_75
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -2098,7 +1426,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2121,18 +1449,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/0--0.01-1.2e20'
+          path: /dictionary/prim/float/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_76
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2146,7 +1475,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2169,9 +1498,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -2190,11 +1519,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/float/0--0.01-1.2e20'
+          path: /dictionary/prim/float/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2207,7 +1537,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2232,18 +1562,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/0.0-null-1.2e20'
+          path: /dictionary/prim/float/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2257,7 +1588,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2280,18 +1611,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/float/1.number.0'
+          path: /dictionary/prim/float/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2305,7 +1637,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2328,18 +1660,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/0--0.01-1.2e20'
+          path: /dictionary/prim/double/0--0.01-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_80
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2353,7 +1686,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2376,9 +1709,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_81
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2397,11 +1730,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/double/0--0.01-1.2e20'
+          path: /dictionary/prim/double/0--0.01-1.2e20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2414,7 +1748,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2439,18 +1773,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/0.0-null-1.2e20'
+          path: /dictionary/prim/double/0.0-null-1.2e20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_82
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2464,7 +1799,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2487,18 +1822,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/double/1.number.0'
+          path: /dictionary/prim/double/1.number.0
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_83
+      schema: *ref_30
       language: !<!Languages> 
         default:
           name: ''
@@ -2512,7 +1848,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2535,18 +1871,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo1.foo2.foo3'
+          path: /dictionary/prim/string/foo1.foo2.foo3
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_84
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2560,7 +1897,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2583,9 +1920,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_85
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -2604,11 +1941,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/string/foo1.foo2.foo3'
+          path: /dictionary/prim/string/foo1.foo2.foo3
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2621,7 +1959,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2646,18 +1984,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo.null.foo2'
+          path: /dictionary/prim/string/foo.null.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_86
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2671,7 +2010,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2694,18 +2033,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/string/foo.123.foo2'
+          path: /dictionary/prim/string/foo.123.foo2
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_87
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -2719,7 +2059,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2742,18 +2082,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/valid'
+          path: /dictionary/prim/date/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2767,7 +2108,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2790,9 +2131,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_88
+        schema: *ref_31
         implementation: Method
         required: true
         extensions:
@@ -2811,11 +2152,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date/valid'
+          path: /dictionary/prim/date/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2828,7 +2170,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2853,18 +2195,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/invalidnull'
+          path: /dictionary/prim/date/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2878,7 +2221,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2901,18 +2244,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date/invalidchars'
+          path: /dictionary/prim/date/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_88
+      schema: *ref_31
       language: !<!Languages> 
         default:
           name: ''
@@ -2926,7 +2270,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2949,18 +2293,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/valid'
+          path: /dictionary/prim/date-time/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -2974,7 +2319,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2997,9 +2342,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_89
+        schema: *ref_32
         implementation: Method
         required: true
         extensions:
@@ -3018,11 +2363,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date-time/valid'
+          path: /dictionary/prim/date-time/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3035,7 +2381,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3060,18 +2406,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/invalidnull'
+          path: /dictionary/prim/date-time/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -3085,7 +2432,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3108,18 +2455,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time/invalidchars'
+          path: /dictionary/prim/date-time/invalidchars
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_89
+      schema: *ref_32
       language: !<!Languages> 
         default:
           name: ''
@@ -3133,7 +2481,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3156,18 +2504,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/date-time-rfc1123/valid'
+          path: /dictionary/prim/date-time-rfc1123/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_90
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -3181,7 +2530,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3204,9 +2553,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_90
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -3225,11 +2574,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/date-time-rfc1123/valid'
+          path: /dictionary/prim/date-time-rfc1123/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3242,7 +2592,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3267,18 +2617,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/duration/valid'
+          path: /dictionary/prim/duration/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_91
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -3292,7 +2643,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3315,9 +2666,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_34
         implementation: Method
         required: true
         extensions:
@@ -3336,11 +2687,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/duration/valid'
+          path: /dictionary/prim/duration/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3353,7 +2705,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3378,18 +2730,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/byte/valid'
+          path: /dictionary/prim/byte/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -3403,7 +2756,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3426,9 +2779,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_92
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -3447,11 +2800,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/prim/byte/valid'
+          path: /dictionary/prim/byte/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3464,7 +2818,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3489,18 +2843,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/byte/invalidnull'
+          path: /dictionary/prim/byte/invalidnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_92
+      schema: *ref_35
       language: !<!Languages> 
         default:
           name: ''
@@ -3514,7 +2869,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3537,18 +2892,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/prim/base64url/valid'
+          path: /dictionary/prim/base64url/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_93
+      schema: *ref_36
       language: !<!Languages> 
         default:
           name: ''
@@ -3562,7 +2918,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3585,18 +2941,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/null'
+          path: /dictionary/complex/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3610,7 +2967,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3633,18 +2990,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/empty'
+          path: /dictionary/complex/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3658,7 +3016,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3681,18 +3039,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/itemnull'
+          path: /dictionary/complex/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3706,7 +3065,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3729,18 +3088,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/itemempty'
+          path: /dictionary/complex/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3754,7 +3114,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3777,18 +3137,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/complex/valid'
+          path: /dictionary/complex/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_94
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -3802,7 +3163,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3825,9 +3186,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_94
+        schema: *ref_37
         implementation: Method
         required: true
         extensions:
@@ -3846,11 +3207,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/complex/valid'
+          path: /dictionary/complex/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3863,7 +3225,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3888,18 +3250,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/null'
+          path: /dictionary/array/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_95
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -3913,7 +3276,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3936,18 +3299,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/empty'
+          path: /dictionary/array/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_96
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -3961,7 +3325,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3984,18 +3348,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/itemnull'
+          path: /dictionary/array/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_97
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4009,7 +3374,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4032,18 +3397,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/itemempty'
+          path: /dictionary/array/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_98
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4057,7 +3423,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4080,18 +3446,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/array/valid'
+          path: /dictionary/array/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_99
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -4105,7 +3472,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4128,9 +3495,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_100
+        schema: *ref_40
         implementation: Method
         required: true
         extensions:
@@ -4149,11 +3516,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/array/valid'
+          path: /dictionary/array/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4166,7 +3534,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4191,18 +3559,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/null'
+          path: /dictionary/dictionary/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_101
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4216,7 +3585,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4239,18 +3608,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/empty'
+          path: /dictionary/dictionary/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_102
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4264,7 +3634,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4287,18 +3657,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/itemnull'
+          path: /dictionary/dictionary/itemnull
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_103
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4312,7 +3683,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4335,18 +3706,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/itemempty'
+          path: /dictionary/dictionary/itemempty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_104
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4360,7 +3732,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4383,18 +3755,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/dictionary/dictionary/valid'
+          path: /dictionary/dictionary/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_105
+      schema: *ref_41
       language: !<!Languages> 
         default:
           name: ''
@@ -4408,7 +3781,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4431,9 +3804,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_55
+      - *ref_23
       - !<!Parameter> 
-        schema: *ref_106
+        schema: *ref_41
         implementation: Method
         required: true
         extensions:
@@ -4452,11 +3825,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/dictionary/dictionary/valid'
+          path: /dictionary/dictionary/valid
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4469,7 +3843,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_57
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-duration/flattened.yaml
+++ b/modelerfour/test/outputs/body-duration/flattened.yaml
@@ -79,7 +79,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-duration
@@ -100,8 +100,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/null'
+          path: /duration/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -162,11 +163,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/duration/positiveduration'
+          path: /duration/positiveduration
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -211,8 +213,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/positiveduration'
+          path: /duration/positiveduration
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -259,8 +262,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/invalid'
+          path: /duration/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4

--- a/modelerfour/test/outputs/body-duration/modeler.yaml
+++ b/modelerfour/test/outputs/body-duration/modeler.yaml
@@ -79,7 +79,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-duration
@@ -100,8 +100,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/null'
+          path: /duration/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -162,11 +163,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/duration/positiveduration'
+          path: /duration/positiveduration
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -211,8 +213,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/positiveduration'
+          path: /duration/positiveduration
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -259,8 +262,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/invalid'
+          path: /duration/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3

--- a/modelerfour/test/outputs/body-duration/namer.yaml
+++ b/modelerfour/test/outputs/body-duration/namer.yaml
@@ -79,7 +79,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-duration
@@ -100,8 +100,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/null'
+          path: /duration/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -162,11 +163,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/duration/positiveduration'
+          path: /duration/positiveduration
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -211,8 +213,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/positiveduration'
+          path: /duration/positiveduration
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -259,8 +262,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/duration/invalid'
+          path: /duration/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4

--- a/modelerfour/test/outputs/body-file/flattened.yaml
+++ b/modelerfour/test/outputs/body-file/flattened.yaml
@@ -68,7 +68,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-file
@@ -89,8 +89,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/nonempty'
+          path: /files/stream/nonempty
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -137,8 +138,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/verylarge'
+          path: /files/stream/verylarge
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -185,8 +187,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/empty'
+          path: /files/stream/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true

--- a/modelerfour/test/outputs/body-file/modeler.yaml
+++ b/modelerfour/test/outputs/body-file/modeler.yaml
@@ -68,7 +68,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-file
@@ -89,8 +89,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/nonempty'
+          path: /files/stream/nonempty
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -137,8 +138,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/verylarge'
+          path: /files/stream/verylarge
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -185,8 +187,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/empty'
+          path: /files/stream/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true

--- a/modelerfour/test/outputs/body-file/namer.yaml
+++ b/modelerfour/test/outputs/body-file/namer.yaml
@@ -68,7 +68,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-file
@@ -89,8 +89,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/nonempty'
+          path: /files/stream/nonempty
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -137,8 +138,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/verylarge'
+          path: /files/stream/verylarge
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -185,8 +187,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/files/stream/empty'
+          path: /files/stream/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!BinaryResponse> 
       binary: true

--- a/modelerfour/test/outputs/body-integer/flattened.yaml
+++ b/modelerfour/test/outputs/body-integer/flattened.yaml
@@ -74,83 +74,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_8
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_9
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_10
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_11
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_13
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     precision: 64
     language: !<!Languages> 
       default:
@@ -167,37 +90,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   unixtimes:
-  - !<!UnixTimeSchema> &ref_15
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: unixtime
-        description: 'date in seconds since 1970-01-01T00:00:00Z.'
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_16
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: unixtime
-        description: 'date in seconds since 1970-01-01T00:00:00Z.'
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_17
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: unixtime
-        description: 'date in seconds since 1970-01-01T00:00:00Z.'
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_18
+  - !<!UnixTimeSchema> &ref_8
     type: unixtime
     apiVersions:
     - !<!ApiVersion> 
@@ -219,7 +112,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-integer
@@ -240,8 +133,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/null'
+          path: /int/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -288,11 +182,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/invalid'
+          path: /int/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_6
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -336,11 +231,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/overflowint32'
+          path: /int/overflowint32
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -384,11 +280,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/underflowint32'
+          path: /int/underflowint32
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -432,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/overflowint64'
+          path: /int/overflowint64
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -480,11 +378,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/underflowint64'
+          path: /int/underflowint64
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -523,7 +422,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -542,11 +441,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/max/32'
+          path: /int/max/32
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -586,7 +486,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -605,11 +505,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/max/64'
+          path: /int/max/64
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -649,7 +550,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -668,11 +569,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/min/32'
+          path: /int/min/32
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -712,7 +614,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -731,11 +633,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/min/64'
+          path: /int/min/64
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -780,11 +683,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/unixtime'
+          path: /int/unixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -823,7 +727,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -842,11 +746,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/unixtime'
+          path: /int/unixtime
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -891,11 +796,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/invalidunixtime'
+          path: /int/invalidunixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -939,11 +845,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/nullunixtime'
+          path: /int/nullunixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-integer/modeler.yaml
+++ b/modelerfour/test/outputs/body-integer/modeler.yaml
@@ -66,32 +66,10 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: paths·int-invalid·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_7
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
         name: paths·int-overflowint32·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_8
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·int-underflowint32·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_9
+  - !<!NumberSchema> &ref_7
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -100,61 +78,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: paths·int-overflowint64·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_10
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·int-underflowint64·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_11
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·int-max-32·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·int-max-64·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_13
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·int-min-32·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·int-min-64·put·requestbody·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
   strings:
@@ -167,7 +90,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   unixtimes:
-  - !<!UnixTimeSchema> &ref_15
+  - !<!UnixTimeSchema> &ref_8
     type: unixtime
     apiVersions:
     - !<!ApiVersion> 
@@ -175,36 +98,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: paths·int-unixtime·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-UNIXTIME
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_16
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·int-unixtime·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-UNIXTIME
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_17
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·int-invalidunixtime·get·responses·200·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-UNIXTIME
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_18
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·int-nullunixtime·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-UNIXTIME
     protocol: !<!Protocols> {}
 globalParameters:
@@ -219,7 +112,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-integer
@@ -240,8 +133,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/null'
+          path: /int/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -288,11 +182,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/invalid'
+          path: /int/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_6
+      schema: *ref_3
       language: !<!Languages> 
         default:
           name: ''
@@ -336,11 +231,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/overflowint32'
+          path: /int/overflowint32
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -384,11 +280,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/underflowint32'
+          path: /int/underflowint32
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -432,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/overflowint64'
+          path: /int/overflowint64
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -480,11 +378,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/underflowint64'
+          path: /int/underflowint64
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -523,7 +422,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -542,11 +441,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/max/32'
+          path: /int/max/32
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -586,7 +486,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -605,11 +505,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/max/64'
+          path: /int/max/64
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -649,7 +550,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -668,11 +569,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/min/32'
+          path: /int/min/32
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -712,7 +614,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -731,11 +633,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/min/64'
+          path: /int/min/64
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -780,11 +683,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/unixtime'
+          path: /int/unixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -823,7 +727,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -842,11 +746,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/unixtime'
+          path: /int/unixtime
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -891,11 +796,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/invalidunixtime'
+          path: /int/invalidunixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -939,11 +845,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/nullunixtime'
+          path: /int/nullunixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-integer/namer.yaml
+++ b/modelerfour/test/outputs/body-integer/namer.yaml
@@ -74,83 +74,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_8
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_9
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_10
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_11
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_13
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     precision: 64
     language: !<!Languages> 
       default:
@@ -167,37 +90,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   unixtimes:
-  - !<!UnixTimeSchema> &ref_15
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: unixtime
-        description: 'date in seconds since 1970-01-01T00:00:00Z.'
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_16
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: unixtime
-        description: 'date in seconds since 1970-01-01T00:00:00Z.'
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_17
-    type: unixtime
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: unixtime
-        description: 'date in seconds since 1970-01-01T00:00:00Z.'
-    protocol: !<!Protocols> {}
-  - !<!UnixTimeSchema> &ref_18
+  - !<!UnixTimeSchema> &ref_8
     type: unixtime
     apiVersions:
     - !<!ApiVersion> 
@@ -219,7 +112,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-integer
@@ -240,8 +133,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/null'
+          path: /int/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_4
@@ -288,11 +182,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/invalid'
+          path: /int/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_6
+      schema: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -336,11 +231,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/overflowint32'
+          path: /int/overflowint32
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -384,11 +280,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/underflowint32'
+          path: /int/underflowint32
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -432,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/overflowint64'
+          path: /int/overflowint64
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -480,11 +378,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/underflowint64'
+          path: /int/underflowint64
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -523,7 +422,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -542,11 +441,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/max/32'
+          path: /int/max/32
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -586,7 +486,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -605,11 +505,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/max/64'
+          path: /int/max/64
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -649,7 +550,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -668,11 +569,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/min/32'
+          path: /int/min/32
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -712,7 +614,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -731,11 +633,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/min/64'
+          path: /int/min/64
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -780,11 +683,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/unixtime'
+          path: /int/unixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -823,7 +727,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -842,11 +746,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/int/unixtime'
+          path: /int/unixtime
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -891,11 +796,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/invalidunixtime'
+          path: /int/invalidunixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -939,11 +845,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/int/nullunixtime'
+          path: /int/nullunixtime
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-number.quirks/flattened.yaml
+++ b/modelerfour/test/outputs/body-number.quirks/flattened.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_19
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -100,7 +100,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -127,7 +127,7 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_25
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -154,7 +154,7 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -181,7 +181,7 @@ schemas: !<!Schemas>
         name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
+  - !<!ConstantSchema> &ref_24
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -208,7 +208,7 @@ schemas: !<!Schemas>
         name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
+  - !<!ConstantSchema> &ref_25
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -235,7 +235,7 @@ schemas: !<!Schemas>
         name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_26
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -262,7 +262,7 @@ schemas: !<!Schemas>
         name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_27
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -289,7 +289,7 @@ schemas: !<!Schemas>
         name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
+  - !<!ConstantSchema> &ref_28
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -351,55 +351,11 @@ schemas: !<!Schemas>
         name: number
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_18
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_1
-  - !<!NumberSchema> &ref_20
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_2
-  - !<!NumberSchema> &ref_22
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_3
-  - !<!NumberSchema> &ref_24
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_4
-  - !<!NumberSchema> &ref_26
+  - !<!NumberSchema> &ref_22
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -411,65 +367,10 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
   - *ref_5
-  - !<!NumberSchema> &ref_28
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_6
-  - !<!NumberSchema> &ref_30
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_7
-  - !<!NumberSchema> &ref_32
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_8
-  - !<!NumberSchema> &ref_34
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_9
-  - !<!NumberSchema> &ref_36
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_10
   strings:
   - !<!StringSchema> &ref_12
@@ -492,7 +393,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-number.quirks
@@ -513,8 +414,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/null'
+          path: /number/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_14
@@ -561,8 +463,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invalidfloat'
+          path: /number/invalidfloat
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_16
@@ -609,8 +512,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddouble'
+          path: /number/invaliddouble
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_17
@@ -652,7 +556,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -671,11 +575,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -720,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -763,7 +669,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -782,11 +688,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -831,11 +738,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_19
       language: !<!Languages> 
         default:
           name: ''
@@ -874,7 +782,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -893,11 +801,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -942,11 +851,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_23
+      schema: *ref_20
       language: !<!Languages> 
         default:
           name: ''
@@ -985,7 +895,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1004,11 +914,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1053,11 +964,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_25
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -1096,7 +1008,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1115,11 +1027,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1164,11 +1077,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1207,7 +1121,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1226,11 +1140,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1275,11 +1190,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1318,7 +1234,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1337,11 +1253,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1386,11 +1303,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_31
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1429,7 +1347,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -1448,11 +1366,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1497,11 +1416,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1540,7 +1460,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1559,11 +1479,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1608,11 +1529,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_35
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1651,7 +1573,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1670,11 +1592,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1719,11 +1642,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_37
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-number.quirks/modeler.yaml
+++ b/modelerfour/test/outputs/body-number.quirks/modeler.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_19
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         name: paths·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -100,7 +100,7 @@ schemas: !<!Schemas>
         name: paths·number-big-double-2-5976931e-101·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -127,7 +127,7 @@ schemas: !<!Schemas>
         name: paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_25
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -154,7 +154,7 @@ schemas: !<!Schemas>
         name: paths·number-big-double-_99999999-99·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -181,7 +181,7 @@ schemas: !<!Schemas>
         name: paths·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
+  - !<!ConstantSchema> &ref_24
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -208,7 +208,7 @@ schemas: !<!Schemas>
         name: paths·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
+  - !<!ConstantSchema> &ref_25
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -235,7 +235,7 @@ schemas: !<!Schemas>
         name: paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_26
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -262,7 +262,7 @@ schemas: !<!Schemas>
         name: paths·number-small-float-3-402823e_20·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_27
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -289,7 +289,7 @@ schemas: !<!Schemas>
         name: paths·number-small-double-2-5976931e_101·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
+  - !<!ConstantSchema> &ref_28
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -351,55 +351,11 @@ schemas: !<!Schemas>
         name: paths·number-invaliddouble·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_18
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-float-3-402823e-20·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_2
-  - !<!NumberSchema> &ref_20
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-double-2-5976931e-101·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_3
-  - !<!NumberSchema> &ref_22
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_4
-  - !<!NumberSchema> &ref_24
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_5
-  - !<!NumberSchema> &ref_26
+  - !<!NumberSchema> &ref_22
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -411,65 +367,10 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
   - *ref_6
-  - !<!NumberSchema> &ref_28
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_7
-  - !<!NumberSchema> &ref_30
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_8
-  - !<!NumberSchema> &ref_32
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·number-small-float-3-402823e_20·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_9
-  - !<!NumberSchema> &ref_34
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·number-small-double-2-5976931e_101·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_10
-  - !<!NumberSchema> &ref_36
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: paths·number-small-decimal-2-5976931e_101·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_11
   strings:
   - !<!StringSchema> &ref_12
@@ -492,7 +393,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-number.quirks
@@ -513,8 +414,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/null'
+          path: /number/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -561,8 +463,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invalidfloat'
+          path: /number/invalidfloat
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_16
@@ -609,8 +512,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddouble'
+          path: /number/invaliddouble
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_17
@@ -652,7 +556,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -671,11 +575,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -720,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -763,7 +669,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -782,11 +688,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -831,11 +738,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_19
       language: !<!Languages> 
         default:
           name: ''
@@ -874,7 +782,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -893,11 +801,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -942,11 +851,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_23
+      schema: *ref_20
       language: !<!Languages> 
         default:
           name: ''
@@ -985,7 +895,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1004,11 +914,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1053,11 +964,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_25
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -1096,7 +1008,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1115,11 +1027,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1164,11 +1077,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1207,7 +1121,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1226,11 +1140,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1275,11 +1190,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1318,7 +1234,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1337,11 +1253,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1386,11 +1303,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_31
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1429,7 +1347,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -1448,11 +1366,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1497,11 +1416,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1540,7 +1460,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1559,11 +1479,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1608,11 +1529,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_35
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1651,7 +1573,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1670,11 +1592,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1719,11 +1642,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_37
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-number.quirks/namer.yaml
+++ b/modelerfour/test/outputs/body-number.quirks/namer.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_19
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -100,7 +100,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -127,7 +127,7 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_25
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -154,7 +154,7 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -181,7 +181,7 @@ schemas: !<!Schemas>
         name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
+  - !<!ConstantSchema> &ref_24
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -208,7 +208,7 @@ schemas: !<!Schemas>
         name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
+  - !<!ConstantSchema> &ref_25
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -235,7 +235,7 @@ schemas: !<!Schemas>
         name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_26
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -262,7 +262,7 @@ schemas: !<!Schemas>
         name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_27
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -289,7 +289,7 @@ schemas: !<!Schemas>
         name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
+  - !<!ConstantSchema> &ref_28
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -351,55 +351,11 @@ schemas: !<!Schemas>
         name: number
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_18
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_1
-  - !<!NumberSchema> &ref_20
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_2
-  - !<!NumberSchema> &ref_22
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_3
-  - !<!NumberSchema> &ref_24
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_4
-  - !<!NumberSchema> &ref_26
+  - !<!NumberSchema> &ref_22
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -411,65 +367,10 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
   - *ref_5
-  - !<!NumberSchema> &ref_28
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_6
-  - !<!NumberSchema> &ref_30
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_7
-  - !<!NumberSchema> &ref_32
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_8
-  - !<!NumberSchema> &ref_34
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_9
-  - !<!NumberSchema> &ref_36
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_10
   strings:
   - !<!StringSchema> &ref_12
@@ -492,7 +393,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-number.quirks
@@ -513,8 +414,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/null'
+          path: /number/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_14
@@ -561,8 +463,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invalidfloat'
+          path: /number/invalidfloat
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_16
@@ -609,8 +512,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddouble'
+          path: /number/invaliddouble
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_17
@@ -652,7 +556,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -671,11 +575,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -720,11 +625,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -763,7 +669,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -782,11 +688,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -831,11 +738,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_19
       language: !<!Languages> 
         default:
           name: ''
@@ -874,7 +782,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -893,11 +801,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -942,11 +851,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_23
+      schema: *ref_20
       language: !<!Languages> 
         default:
           name: ''
@@ -985,7 +895,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1004,11 +914,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1053,11 +964,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_25
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -1096,7 +1008,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1115,11 +1027,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1164,11 +1077,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1207,7 +1121,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1226,11 +1140,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1275,11 +1190,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1318,7 +1234,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1337,11 +1253,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1386,11 +1303,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_31
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1429,7 +1347,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -1448,11 +1366,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1497,11 +1416,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1540,7 +1460,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1559,11 +1479,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1608,11 +1529,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_35
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1651,7 +1573,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1670,11 +1592,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1719,11 +1642,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_37
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-number/flattened.yaml
+++ b/modelerfour/test/outputs/body-number/flattened.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_19
+  - !<!ObjectSchema> &ref_15
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_15
+      schema: !<!StringSchema> &ref_11
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_24
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -100,7 +100,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -127,13 +127,13 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: 99999999.99
+      value: -99999999.99
       language:
         default:
           name: ''
@@ -154,13 +154,13 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: -99999999.99
+      value: 2.5976931e+101
       language:
         default:
           name: ''
@@ -170,7 +170,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      precision: 64
+      precision: 128
       language: !<!Languages> 
         default:
           name: number
@@ -181,13 +181,13 @@ schemas: !<!Schemas>
         name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
+  - !<!ConstantSchema> &ref_24
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: -99999999.99
+      value: 99999999.99
       language:
         default:
           name: ''
@@ -197,7 +197,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      precision: 64
+      precision: 128
       language: !<!Languages> 
         default:
           name: number
@@ -208,13 +208,13 @@ schemas: !<!Schemas>
         name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
+  - !<!ConstantSchema> &ref_25
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: 2.5976931e+101
+      value: -99999999.99
       language:
         default:
           name: ''
@@ -235,13 +235,13 @@ schemas: !<!Schemas>
         name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_26
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: 99999999.99
+      value: 3.402823e-20
       language:
         default:
           name: ''
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      precision: 128
+      precision: 64
       language: !<!Languages> 
         default:
           name: number
@@ -262,13 +262,13 @@ schemas: !<!Schemas>
         name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_27
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: 99999999.99
+      value: 2.5976931e-101
       language:
         default:
           name: ''
@@ -278,7 +278,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      precision: 128
+      precision: 64
       language: !<!Languages> 
         default:
           name: number
@@ -289,13 +289,13 @@ schemas: !<!Schemas>
         name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_28
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: -99999999.99
+      value: 2.5976931e-101
       language:
         default:
           name: ''
@@ -316,116 +316,8 @@ schemas: !<!Schemas>
         name: Constant9
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: -99999999.99
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_11
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 128
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Constant10
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 3.402823e-20
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_12
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Constant11
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 2.5976931e-101
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_13
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Constant12
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 2.5976931e-101
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_14
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 128
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Constant13
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
   numbers:
-  - !<!NumberSchema> &ref_18
+  - !<!NumberSchema> &ref_14
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -437,7 +329,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
   - *ref_0
-  - !<!NumberSchema> &ref_20
+  - !<!NumberSchema> &ref_16
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -448,7 +340,7 @@ schemas: !<!Schemas>
         name: number
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_21
+  - !<!NumberSchema> &ref_17
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -459,109 +351,39 @@ schemas: !<!Schemas>
         name: number
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
+  - !<!NumberSchema> &ref_18
     type: number
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_23
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
     language: !<!Languages> 
       default:
         name: number
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
   - *ref_1
-  - !<!NumberSchema> &ref_25
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_2
   - *ref_3
   - *ref_4
   - *ref_5
   - *ref_6
-  - !<!NumberSchema> &ref_31
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_7
   - *ref_8
   - *ref_9
   - *ref_10
-  - *ref_11
-  - !<!NumberSchema> &ref_37
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_12
-  - !<!NumberSchema> &ref_39
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_13
-  - !<!NumberSchema> &ref_41
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_14
   strings:
-  - !<!StringSchema> &ref_16
+  - !<!StringSchema> &ref_12
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: simple string
     protocol: !<!Protocols> {}
-  - *ref_15
+  - *ref_11
 globalParameters:
-- !<!Parameter> &ref_17
-  schema: *ref_16
+- !<!Parameter> &ref_13
+  schema: *ref_12
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -571,7 +393,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-number
@@ -585,18 +407,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/null'
+          path: /number/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -610,7 +433,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -633,18 +456,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invalidfloat'
+          path: /number/invalidfloat
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_16
       language: !<!Languages> 
         default:
           name: ''
@@ -658,7 +482,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -681,18 +505,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddouble'
+          path: /number/invaliddouble
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -706,7 +531,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -729,18 +554,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddecimal'
+          path: /number/invaliddecimal
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_22
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -754,7 +580,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -777,9 +603,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -798,11 +624,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -815,7 +642,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -840,18 +667,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_24
+      schema: *ref_19
       language: !<!Languages> 
         default:
           name: ''
@@ -865,7 +693,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -888,9 +716,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -909,11 +737,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -926,7 +755,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -951,18 +780,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_20
       language: !<!Languages> 
         default:
           name: ''
@@ -976,7 +806,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -999,9 +829,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1020,11 +850,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1037,7 +868,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1062,18 +893,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -1087,7 +919,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1110,9 +942,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1131,11 +963,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1148,7 +981,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1173,18 +1006,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''
@@ -1198,7 +1032,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1221,9 +1055,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_18
         implementation: Method
         required: true
         extensions:
@@ -1242,11 +1076,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1259,7 +1094,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1284,18 +1119,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1309,7 +1145,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1332,9 +1168,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_24
         implementation: Method
         required: true
         extensions:
@@ -1353,11 +1189,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1370,7 +1207,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1395,18 +1232,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_34
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1420,7 +1258,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1443,9 +1281,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -1464,11 +1302,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1481,7 +1320,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1506,18 +1345,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_36
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1531,7 +1371,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1554,9 +1394,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -1575,11 +1415,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1592,7 +1433,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1617,18 +1458,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_38
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1642,7 +1484,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1665,9 +1507,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1686,11 +1528,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1703,7 +1546,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1728,18 +1571,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1753,7 +1597,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1776,9 +1620,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_18
         implementation: Method
         required: true
         extensions:
@@ -1797,11 +1641,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1814,7 +1659,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1839,18 +1684,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_42
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1864,7 +1710,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-number/modeler.yaml
+++ b/modelerfour/test/outputs/body-number/modeler.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_14
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_24
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         name: paths·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -100,7 +100,7 @@ schemas: !<!Schemas>
         name: paths·number-big-double-2-5976931e-101·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -119,33 +119,6 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-double-99999999-99·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 99999999.99
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_5
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
           name: paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema
           description: MISSING·SCHEMA-DESCRIPTION-NUMBER
       protocol: !<!Protocols> {}
@@ -154,7 +127,7 @@ schemas: !<!Schemas>
         name: paths·number-big-double-99999999-99·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -165,34 +138,7 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
-    valueType: !<!NumberSchema> &ref_6
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-double-_99999999-99·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: -99999999.99
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_7
+    valueType: !<!NumberSchema> &ref_5
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -208,7 +154,7 @@ schemas: !<!Schemas>
         name: paths·number-big-double-_99999999-99·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -219,7 +165,7 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
-    valueType: !<!NumberSchema> &ref_8
+    valueType: !<!NumberSchema> &ref_6
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -235,7 +181,7 @@ schemas: !<!Schemas>
         name: paths·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_24
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -246,34 +192,7 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
-    valueType: !<!NumberSchema> &ref_9
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 128
-      language: !<!Languages> 
-        default:
-          name: paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-decimal-99999999-99·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 99999999.99
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_10
+    valueType: !<!NumberSchema> &ref_7
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -289,7 +208,7 @@ schemas: !<!Schemas>
         name: paths·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_25
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -300,34 +219,7 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
-    valueType: !<!NumberSchema> &ref_11
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 128
-      language: !<!Languages> 
-        default:
-          name: paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-decimal-_99999999-99·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: -99999999.99
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_12
+    valueType: !<!NumberSchema> &ref_8
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -343,7 +235,7 @@ schemas: !<!Schemas>
         name: paths·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_26
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -354,7 +246,7 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
-    valueType: !<!NumberSchema> &ref_13
+    valueType: !<!NumberSchema> &ref_9
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -370,7 +262,7 @@ schemas: !<!Schemas>
         name: paths·number-small-float-3-402823e_20·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
+  - !<!ConstantSchema> &ref_27
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -381,7 +273,7 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
-    valueType: !<!NumberSchema> &ref_14
+    valueType: !<!NumberSchema> &ref_10
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -397,7 +289,7 @@ schemas: !<!Schemas>
         name: paths·number-small-double-2-5976931e_101·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
+  - !<!ConstantSchema> &ref_28
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -408,7 +300,7 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
-    valueType: !<!NumberSchema> &ref_15
+    valueType: !<!NumberSchema> &ref_11
       type: number
       apiVersions:
       - !<!ApiVersion> 
@@ -425,7 +317,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   numbers:
-  - !<!NumberSchema> &ref_17
+  - !<!NumberSchema> &ref_13
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -437,7 +329,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
   - *ref_0
-  - !<!NumberSchema> &ref_20
+  - !<!NumberSchema> &ref_16
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -448,7 +340,7 @@ schemas: !<!Schemas>
         name: paths·number-invalidfloat·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_21
+  - !<!NumberSchema> &ref_17
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -459,7 +351,7 @@ schemas: !<!Schemas>
         name: paths·number-invaliddouble·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
+  - !<!NumberSchema> &ref_18
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -470,88 +362,18 @@ schemas: !<!Schemas>
         name: paths·number-invaliddecimal·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_23
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-float-3-402823e-20·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_2
-  - !<!NumberSchema> &ref_25
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-double-2-5976931e-101·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_3
   - *ref_4
   - *ref_5
   - *ref_6
   - *ref_7
-  - !<!NumberSchema> &ref_31
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: paths·number-big-decimal-2-5976931e-101·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_8
   - *ref_9
   - *ref_10
   - *ref_11
-  - *ref_12
-  - !<!NumberSchema> &ref_37
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·number-small-float-3-402823e_20·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_13
-  - !<!NumberSchema> &ref_39
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·number-small-double-2-5976931e_101·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_14
-  - !<!NumberSchema> &ref_41
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: paths·number-small-decimal-2-5976931e_101·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_15
   strings:
-  - !<!StringSchema> &ref_16
+  - !<!StringSchema> &ref_12
     type: string
     language: !<!Languages> 
       default:
@@ -560,8 +382,8 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
 globalParameters:
-- !<!Parameter> &ref_19
-  schema: *ref_16
+- !<!Parameter> &ref_15
+  schema: *ref_12
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -571,7 +393,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-number
@@ -585,18 +407,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/null'
+          path: /number/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -610,7 +433,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -633,18 +456,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invalidfloat'
+          path: /number/invalidfloat
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_16
       language: !<!Languages> 
         default:
           name: ''
@@ -658,7 +482,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -681,18 +505,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddouble'
+          path: /number/invaliddouble
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -706,7 +531,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -729,18 +554,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddecimal'
+          path: /number/invaliddecimal
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_22
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -754,7 +580,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -777,9 +603,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -798,11 +624,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -815,7 +642,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -840,18 +667,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_24
+      schema: *ref_19
       language: !<!Languages> 
         default:
           name: ''
@@ -865,7 +693,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -888,9 +716,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -909,11 +737,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -926,7 +755,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -951,18 +780,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_20
       language: !<!Languages> 
         default:
           name: ''
@@ -976,7 +806,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -999,9 +829,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1020,11 +850,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1037,7 +868,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1062,18 +893,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -1087,7 +919,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1110,9 +942,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1131,11 +963,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1148,7 +981,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1173,18 +1006,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''
@@ -1198,7 +1032,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1221,9 +1055,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_18
         implementation: Method
         required: true
         extensions:
@@ -1242,11 +1076,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1259,7 +1094,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1284,18 +1119,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1309,7 +1145,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1332,9 +1168,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_24
         implementation: Method
         required: true
         extensions:
@@ -1353,11 +1189,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1370,7 +1207,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1395,18 +1232,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_34
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1420,7 +1258,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1443,9 +1281,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -1464,11 +1302,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1481,7 +1320,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1506,18 +1345,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_36
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1531,7 +1371,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1554,9 +1394,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -1575,11 +1415,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1592,7 +1433,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1617,18 +1458,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_38
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1642,7 +1484,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1665,9 +1507,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1686,11 +1528,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1703,7 +1546,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1728,18 +1571,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1753,7 +1597,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1776,9 +1620,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_18
         implementation: Method
         required: true
         extensions:
@@ -1797,11 +1641,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1814,7 +1659,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1839,18 +1684,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_19
+      - *ref_15
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_42
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1864,7 +1710,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-number/namer.yaml
+++ b/modelerfour/test/outputs/body-number/namer.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_19
+  - !<!ObjectSchema> &ref_15
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_15
+      schema: !<!StringSchema> &ref_11
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_24
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -100,7 +100,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -127,13 +127,13 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: 99999999.99
+      value: -99999999.99
       language:
         default:
           name: ''
@@ -154,13 +154,13 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: -99999999.99
+      value: 2.5976931e+101
       language:
         default:
           name: ''
@@ -170,7 +170,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      precision: 64
+      precision: 128
       language: !<!Languages> 
         default:
           name: number
@@ -181,13 +181,13 @@ schemas: !<!Schemas>
         name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
+  - !<!ConstantSchema> &ref_24
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: -99999999.99
+      value: 99999999.99
       language:
         default:
           name: ''
@@ -197,7 +197,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      precision: 64
+      precision: 128
       language: !<!Languages> 
         default:
           name: number
@@ -208,13 +208,13 @@ schemas: !<!Schemas>
         name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
+  - !<!ConstantSchema> &ref_25
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: 2.5976931e+101
+      value: -99999999.99
       language:
         default:
           name: ''
@@ -235,13 +235,13 @@ schemas: !<!Schemas>
         name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_26
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: 99999999.99
+      value: 3.402823e-20
       language:
         default:
           name: ''
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      precision: 128
+      precision: 64
       language: !<!Languages> 
         default:
           name: number
@@ -262,13 +262,13 @@ schemas: !<!Schemas>
         name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_27
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: 99999999.99
+      value: 2.5976931e-101
       language:
         default:
           name: ''
@@ -278,7 +278,7 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      precision: 128
+      precision: 64
       language: !<!Languages> 
         default:
           name: number
@@ -289,13 +289,13 @@ schemas: !<!Schemas>
         name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_28
     type: constant
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: -99999999.99
+      value: 2.5976931e-101
       language:
         default:
           name: ''
@@ -316,116 +316,8 @@ schemas: !<!Schemas>
         name: Constant9
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: -99999999.99
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_11
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 128
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Constant10
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 3.402823e-20
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_12
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Constant11
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 2.5976931e-101
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_13
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Constant12
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 2.5976931e-101
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: !<!NumberSchema> &ref_14
-      type: number
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      precision: 128
-      language: !<!Languages> 
-        default:
-          name: number
-          description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Constant13
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
   numbers:
-  - !<!NumberSchema> &ref_18
+  - !<!NumberSchema> &ref_14
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -437,7 +329,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
   - *ref_0
-  - !<!NumberSchema> &ref_20
+  - !<!NumberSchema> &ref_16
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -448,7 +340,7 @@ schemas: !<!Schemas>
         name: number
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_21
+  - !<!NumberSchema> &ref_17
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -459,109 +351,39 @@ schemas: !<!Schemas>
         name: number
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
+  - !<!NumberSchema> &ref_18
     type: number
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_23
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
     language: !<!Languages> 
       default:
         name: number
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
     protocol: !<!Protocols> {}
   - *ref_1
-  - !<!NumberSchema> &ref_25
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_2
   - *ref_3
   - *ref_4
   - *ref_5
   - *ref_6
-  - !<!NumberSchema> &ref_31
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
   - *ref_7
   - *ref_8
   - *ref_9
   - *ref_10
-  - *ref_11
-  - !<!NumberSchema> &ref_37
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_12
-  - !<!NumberSchema> &ref_39
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_13
-  - !<!NumberSchema> &ref_41
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 128
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - *ref_14
   strings:
-  - !<!StringSchema> &ref_16
+  - !<!StringSchema> &ref_12
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: simple string
     protocol: !<!Protocols> {}
-  - *ref_15
+  - *ref_11
 globalParameters:
-- !<!Parameter> &ref_17
-  schema: *ref_16
+- !<!Parameter> &ref_13
+  schema: *ref_12
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -571,7 +393,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: body-number
@@ -585,18 +407,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/null'
+          path: /number/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -610,7 +433,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -633,18 +456,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invalidfloat'
+          path: /number/invalidfloat
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_16
       language: !<!Languages> 
         default:
           name: ''
@@ -658,7 +482,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -681,18 +505,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddouble'
+          path: /number/invaliddouble
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_21
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -706,7 +531,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -729,18 +554,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/invaliddecimal'
+          path: /number/invaliddecimal
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_22
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -754,7 +580,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -777,9 +603,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -798,11 +624,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -815,7 +642,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -840,18 +667,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/float/3.402823e+20'
+          path: /number/big/float/3.402823e+20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_24
+      schema: *ref_19
       language: !<!Languages> 
         default:
           name: ''
@@ -865,7 +693,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -888,9 +716,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -909,11 +737,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -926,7 +755,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -951,18 +780,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/2.5976931e+101'
+          path: /number/big/double/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_20
       language: !<!Languages> 
         default:
           name: ''
@@ -976,7 +806,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -999,9 +829,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1020,11 +850,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1037,7 +868,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1062,18 +893,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/99999999.99'
+          path: /number/big/double/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_21
       language: !<!Languages> 
         default:
           name: ''
@@ -1087,7 +919,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1110,9 +942,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1131,11 +963,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1148,7 +981,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1173,18 +1006,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/double/-99999999.99'
+          path: /number/big/double/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_22
       language: !<!Languages> 
         default:
           name: ''
@@ -1198,7 +1032,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1221,9 +1055,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_18
         implementation: Method
         required: true
         extensions:
@@ -1242,11 +1076,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1259,7 +1094,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1284,18 +1119,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/2.5976931e+101'
+          path: /number/big/decimal/2.5976931e+101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_32
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1309,7 +1145,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1332,9 +1168,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_24
         implementation: Method
         required: true
         extensions:
@@ -1353,11 +1189,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1370,7 +1207,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1395,18 +1232,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/99999999.99'
+          path: /number/big/decimal/99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_34
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1420,7 +1258,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1443,9 +1281,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -1464,11 +1302,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1481,7 +1320,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1506,18 +1345,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/big/decimal/-99999999.99'
+          path: /number/big/decimal/-99999999.99
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_36
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -1531,7 +1371,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1554,9 +1394,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_16
         implementation: Method
         required: true
         extensions:
@@ -1575,11 +1415,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1592,7 +1433,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1617,18 +1458,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/float/3.402823e-20'
+          path: /number/small/float/3.402823e-20
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_38
+      schema: *ref_26
       language: !<!Languages> 
         default:
           name: ''
@@ -1642,7 +1484,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1665,9 +1507,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_17
         implementation: Method
         required: true
         extensions:
@@ -1686,11 +1528,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1703,7 +1546,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1728,18 +1571,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/double/2.5976931e-101'
+          path: /number/small/double/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -1753,7 +1597,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1776,9 +1620,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_18
         implementation: Method
         required: true
         extensions:
@@ -1797,11 +1641,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1814,7 +1659,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -1839,18 +1684,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_17
+      - *ref_13
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/number/small/decimal/2.5976931e-101'
+          path: /number/small/decimal/2.5976931e-101
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_42
+      schema: *ref_28
       language: !<!Languages> 
         default:
           name: ''
@@ -1864,7 +1710,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/body-string.quirks/flattened.yaml
+++ b/modelerfour/test/outputs/body-string.quirks/flattened.yaml
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_14
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -107,7 +107,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_17
+  - !<!ChoiceSchema> &ref_13
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -138,7 +138,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_16
+  - !<!ByteArraySchema> &ref_12
     type: byte-array
     format: base64url
     apiVersions:
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_11
+  - !<!ConstantSchema> &ref_10
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -199,7 +199,7 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_13
+  - !<!ConstantSchema> &ref_11
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -232,47 +232,7 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_10
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_14
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_4
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_5
   schema: *ref_0
@@ -285,7 +245,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-string.quirks
@@ -306,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -368,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -417,8 +379,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_9
@@ -460,7 +423,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -479,11 +442,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -528,11 +492,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -571,7 +536,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -590,11 +555,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -639,11 +605,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_13
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -682,7 +649,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -701,11 +668,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -750,11 +718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/notProvided'
+          path: /string/notProvided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -798,11 +767,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64Encoding'
+          path: /string/base64Encoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -846,11 +816,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -889,7 +860,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -908,11 +879,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -957,11 +929,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/nullBase64UrlEncoding'
+          path: /string/nullBase64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1013,11 +986,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1056,7 +1030,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1075,11 +1049,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1124,11 +1099,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1167,7 +1143,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1186,11 +1162,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1235,11 +1212,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1278,7 +1256,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1297,11 +1275,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/body-string.quirks/modeler.yaml
+++ b/modelerfour/test/outputs/body-string.quirks/modeler.yaml
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_14
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -107,7 +107,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_17
+  - !<!ChoiceSchema> &ref_13
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -138,7 +138,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_16
+  - !<!ByteArraySchema> &ref_12
     type: byte-array
     format: base64url
     apiVersions:
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
         name: paths·string-empty·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_11
+  - !<!ConstantSchema> &ref_10
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -199,7 +199,7 @@ schemas: !<!Schemas>
         name: paths·string-mbcs·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_13
+  - !<!ConstantSchema> &ref_11
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -229,50 +229,10 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: paths·string-null·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_10
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·string-empty·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·string-mbcs·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_14
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·string-whitespace·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - *ref_3
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
         name: paths·string-notprovided·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
+  - *ref_3
 globalParameters:
 - !<!Parameter> &ref_7
   schema: *ref_0
@@ -285,7 +245,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-string.quirks
@@ -306,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -368,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -417,8 +379,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_9
@@ -460,7 +423,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -479,11 +442,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -528,11 +492,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -571,7 +536,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -590,11 +555,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -639,11 +605,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_13
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -682,7 +649,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -701,11 +668,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -750,11 +718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/notProvided'
+          path: /string/notProvided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -798,11 +767,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64Encoding'
+          path: /string/base64Encoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -846,11 +816,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -889,7 +860,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -908,11 +879,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -957,11 +929,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/nullBase64UrlEncoding'
+          path: /string/nullBase64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1013,11 +986,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1056,7 +1030,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1075,11 +1049,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1124,11 +1099,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1167,7 +1143,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1186,11 +1162,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1235,11 +1212,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1278,7 +1256,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1297,11 +1275,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/body-string.quirks/namer.yaml
+++ b/modelerfour/test/outputs/body-string.quirks/namer.yaml
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_14
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -107,7 +107,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_17
+  - !<!ChoiceSchema> &ref_13
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -138,7 +138,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_16
+  - !<!ByteArraySchema> &ref_12
     type: byte-array
     format: base64url
     apiVersions:
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_11
+  - !<!ConstantSchema> &ref_10
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -199,7 +199,7 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_13
+  - !<!ConstantSchema> &ref_11
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -232,47 +232,7 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_10
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_14
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_4
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_5
   schema: *ref_0
@@ -285,7 +245,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-string.quirks
@@ -306,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -368,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -417,8 +379,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_9
@@ -460,7 +423,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -479,11 +442,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -528,11 +492,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -571,7 +536,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -590,11 +555,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -639,11 +605,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_13
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -682,7 +649,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -701,11 +668,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -750,11 +718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/notProvided'
+          path: /string/notProvided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -798,11 +767,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64Encoding'
+          path: /string/base64Encoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -846,11 +816,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -889,7 +860,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -908,11 +879,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -957,11 +929,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/nullBase64UrlEncoding'
+          path: /string/nullBase64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1013,11 +986,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1056,7 +1030,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1075,11 +1049,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1124,11 +1099,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1167,7 +1143,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1186,11 +1162,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1235,11 +1212,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1278,7 +1256,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1297,11 +1275,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/body-string/flattened.yaml
+++ b/modelerfour/test/outputs/body-string/flattened.yaml
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_14
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -107,7 +107,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_17
+  - !<!ChoiceSchema> &ref_13
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -138,7 +138,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_16
+  - !<!ByteArraySchema> &ref_12
     type: byte-array
     format: base64url
     apiVersions:
@@ -188,6 +188,7 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
+      value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
       language:
         default:
           name: ''
@@ -204,6 +205,7 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
+      value: '    Now is the time for all good men to come to the aid of their country    '
       language:
         default:
           name: ''
@@ -214,74 +216,6 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_11
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant4
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_12
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant5
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_13
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: '    Now is the time for all good men to come to the aid of their country    '
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant6
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_14
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: '    Now is the time for all good men to come to the aid of their country    '
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant7
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
   - *ref_1
   numbers:
   - *ref_2
@@ -289,7 +223,7 @@ schemas: !<!Schemas>
   - *ref_0
   - *ref_3
   - *ref_4
-  - !<!StringSchema> &ref_15
+  - !<!StringSchema> &ref_11
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -311,7 +245,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-string
@@ -332,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -375,7 +310,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -394,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -443,11 +379,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -486,7 +423,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -505,11 +442,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -554,11 +492,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_9
       language: !<!Languages> 
         default:
           name: ''
@@ -597,7 +536,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_9
         implementation: Method
         required: true
         extensions:
@@ -616,11 +555,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -665,11 +605,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_13
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -708,7 +649,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_10
         implementation: Method
         required: true
         extensions:
@@ -727,11 +668,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -776,11 +718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/notProvided'
+          path: /string/notProvided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -824,11 +767,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64Encoding'
+          path: /string/base64Encoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -872,11 +816,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -915,7 +860,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -934,11 +879,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -983,11 +929,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/nullBase64UrlEncoding'
+          path: /string/nullBase64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1039,11 +986,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1082,7 +1030,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1101,11 +1049,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1150,11 +1099,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1193,7 +1143,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1212,11 +1162,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1261,11 +1212,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1304,7 +1256,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1323,11 +1275,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/body-string/modeler.yaml
+++ b/modelerfour/test/outputs/body-string/modeler.yaml
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_14
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -107,7 +107,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_17
+  - !<!ChoiceSchema> &ref_13
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -138,7 +138,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_16
+  - !<!ByteArraySchema> &ref_12
     type: byte-array
     format: base64url
     apiVersions:
@@ -179,42 +179,10 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: paths·string-null·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_9
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
         name: paths·string-empty·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_10
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·string-empty·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_11
+  - !<!ConstantSchema> &ref_9
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -231,24 +199,7 @@ schemas: !<!Schemas>
         name: paths·string-mbcs·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_12
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·string-mbcs·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_13
+  - !<!ConstantSchema> &ref_10
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -265,23 +216,6 @@ schemas: !<!Schemas>
         name: paths·string-whitespace·get·responses·200·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_14
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: '    Now is the time for all good men to come to the aid of their country    '
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·string-whitespace·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
   - *ref_2
   numbers:
   - *ref_4
@@ -289,7 +223,7 @@ schemas: !<!Schemas>
   - *ref_0
   - *ref_1
   - *ref_3
-  - !<!StringSchema> &ref_15
+  - !<!StringSchema> &ref_11
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -311,7 +245,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-string
@@ -332,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -375,7 +310,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_5
         implementation: Method
         required: true
         extensions:
@@ -394,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -443,11 +379,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -486,7 +423,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -505,11 +442,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -554,11 +492,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_9
       language: !<!Languages> 
         default:
           name: ''
@@ -597,7 +536,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_9
         implementation: Method
         required: true
         extensions:
@@ -616,11 +555,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -665,11 +605,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_13
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -708,7 +649,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_10
         implementation: Method
         required: true
         extensions:
@@ -727,11 +668,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -776,11 +718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/notProvided'
+          path: /string/notProvided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -824,11 +767,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64Encoding'
+          path: /string/base64Encoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -872,11 +816,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -915,7 +860,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -934,11 +879,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -983,11 +929,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/nullBase64UrlEncoding'
+          path: /string/nullBase64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1039,11 +986,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1082,7 +1030,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1101,11 +1049,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1150,11 +1099,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1193,7 +1143,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1212,11 +1162,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1261,11 +1212,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1304,7 +1256,7 @@ operationGroups:
       parameters:
       - *ref_7
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1323,11 +1275,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/body-string/namer.yaml
+++ b/modelerfour/test/outputs/body-string/namer.yaml
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_14
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -107,7 +107,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_17
+  - !<!ChoiceSchema> &ref_13
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -138,7 +138,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_16
+  - !<!ByteArraySchema> &ref_12
     type: byte-array
     format: base64url
     apiVersions:
@@ -188,6 +188,7 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
+      value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
       language:
         default:
           name: ''
@@ -204,6 +205,7 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
+      value: '    Now is the time for all good men to come to the aid of their country    '
       language:
         default:
           name: ''
@@ -214,74 +216,6 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_11
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant4
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_12
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant5
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_13
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: '    Now is the time for all good men to come to the aid of their country    '
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant6
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_14
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: '    Now is the time for all good men to come to the aid of their country    '
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant7
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
   - *ref_1
   numbers:
   - *ref_2
@@ -289,7 +223,7 @@ schemas: !<!Schemas>
   - *ref_0
   - *ref_3
   - *ref_4
-  - !<!StringSchema> &ref_15
+  - !<!StringSchema> &ref_11
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -311,7 +245,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: body-string
@@ -332,8 +266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -375,7 +310,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -394,11 +329,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/null'
+          path: /string/null
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -443,11 +379,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -486,7 +423,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         required: true
         extensions:
@@ -505,11 +442,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/empty'
+          path: /string/empty
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -554,11 +492,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_11
+      schema: *ref_9
       language: !<!Languages> 
         default:
           name: ''
@@ -597,7 +536,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_9
         implementation: Method
         required: true
         extensions:
@@ -616,11 +555,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/mbcs'
+          path: /string/mbcs
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -665,11 +605,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_13
+      schema: *ref_10
       language: !<!Languages> 
         default:
           name: ''
@@ -708,7 +649,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_10
         implementation: Method
         required: true
         extensions:
@@ -727,11 +668,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/whitespace'
+          path: /string/whitespace
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -776,11 +718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/notProvided'
+          path: /string/notProvided
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -824,11 +767,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64Encoding'
+          path: /string/base64Encoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -872,11 +816,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -915,7 +860,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -934,11 +879,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/base64UrlEncoding'
+          path: /string/base64UrlEncoding
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -983,11 +929,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/nullBase64UrlEncoding'
+          path: /string/nullBase64UrlEncoding
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1039,11 +986,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1082,7 +1030,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1101,11 +1049,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/notExpandable'
+          path: /string/enum/notExpandable
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1150,11 +1099,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_13
       language: !<!Languages> 
         default:
           name: ''
@@ -1193,7 +1143,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -1212,11 +1162,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/Referenced'
+          path: /string/enum/Referenced
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1261,11 +1212,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_14
       language: !<!Languages> 
         default:
           name: ''
@@ -1304,7 +1256,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1323,11 +1275,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/string/enum/ReferencedConstant'
+          path: /string/enum/ReferencedConstant
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/complex-model/flattened.yaml
+++ b/modelerfour/test/outputs/complex-model/flattened.yaml
@@ -173,7 +173,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_24
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -210,7 +210,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_25
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -237,7 +237,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -317,7 +317,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2014-04-01-preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
+  - !<!ConstantSchema> &ref_21
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2014-04-01-preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_24
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -365,46 +365,6 @@ schemas: !<!Schemas>
   - *ref_12
   - *ref_13
   - *ref_14
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_26
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_15
   schema: *ref_7
@@ -417,7 +377,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Some cool documentation.
   title: complex-model
@@ -471,8 +431,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_19
@@ -514,7 +475,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_17
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -525,7 +486,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_17
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -536,7 +497,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_21
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -547,7 +508,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -566,14 +527,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_25
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -614,7 +576,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_17
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -625,7 +587,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_17
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -636,7 +598,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_24
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -647,7 +609,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -666,11 +628,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_19

--- a/modelerfour/test/outputs/complex-model/modeler.yaml
+++ b/modelerfour/test/outputs/complex-model/modeler.yaml
@@ -173,7 +173,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_24
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -210,7 +210,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_25
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -237,7 +237,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -317,7 +317,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2014-04-01-preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
+  - !<!ConstantSchema> &ref_21
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2014-04-01-preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_24
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -365,46 +365,6 @@ schemas: !<!Schemas>
   - *ref_4
   - *ref_5
   - *ref_7
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_26
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-microsoft-cache-redis·put·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_20
   schema: *ref_0
@@ -417,7 +377,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Some cool documentation.
   title: complex-model
@@ -471,8 +431,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_18
@@ -514,7 +475,7 @@ operationGroups:
       parameters:
       - *ref_20
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_16
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -525,7 +486,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_16
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -536,7 +497,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_21
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -547,7 +508,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -566,14 +527,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_25
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -614,7 +576,7 @@ operationGroups:
       parameters:
       - *ref_20
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_16
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -625,7 +587,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_16
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -636,7 +598,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_24
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -647,7 +609,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -666,11 +628,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_18

--- a/modelerfour/test/outputs/complex-model/namer.yaml
+++ b/modelerfour/test/outputs/complex-model/namer.yaml
@@ -173,7 +173,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_24
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -210,7 +210,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_25
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -237,7 +237,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -317,7 +317,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2014-04-01-preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
+  - !<!ConstantSchema> &ref_21
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2014-04-01-preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_24
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -365,46 +365,6 @@ schemas: !<!Schemas>
   - *ref_12
   - *ref_13
   - *ref_14
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_26
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_15
   schema: *ref_7
@@ -417,7 +377,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Some cool documentation.
   title: complex-model
@@ -471,8 +431,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_19
@@ -514,7 +475,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_17
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -525,7 +486,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_17
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -536,7 +497,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_21
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -547,7 +508,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -566,14 +527,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_25
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -614,7 +576,7 @@ operationGroups:
       parameters:
       - *ref_15
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_17
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -625,7 +587,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_17
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -636,7 +598,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_24
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -647,7 +609,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -666,11 +628,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_19

--- a/modelerfour/test/outputs/custom-baseUrl-more-options/flattened.yaml
+++ b/modelerfour/test/outputs/custom-baseUrl-more-options/flattened.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_9
+  - !<!ObjectSchema> &ref_8
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -70,16 +70,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_8
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     defaultValue: v1
     language: !<!Languages> 
       default:
@@ -109,7 +99,7 @@ globalParameters:
       description: 'The vault name, e.g. https://myvault'
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_4
   schema: *ref_2
   implementation: Client
@@ -120,7 +110,7 @@ globalParameters:
       description: Secret value.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_5
   schema: *ref_2
   clientDefaultValue: host
@@ -132,7 +122,7 @@ globalParameters:
       description: A string value that is used as a global part of the parameterized host. Default value 'host'.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: custom-baseUrl-more-options
@@ -161,7 +151,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -172,7 +162,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_7
         implementation: Method
         language: !<!Languages> 
           default:
@@ -187,8 +177,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{vault}{secret}{dnsSuffix}/customuri/{subscriptionId}/{keyName}'
+          path: '/customuri/{subscriptionId}/{keyName}'
           method: get
+          url: '{vault}{secret}{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -201,7 +192,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/custom-baseUrl-more-options/modeler.yaml
+++ b/modelerfour/test/outputs/custom-baseUrl-more-options/modeler.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_6
+  - !<!ObjectSchema> &ref_5
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -70,16 +70,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: components·parameters·subscriptionidparameter·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_5
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     defaultValue: v1
     language: !<!Languages> 
       default:
@@ -99,7 +89,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_7
+- !<!Parameter> &ref_6
   schema: *ref_2
   implementation: Client
   required: true
@@ -109,8 +99,8 @@ globalParameters:
       description: 'The vault name, e.g. https://myvault'
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
-- !<!Parameter> &ref_8
+      in: uri
+- !<!Parameter> &ref_7
   schema: *ref_2
   implementation: Client
   required: true
@@ -120,8 +110,8 @@ globalParameters:
       description: Secret value.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
-- !<!Parameter> &ref_9
+      in: uri
+- !<!Parameter> &ref_8
   schema: *ref_2
   clientDefaultValue: host
   implementation: Client
@@ -132,7 +122,7 @@ globalParameters:
       description: A string value that is used as a global part of the parameterized host. Default value 'host'.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: custom-baseUrl-more-options
@@ -146,9 +136,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
+      - *ref_6
       - *ref_7
       - *ref_8
-      - *ref_9
       - !<!Parameter> 
         schema: *ref_3
         implementation: Method
@@ -161,7 +151,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_4
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -172,7 +162,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_5
+        schema: *ref_4
         implementation: Method
         language: !<!Languages> 
           default:
@@ -187,8 +177,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{vault}{secret}{dnsSuffix}/customuri/{subscriptionId}/{keyName}'
+          path: '/customuri/{subscriptionId}/{keyName}'
           method: get
+          url: '{vault}{secret}{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -201,7 +192,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_6
+      schema: *ref_5
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/custom-baseUrl-more-options/namer.yaml
+++ b/modelerfour/test/outputs/custom-baseUrl-more-options/namer.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_9
+  - !<!ObjectSchema> &ref_8
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -70,16 +70,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_8
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     defaultValue: v1
     language: !<!Languages> 
       default:
@@ -109,7 +99,7 @@ globalParameters:
       description: 'The vault name, e.g. https://myvault'
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_4
   schema: *ref_2
   implementation: Client
@@ -120,7 +110,7 @@ globalParameters:
       description: Secret value.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_5
   schema: *ref_2
   clientDefaultValue: host
@@ -132,7 +122,7 @@ globalParameters:
       description: A string value that is used as a global part of the parameterized host. Default value 'host'.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: custom-baseUrl-more-options
@@ -161,7 +151,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -172,7 +162,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_7
         implementation: Method
         language: !<!Languages> 
           default:
@@ -187,8 +177,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{vault}{secret}{dnsSuffix}/customuri/{subscriptionId}/{keyName}'
+          path: '/customuri/{subscriptionId}/{keyName}'
           method: get
+          url: '{vault}{secret}{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -201,7 +192,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/custom-baseUrl/flattened.yaml
+++ b/modelerfour/test/outputs/custom-baseUrl/flattened.yaml
@@ -78,7 +78,7 @@ globalParameters:
       description: Account Name
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_4
   schema: *ref_2
   clientDefaultValue: host
@@ -90,7 +90,7 @@ globalParameters:
       description: A string value that is used as a global part of the parameterized host
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: custom-baseUrl
@@ -112,8 +112,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'http://{accountName}{host}/customuri'
+          path: /customuri
           method: get
+          url: 'http://{accountName}{host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/custom-baseUrl/modeler.yaml
+++ b/modelerfour/test/outputs/custom-baseUrl/modeler.yaml
@@ -78,7 +78,7 @@ globalParameters:
       description: Account Name
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_5
   schema: *ref_2
   clientDefaultValue: host
@@ -90,7 +90,7 @@ globalParameters:
       description: A string value that is used as a global part of the parameterized host
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: custom-baseUrl
@@ -112,8 +112,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'http://{accountName}{host}/customuri'
+          path: /customuri
           method: get
+          url: 'http://{accountName}{host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/custom-baseUrl/namer.yaml
+++ b/modelerfour/test/outputs/custom-baseUrl/namer.yaml
@@ -78,7 +78,7 @@ globalParameters:
       description: Account Name
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_4
   schema: *ref_2
   clientDefaultValue: host
@@ -90,7 +90,7 @@ globalParameters:
       description: A string value that is used as a global part of the parameterized host
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: custom-baseUrl
@@ -112,8 +112,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'http://{accountName}{host}/customuri'
+          path: /customuri
           method: get
+          url: 'http://{accountName}{host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/datalake-storage/flattened.yaml
+++ b/modelerfour/test/outputs/datalake-storage/flattened.yaml
@@ -3598,7 +3598,7 @@ globalParameters:
       description: The Azure Storage account name.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_20
   schema: *ref_3
   clientDefaultValue: dfs.core.windows.net
@@ -3610,7 +3610,7 @@ globalParameters:
       description: The DNS suffix for the Azure Data Lake Storage endpoint.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Azure Data Lake Storage provides storage for Hadoop and other big data workloads.
   title: Azure Data Lake Storage REST API
@@ -3717,8 +3717,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/'
+          path: /
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_29
@@ -3861,8 +3862,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: put
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4021,8 +4023,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: patch
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4157,8 +4160,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: head
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4307,8 +4311,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: delete
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4493,8 +4498,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_95
@@ -4897,8 +4903,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5296,13 +5303,14 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: patch
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
           - text/plain
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5575,8 +5583,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: post
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5829,8 +5838,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -6162,8 +6172,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: head
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6413,8 +6424,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: delete
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/datalake-storage/modeler.yaml
+++ b/modelerfour/test/outputs/datalake-storage/modeler.yaml
@@ -3598,7 +3598,7 @@ globalParameters:
       description: The Azure Storage account name.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_37
   schema: *ref_0
   clientDefaultValue: dfs.core.windows.net
@@ -3610,7 +3610,7 @@ globalParameters:
       description: The DNS suffix for the Azure Data Lake Storage endpoint.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Azure Data Lake Storage provides storage for Hadoop and other big data workloads.
   title: Azure Data Lake Storage REST API
@@ -3717,8 +3717,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/'
+          path: /
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_32
@@ -3861,8 +3862,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: put
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4021,8 +4023,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: patch
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4157,8 +4160,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: head
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4307,8 +4311,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: delete
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4493,8 +4498,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_101
@@ -4897,8 +4903,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5296,13 +5303,14 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: patch
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
           - text/plain
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5575,8 +5583,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: post
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5829,8 +5838,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -6162,8 +6172,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: head
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6413,8 +6424,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: delete
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/datalake-storage/namer.yaml
+++ b/modelerfour/test/outputs/datalake-storage/namer.yaml
@@ -3598,7 +3598,7 @@ globalParameters:
       description: The Azure Storage account name.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 - !<!Parameter> &ref_20
   schema: *ref_3
   clientDefaultValue: dfs.core.windows.net
@@ -3610,7 +3610,7 @@ globalParameters:
       description: The DNS suffix for the Azure Data Lake Storage endpoint.
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Azure Data Lake Storage provides storage for Hadoop and other big data workloads.
   title: Azure Data Lake Storage REST API
@@ -3717,8 +3717,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/'
+          path: /
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_29
@@ -3861,8 +3862,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: put
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4021,8 +4023,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: patch
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4157,8 +4160,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: head
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4307,8 +4311,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: delete
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4493,8 +4498,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}'
+          path: '/{filesystem}'
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_95
@@ -4897,8 +4903,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: put
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5296,13 +5303,14 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpBinaryRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: patch
           binary: true
           knownMediaType: binary
           mediaTypes:
           - application/octet-stream
           - text/plain
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5575,8 +5583,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: post
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5829,8 +5838,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: get
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!BinaryResponse> 
       binary: true
@@ -6162,8 +6172,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: head
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6413,8 +6424,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: 'https://{accountName}.{dnsSuffix}/{filesystem}/{path}'
+          path: '/{filesystem}/{path}'
           method: delete
+          url: 'https://{accountName}.{dnsSuffix}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/extensible-enums-swagger/flattened.yaml
+++ b/modelerfour/test/outputs/extensible-enums-swagger/flattened.yaml
@@ -166,7 +166,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: PetStore
   title: extensible-enums-swagger
@@ -198,8 +198,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/extensibleenums/pet/{petId}'
+          path: '/extensibleenums/pet/{petId}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -246,11 +247,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/extensibleenums/pet/addPet'
+          path: /extensibleenums/pet/addPet
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/extensible-enums-swagger/modeler.yaml
+++ b/modelerfour/test/outputs/extensible-enums-swagger/modeler.yaml
@@ -166,7 +166,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: PetStore
   title: extensible-enums-swagger
@@ -198,8 +198,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/extensibleenums/pet/{petId}'
+          path: '/extensibleenums/pet/{petId}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -246,11 +247,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/extensibleenums/pet/addPet'
+          path: /extensibleenums/pet/addPet
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5

--- a/modelerfour/test/outputs/extensible-enums-swagger/namer.yaml
+++ b/modelerfour/test/outputs/extensible-enums-swagger/namer.yaml
@@ -166,7 +166,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: PetStore
   title: extensible-enums-swagger
@@ -198,8 +198,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/extensibleenums/pet/{petId}'
+          path: '/extensibleenums/pet/{petId}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6
@@ -246,11 +247,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/extensibleenums/pet/addPet'
+          path: /extensibleenums/pet/addPet
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/head-exceptions/flattened.yaml
+++ b/modelerfour/test/outputs/head-exceptions/flattened.yaml
@@ -20,7 +20,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: head-exceptions
@@ -41,8 +41,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -81,8 +82,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -121,8 +123,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/head-exceptions/modeler.yaml
+++ b/modelerfour/test/outputs/head-exceptions/modeler.yaml
@@ -20,7 +20,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: head-exceptions
@@ -41,8 +41,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -81,8 +82,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -121,8 +123,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/head-exceptions/namer.yaml
+++ b/modelerfour/test/outputs/head-exceptions/namer.yaml
@@ -20,7 +20,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: head-exceptions
@@ -41,8 +41,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -81,8 +82,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -121,8 +123,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/head/flattened.yaml
+++ b/modelerfour/test/outputs/head/flattened.yaml
@@ -20,7 +20,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: head
@@ -41,8 +41,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -90,8 +91,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -139,8 +141,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/head/modeler.yaml
+++ b/modelerfour/test/outputs/head/modeler.yaml
@@ -20,7 +20,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: head
@@ -41,8 +41,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -90,8 +91,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -139,8 +141,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/head/namer.yaml
+++ b/modelerfour/test/outputs/head/namer.yaml
@@ -20,7 +20,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: head
@@ -41,8 +41,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -90,8 +91,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -139,8 +141,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/header/flattened.yaml
+++ b/modelerfour/test/outputs/header/flattened.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_49
+  - !<!ChoiceSchema> &ref_16
     choices:
     - !<!ChoiceValue> 
       value: White
@@ -84,17 +84,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   booleans:
-  - !<!BooleanSchema> &ref_26
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_28
+  - !<!BooleanSchema> &ref_10
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -106,7 +96,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_46
+  - !<!ByteArraySchema> &ref_15
     type: byte-array
     format: byte
     apiVersions:
@@ -119,7 +109,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   dateTimes:
-  - !<!DateTimeSchema> &ref_37
+  - !<!DateTimeSchema> &ref_12
     type: date-time
     format: date-time
     apiVersions:
@@ -131,7 +121,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-DATETIME
         header: value
     protocol: !<!Protocols> {}
-  - !<!DateTimeSchema> &ref_40
+  - !<!DateTimeSchema> &ref_13
     type: date-time
     format: date-time-rfc1123
     apiVersions:
@@ -144,7 +134,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   dates:
-  - !<!DateSchema> &ref_34
+  - !<!DateSchema> &ref_11
     type: date
     apiVersions:
     - !<!ApiVersion> 
@@ -156,7 +146,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   durations:
-  - !<!DurationSchema> &ref_43
+  - !<!DurationSchema> &ref_14
     type: duration
     apiVersions:
     - !<!ApiVersion> 
@@ -169,18 +159,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   numbers:
   - *ref_0
-  - !<!NumberSchema> &ref_10
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
+  - !<!NumberSchema> &ref_6
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -192,18 +171,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
+  - !<!NumberSchema> &ref_7
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -215,18 +183,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_18
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_20
+  - !<!NumberSchema> &ref_8
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -238,18 +195,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_24
+  - !<!NumberSchema> &ref_9
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -272,301 +218,9 @@ schemas: !<!Schemas>
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - *ref_2
-  - !<!StringSchema> &ref_6
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: User-Agent
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_7
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_8
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Content-Type
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_9
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_11
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_17
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_19
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
         header: value
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_41
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_42
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_44
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_45
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_48
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_50
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_2
 globalParameters:
 - !<!Parameter> &ref_3
   schema: *ref_1
@@ -579,7 +233,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: header
@@ -611,8 +265,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/existingkey'
+          path: /header/param/existingkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -655,8 +310,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/existingkey'
+          path: /header/response/existingkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -667,7 +323,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_6
+            schema: *ref_4
             header: User-Agent
           statusCodes:
           - '200'
@@ -698,7 +354,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -714,8 +370,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/protectedkey'
+          path: /header/param/protectedkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -758,8 +415,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/protectedkey'
+          path: /header/response/protectedkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -770,7 +428,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_8
+            schema: *ref_4
             header: Content-Type
           statusCodes:
           - '200'
@@ -801,7 +459,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -812,7 +470,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_6
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -828,8 +486,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/integer'
+          path: /header/param/prim/integer
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -867,7 +526,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -883,8 +542,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/integer'
+          path: /header/response/prim/integer
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -895,7 +555,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_12
+            schema: *ref_6
             header: value
           statusCodes:
           - '200'
@@ -926,7 +586,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -937,7 +597,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -953,8 +613,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/long'
+          path: /header/param/prim/long
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -992,7 +653,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1008,8 +669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/long'
+          path: /header/response/prim/long
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1020,7 +682,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_16
+            schema: *ref_7
             header: value
           statusCodes:
           - '200'
@@ -1051,7 +713,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1062,7 +724,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1078,8 +740,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/float'
+          path: /header/param/prim/float
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1117,7 +780,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1133,8 +796,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/float'
+          path: /header/response/prim/float
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1145,7 +809,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_20
+            schema: *ref_8
             header: value
           statusCodes:
           - '200'
@@ -1176,7 +840,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1187,7 +851,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_9
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1203,8 +867,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/double'
+          path: /header/param/prim/double
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1242,7 +907,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1258,8 +923,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/double'
+          path: /header/response/prim/double
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1270,7 +936,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_24
+            schema: *ref_9
             header: value
           statusCodes:
           - '200'
@@ -1301,18 +967,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "true" or "false"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_10
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1328,8 +994,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/bool'
+          path: /header/param/prim/bool
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1367,13 +1034,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "true" or "false"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1383,8 +1050,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/bool'
+          path: /header/response/prim/bool
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1395,7 +1063,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_28
+            schema: *ref_10
             header: value
           statusCodes:
           - '200'
@@ -1426,18 +1094,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_4
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1452,8 +1120,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/string'
+          path: /header/param/prim/string
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1491,13 +1160,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1507,8 +1176,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/string'
+          path: /header/response/prim/string
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1519,7 +1189,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_4
             header: value
           statusCodes:
           - '200'
@@ -1550,18 +1220,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_11
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1577,8 +1247,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/date'
+          path: /header/param/prim/date
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1616,13 +1287,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1632,8 +1303,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/date'
+          path: /header/response/prim/date
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1644,7 +1316,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_11
             header: value
           statusCodes:
           - '200'
@@ -1675,18 +1347,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1702,8 +1374,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/datetime'
+          path: /header/param/prim/datetime
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1741,13 +1414,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1757,8 +1430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/datetime'
+          path: /header/response/prim/datetime
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1769,7 +1443,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_12
             header: value
           statusCodes:
           - '200'
@@ -1800,18 +1474,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_13
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1826,8 +1500,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/datetimerfc1123'
+          path: /header/param/prim/datetimerfc1123
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1865,13 +1540,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1881,8 +1556,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/datetimerfc1123'
+          path: /header/response/prim/datetimerfc1123
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1893,7 +1569,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_13
             header: value
           statusCodes:
           - '200'
@@ -1924,18 +1600,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_14
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1951,8 +1627,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/duration'
+          path: /header/param/prim/duration
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1990,13 +1667,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2006,8 +1683,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/duration'
+          path: /header/response/prim/duration
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2018,7 +1696,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_43
+            schema: *ref_14
             header: value
           statusCodes:
           - '200'
@@ -2049,18 +1727,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_15
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2076,8 +1754,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/byte'
+          path: /header/param/prim/byte
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2115,13 +1794,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2131,8 +1810,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/byte'
+          path: /header/response/prim/byte
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2143,7 +1823,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_15
             header: value
           statusCodes:
           - '200'
@@ -2174,18 +1854,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_16
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2200,8 +1880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/enum'
+          path: /header/param/prim/enum
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2239,13 +1920,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2255,8 +1936,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/enum'
+          path: /header/response/prim/enum
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2267,7 +1949,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_16
             header: value
           statusCodes:
           - '200'
@@ -2303,8 +1985,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+          path: /header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/header/modeler.yaml
+++ b/modelerfour/test/outputs/header/modeler.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_49
+  - !<!ChoiceSchema> &ref_16
     choices:
     - !<!ChoiceValue> 
       value: White
@@ -84,7 +84,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   booleans:
-  - !<!BooleanSchema> &ref_26
+  - !<!BooleanSchema> &ref_10
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -93,20 +93,10 @@ schemas: !<!Schemas>
       default:
         name: paths·header-param-prim-bool·post·parameters·1·schema
         description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_28
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-bool·post·responses·200·headers·value·schema
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
         header: value
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_46
+  - !<!ByteArraySchema> &ref_15
     type: byte-array
     format: byte
     apiVersions:
@@ -119,7 +109,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   dateTimes:
-  - !<!DateTimeSchema> &ref_37
+  - !<!DateTimeSchema> &ref_12
     type: date-time
     format: date-time
     apiVersions:
@@ -131,7 +121,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-DATETIME
         header: value
     protocol: !<!Protocols> {}
-  - !<!DateTimeSchema> &ref_40
+  - !<!DateTimeSchema> &ref_13
     type: date-time
     format: date-time-rfc1123
     apiVersions:
@@ -144,7 +134,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   dates:
-  - !<!DateSchema> &ref_34
+  - !<!DateSchema> &ref_11
     type: date
     apiVersions:
     - !<!ApiVersion> 
@@ -156,7 +146,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   durations:
-  - !<!DurationSchema> &ref_43
+  - !<!DurationSchema> &ref_14
     type: duration
     apiVersions:
     - !<!ApiVersion> 
@@ -169,7 +159,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   numbers:
   - *ref_1
-  - !<!NumberSchema> &ref_10
+  - !<!NumberSchema> &ref_6
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -179,20 +169,9 @@ schemas: !<!Schemas>
       default:
         name: paths·header-param-prim-integer·post·parameters·1·schema
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-integer·post·responses·200·headers·value·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
+  - !<!NumberSchema> &ref_7
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -202,20 +181,9 @@ schemas: !<!Schemas>
       default:
         name: paths·header-param-prim-long·post·parameters·1·schema
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-long·post·responses·200·headers·value·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_18
+  - !<!NumberSchema> &ref_8
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -225,20 +193,9 @@ schemas: !<!Schemas>
       default:
         name: paths·header-param-prim-float·post·parameters·1·schema
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_20
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-float·post·responses·200·headers·value·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
+  - !<!NumberSchema> &ref_9
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -247,17 +204,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: paths·header-param-prim-double·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_24
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-double·post·responses·200·headers·value·schema
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
         header: value
     protocol: !<!Protocols> {}
@@ -272,301 +218,9 @@ schemas: !<!Schemas>
       default:
         name: paths·header-param-existingkey·post·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - *ref_0
-  - !<!StringSchema> &ref_6
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-existingkey·post·responses·200·headers·user_agent·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: User-Agent
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_7
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-protectedkey·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_8
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-protectedkey·post·responses·200·headers·content_type·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Content-Type
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_9
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-integer·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_11
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-integer·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-long·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-long·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_17
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-float·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_19
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-float·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-double·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-double·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-bool·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-bool·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-string·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-string·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-string·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-string·post·responses·200·headers·value·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
         header: value
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-date·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-date·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-datetime·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-datetime·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-datetimerfc1123·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_41
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-datetimerfc1123·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_42
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-duration·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_44
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-duration·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_45
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-byte·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-byte·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_48
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-param-prim-enum·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_50
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·header-response-prim-enum·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_0
 globalParameters:
 - !<!Parameter> &ref_5
   schema: *ref_2
@@ -579,7 +233,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: header
@@ -611,8 +265,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/existingkey'
+          path: /header/param/existingkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -655,8 +310,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/existingkey'
+          path: /header/response/existingkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -667,7 +323,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_6
+            schema: *ref_3
             header: User-Agent
           statusCodes:
           - '200'
@@ -698,7 +354,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -714,8 +370,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/protectedkey'
+          path: /header/param/protectedkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -758,8 +415,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/protectedkey'
+          path: /header/response/protectedkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -770,7 +428,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_8
+            schema: *ref_3
             header: Content-Type
           statusCodes:
           - '200'
@@ -801,7 +459,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -812,7 +470,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_6
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -828,8 +486,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/integer'
+          path: /header/param/prim/integer
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -867,7 +526,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -883,8 +542,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/integer'
+          path: /header/response/prim/integer
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -895,7 +555,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_12
+            schema: *ref_6
             header: value
           statusCodes:
           - '200'
@@ -926,7 +586,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -937,7 +597,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -953,8 +613,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/long'
+          path: /header/param/prim/long
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -992,7 +653,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1008,8 +669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/long'
+          path: /header/response/prim/long
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1020,7 +682,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_16
+            schema: *ref_7
             header: value
           statusCodes:
           - '200'
@@ -1051,7 +713,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1062,7 +724,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1078,8 +740,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/float'
+          path: /header/param/prim/float
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1117,7 +780,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1133,8 +796,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/float'
+          path: /header/response/prim/float
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1145,7 +809,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_20
+            schema: *ref_8
             header: value
           statusCodes:
           - '200'
@@ -1176,7 +840,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1187,7 +851,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_9
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1203,8 +867,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/double'
+          path: /header/param/prim/double
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1242,7 +907,7 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1258,8 +923,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/double'
+          path: /header/response/prim/double
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1270,7 +936,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_24
+            schema: *ref_9
             header: value
           statusCodes:
           - '200'
@@ -1301,18 +967,18 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "true" or "false"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_10
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1328,8 +994,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/bool'
+          path: /header/param/prim/bool
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1367,13 +1034,13 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "true" or "false"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1383,8 +1050,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/bool'
+          path: /header/response/prim/bool
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1395,7 +1063,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_28
+            schema: *ref_10
             header: value
           statusCodes:
           - '200'
@@ -1426,18 +1094,18 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_3
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1452,8 +1120,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/string'
+          path: /header/param/prim/string
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1491,13 +1160,13 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1507,8 +1176,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/string'
+          path: /header/response/prim/string
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1519,7 +1189,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_3
             header: value
           statusCodes:
           - '200'
@@ -1550,18 +1220,18 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_11
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1577,8 +1247,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/date'
+          path: /header/param/prim/date
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1616,13 +1287,13 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1632,8 +1303,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/date'
+          path: /header/response/prim/date
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1644,7 +1316,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_11
             header: value
           statusCodes:
           - '200'
@@ -1675,18 +1347,18 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1702,8 +1374,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/datetime'
+          path: /header/param/prim/datetime
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1741,13 +1414,13 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1757,8 +1430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/datetime'
+          path: /header/response/prim/datetime
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1769,7 +1443,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_12
             header: value
           statusCodes:
           - '200'
@@ -1800,18 +1474,18 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_13
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1826,8 +1500,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/datetimerfc1123'
+          path: /header/param/prim/datetimerfc1123
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1865,13 +1540,13 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1881,8 +1556,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/datetimerfc1123'
+          path: /header/response/prim/datetimerfc1123
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1893,7 +1569,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_13
             header: value
           statusCodes:
           - '200'
@@ -1924,18 +1600,18 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_14
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1951,8 +1627,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/duration'
+          path: /header/param/prim/duration
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1990,13 +1667,13 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2006,8 +1683,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/duration'
+          path: /header/response/prim/duration
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2018,7 +1696,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_43
+            schema: *ref_14
             header: value
           statusCodes:
           - '200'
@@ -2049,18 +1727,18 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_15
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2076,8 +1754,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/byte'
+          path: /header/param/prim/byte
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2115,13 +1794,13 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2131,8 +1810,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/byte'
+          path: /header/response/prim/byte
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2143,7 +1823,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_15
             header: value
           statusCodes:
           - '200'
@@ -2174,18 +1854,18 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_16
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2200,8 +1880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/enum'
+          path: /header/param/prim/enum
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2239,13 +1920,13 @@ operationGroups:
       parameters:
       - *ref_5
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2255,8 +1936,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/enum'
+          path: /header/response/prim/enum
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2267,7 +1949,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_16
             header: value
           statusCodes:
           - '200'
@@ -2303,8 +1985,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+          path: /header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/header/namer.yaml
+++ b/modelerfour/test/outputs/header/namer.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_49
+  - !<!ChoiceSchema> &ref_16
     choices:
     - !<!ChoiceValue> 
       value: White
@@ -84,17 +84,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   booleans:
-  - !<!BooleanSchema> &ref_26
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_28
+  - !<!BooleanSchema> &ref_10
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -106,7 +96,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_46
+  - !<!ByteArraySchema> &ref_15
     type: byte-array
     format: byte
     apiVersions:
@@ -119,7 +109,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   dateTimes:
-  - !<!DateTimeSchema> &ref_37
+  - !<!DateTimeSchema> &ref_12
     type: date-time
     format: date-time
     apiVersions:
@@ -131,7 +121,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-DATETIME
         header: value
     protocol: !<!Protocols> {}
-  - !<!DateTimeSchema> &ref_40
+  - !<!DateTimeSchema> &ref_13
     type: date-time
     format: date-time-rfc1123
     apiVersions:
@@ -144,7 +134,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   dates:
-  - !<!DateSchema> &ref_34
+  - !<!DateSchema> &ref_11
     type: date
     apiVersions:
     - !<!ApiVersion> 
@@ -156,7 +146,7 @@ schemas: !<!Schemas>
         header: value
     protocol: !<!Protocols> {}
   durations:
-  - !<!DurationSchema> &ref_43
+  - !<!DurationSchema> &ref_14
     type: duration
     apiVersions:
     - !<!ApiVersion> 
@@ -169,18 +159,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   numbers:
   - *ref_0
-  - !<!NumberSchema> &ref_10
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_12
+  - !<!NumberSchema> &ref_6
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -192,18 +171,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_14
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
+  - !<!NumberSchema> &ref_7
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -215,18 +183,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_18
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_20
+  - !<!NumberSchema> &ref_8
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -238,18 +195,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-NUMBER
         header: value
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
-    type: number
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 64
-    language: !<!Languages> 
-      default:
-        name: number
-        description: MISSING·SCHEMA-DESCRIPTION-NUMBER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_24
+  - !<!NumberSchema> &ref_9
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -272,301 +218,9 @@ schemas: !<!Schemas>
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - *ref_2
-  - !<!StringSchema> &ref_6
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: User-Agent
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_7
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_8
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Content-Type
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_9
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_11
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_17
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_19
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
         header: value
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_41
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_42
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_44
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_45
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_48
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_50
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_2
 globalParameters:
 - !<!Parameter> &ref_3
   schema: *ref_1
@@ -579,7 +233,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: header
@@ -611,8 +265,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/existingkey'
+          path: /header/param/existingkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -655,8 +310,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/existingkey'
+          path: /header/response/existingkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -667,7 +323,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_6
+            schema: *ref_4
             header: User-Agent
           statusCodes:
           - '200'
@@ -698,7 +354,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -714,8 +370,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/protectedkey'
+          path: /header/param/protectedkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -758,8 +415,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/protectedkey'
+          path: /header/response/protectedkey
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -770,7 +428,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_8
+            schema: *ref_4
             header: Content-Type
           statusCodes:
           - '200'
@@ -801,7 +459,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -812,7 +470,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_6
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -828,8 +486,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/integer'
+          path: /header/param/prim/integer
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -867,7 +526,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_11
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -883,8 +542,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/integer'
+          path: /header/response/prim/integer
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -895,7 +555,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_12
+            schema: *ref_6
             header: value
           statusCodes:
           - '200'
@@ -926,7 +586,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_13
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -937,7 +597,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_14
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -953,8 +613,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/long'
+          path: /header/param/prim/long
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -992,7 +653,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1008,8 +669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/long'
+          path: /header/response/prim/long
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1020,7 +682,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_16
+            schema: *ref_7
             header: value
           statusCodes:
           - '200'
@@ -1051,7 +713,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1062,7 +724,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1078,8 +740,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/float'
+          path: /header/param/prim/float
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1117,7 +780,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1133,8 +796,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/float'
+          path: /header/response/prim/float
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1145,7 +809,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_20
+            schema: *ref_8
             header: value
           statusCodes:
           - '200'
@@ -1176,7 +840,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1187,7 +851,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_9
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1203,8 +867,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/double'
+          path: /header/param/prim/double
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1242,7 +907,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1258,8 +923,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/double'
+          path: /header/response/prim/double
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1270,7 +936,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_24
+            schema: *ref_9
             header: value
           statusCodes:
           - '200'
@@ -1301,18 +967,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "true" or "false"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_10
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1328,8 +994,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/bool'
+          path: /header/param/prim/bool
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1367,13 +1034,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "true" or "false"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1383,8 +1050,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/bool'
+          path: /header/response/prim/bool
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1395,7 +1063,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_28
+            schema: *ref_10
             header: value
           statusCodes:
           - '200'
@@ -1426,18 +1094,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_4
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1452,8 +1120,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/string'
+          path: /header/param/prim/string
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1491,13 +1160,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1507,8 +1176,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/string'
+          path: /header/response/prim/string
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1519,7 +1189,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_4
             header: value
           statusCodes:
           - '200'
@@ -1550,18 +1220,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_11
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1577,8 +1247,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/date'
+          path: /header/param/prim/date
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1616,13 +1287,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1632,8 +1303,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/date'
+          path: /header/response/prim/date
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1644,7 +1316,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_11
             header: value
           statusCodes:
           - '200'
@@ -1675,18 +1347,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1702,8 +1374,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/datetime'
+          path: /header/param/prim/datetime
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1741,13 +1414,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1757,8 +1430,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/datetime'
+          path: /header/response/prim/datetime
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1769,7 +1443,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_12
             header: value
           statusCodes:
           - '200'
@@ -1800,18 +1474,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_13
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1826,8 +1500,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/datetimerfc1123'
+          path: /header/param/prim/datetimerfc1123
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1865,13 +1540,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "min"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -1881,8 +1556,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/datetimerfc1123'
+          path: /header/response/prim/datetimerfc1123
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1893,7 +1569,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_13
             header: value
           statusCodes:
           - '200'
@@ -1924,18 +1600,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_14
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1951,8 +1627,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/duration'
+          path: /header/param/prim/duration
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1990,13 +1667,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2006,8 +1683,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/duration'
+          path: /header/response/prim/duration
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2018,7 +1696,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_43
+            schema: *ref_14
             header: value
           statusCodes:
           - '200'
@@ -2049,18 +1727,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_15
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2076,8 +1754,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/byte'
+          path: /header/param/prim/byte
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2115,13 +1794,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2131,8 +1810,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/byte'
+          path: /header/response/prim/byte
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2143,7 +1823,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_15
             header: value
           statusCodes:
           - '200'
@@ -2174,18 +1854,18 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_16
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2200,8 +1880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/param/prim/enum'
+          path: /header/param/prim/enum
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2239,13 +1920,13 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: scenario
-            description: 'Send a post request with header values "scenario": "valid" or "null" or "empty"'
+            description: 'Send a post request with header values "scenario": "positive" or "negative"'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: header
@@ -2255,8 +1936,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/response/prim/enum'
+          path: /header/response/prim/enum
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2267,7 +1949,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_16
             header: value
           statusCodes:
           - '200'
@@ -2303,8 +1985,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+          path: /header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/httpInfrastructure.quirks/flattened.yaml
+++ b/modelerfour/test/outputs/httpInfrastructure.quirks/flattened.yaml
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_1
-  - !<!ObjectSchema> &ref_78
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_79
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_33
+  - !<!ArraySchema> &ref_16
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -200,417 +200,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_18
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_19
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_20
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_21
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_22
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_23
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_24
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_25
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_26
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_27
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_28
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_29
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_31
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_30
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_37
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_41
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_43
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_54
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_48
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_50
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_52
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_56
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_57
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_58
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_59
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_60
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_61
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_62
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_63
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_64
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_65
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_66
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_67
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_68
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_69
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_70
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_71
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_72
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_74
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_75
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_76
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_77
+  - !<!BooleanSchema> &ref_14
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -638,75 +228,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: Simple boolean value true
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_14
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant1
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_15
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant2
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_16
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant3
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_17
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant4
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -726,11 +248,11 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant5
+        name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_17
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -744,47 +266,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant6
+        name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant7
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant8
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -798,119 +284,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant9
+        name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant10
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant11
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/failure/500
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant12
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_44
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant13
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant14
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant15
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_47
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -924,11 +302,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant16
+        name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_55
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -942,11 +320,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant17
+        name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_49
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -960,11 +338,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant18
+        name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_51
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -978,11 +356,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant19
+        name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -996,26 +374,9 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant20
+        name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant21
-        description: Simple boolean value true
     protocol: !<!Protocols> {}
   numbers:
   - *ref_4
@@ -1039,7 +400,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: httpInfrastructure.quirks
@@ -1060,8 +421,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/emptybody/error'
+          path: /http/failure/emptybody/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -1108,11 +470,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/error'
+          path: /http/failure/nomodel/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1142,11 +505,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/empty'
+          path: /http/failure/nomodel/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1184,8 +548,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1228,11 +593,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1276,11 +642,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1319,7 +686,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1338,11 +705,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1382,7 +750,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1401,11 +769,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1445,7 +814,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1464,11 +833,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1508,7 +878,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1527,11 +897,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1571,7 +942,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1590,11 +961,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1634,7 +1006,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1653,11 +1025,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1697,7 +1070,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1716,11 +1089,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1760,7 +1134,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1779,11 +1153,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1823,7 +1198,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1842,11 +1217,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1886,7 +1262,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1905,11 +1281,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1954,8 +1331,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1993,7 +1371,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2012,11 +1390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2056,7 +1435,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2075,11 +1454,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2119,7 +1499,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2138,11 +1518,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2187,8 +1568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2243,7 +1625,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2262,11 +1644,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2319,8 +1702,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2340,7 +1724,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_15
             header: Location
           statusCodes:
           - '300'
@@ -2376,8 +1760,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2389,7 +1774,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_16
       language: !<!Languages> 
         default:
           name: ''
@@ -2398,7 +1783,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_17
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2437,8 +1822,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2458,7 +1844,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_15
             header: Location
           statusCodes:
           - '301'
@@ -2494,8 +1880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2515,7 +1902,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_17
             header: Location
           statusCodes:
           - '301'
@@ -2546,7 +1933,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2565,11 +1952,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2580,7 +1968,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_18
             header: Location
           statusCodes:
           - '301'
@@ -2618,8 +2006,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2639,7 +2028,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_15
             header: Location
           statusCodes:
           - '302'
@@ -2675,8 +2064,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2696,7 +2086,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_17
             header: Location
           statusCodes:
           - '302'
@@ -2727,7 +2117,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2746,11 +2136,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2761,7 +2152,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_18
             header: Location
           statusCodes:
           - '302'
@@ -2794,7 +2185,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2813,11 +2204,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/303'
+          path: /http/redirect/303
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2837,7 +2229,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_17
             header: Location
           statusCodes:
           - '303'
@@ -2875,8 +2267,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2896,7 +2289,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_15
             header: Location
           statusCodes:
           - '307'
@@ -2932,8 +2325,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2953,7 +2347,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_17
             header: Location
           statusCodes:
           - '307'
@@ -2989,8 +2383,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: options
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3010,7 +2405,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_19
             header: Location
           statusCodes:
           - '307'
@@ -3041,7 +2436,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3060,11 +2455,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3084,7 +2480,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_20
             header: Location
           statusCodes:
           - '307'
@@ -3117,7 +2513,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3136,11 +2532,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3160,7 +2557,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_21
             header: Location
           statusCodes:
           - '307'
@@ -3193,7 +2590,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3212,11 +2609,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3236,7 +2634,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_22
             header: Location
           statusCodes:
           - '307'
@@ -3277,7 +2675,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3296,11 +2694,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3320,7 +2719,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_23
             header: Location
           statusCodes:
           - '307'
@@ -3366,8 +2765,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3400,8 +2800,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3434,8 +2835,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3463,7 +2865,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3482,11 +2884,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3516,7 +2919,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3535,11 +2938,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3569,7 +2973,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3588,11 +2992,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3622,7 +3027,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3641,11 +3046,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3680,8 +3086,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/401'
+          path: /http/failure/client/401
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3714,8 +3121,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/402'
+          path: /http/failure/client/402
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3748,8 +3156,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3782,8 +3191,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3811,7 +3221,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3830,11 +3240,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/404'
+          path: /http/failure/client/404
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3864,7 +3275,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3883,11 +3294,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/405'
+          path: /http/failure/client/405
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3917,7 +3329,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3936,11 +3348,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/406'
+          path: /http/failure/client/406
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3970,7 +3383,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3989,11 +3402,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/407'
+          path: /http/failure/client/407
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4023,7 +3437,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4042,11 +3456,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/409'
+          path: /http/failure/client/409
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4081,8 +3496,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/410'
+          path: /http/failure/client/410
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4115,8 +3531,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/411'
+          path: /http/failure/client/411
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4149,8 +3566,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4183,8 +3601,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4212,7 +3631,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4231,11 +3650,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/413'
+          path: /http/failure/client/413
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4265,7 +3685,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4284,11 +3704,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/414'
+          path: /http/failure/client/414
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4318,7 +3739,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4337,11 +3758,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/415'
+          path: /http/failure/client/415
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4376,8 +3798,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/416'
+          path: /http/failure/client/416
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4405,7 +3828,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4424,11 +3847,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/417'
+          path: /http/failure/client/417
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4463,8 +3887,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/429'
+          path: /http/failure/client/429
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4505,8 +3930,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4539,8 +3965,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4568,7 +3995,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4587,11 +4014,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4621,7 +4049,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4640,11 +4068,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4687,8 +4116,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/408'
+          path: /http/retry/408
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4726,7 +4156,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4745,11 +4175,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4789,7 +4220,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4808,11 +4239,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4857,8 +4289,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4901,11 +4334,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -4944,7 +4378,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4963,11 +4397,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5007,7 +4442,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5026,11 +4461,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5070,7 +4506,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5089,11 +4525,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5133,7 +4570,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5152,11 +4589,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5209,8 +4647,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/200/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5266,8 +4705,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/204/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5323,8 +4763,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/201/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5380,8 +4821,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/202/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5437,8 +4879,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/400/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5494,8 +4937,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5555,8 +4999,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5616,8 +5061,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5677,8 +5123,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5694,7 +5141,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5707,7 +5154,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5751,8 +5198,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5768,7 +5216,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5781,7 +5229,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5825,8 +5273,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/404/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5842,7 +5291,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5855,7 +5304,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5899,8 +5348,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5916,7 +5366,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5929,7 +5379,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5973,8 +5423,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/202/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6026,8 +5477,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/204/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6079,8 +5531,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/400/valid'
+          path: /http/payloads/202/none/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6132,8 +5585,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/202/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/202/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6181,8 +5635,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/204/none'
+          path: /http/payloads/202/none/204/none/default/none/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6230,8 +5685,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/none'
+          path: /http/payloads/202/none/204/none/default/none/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6279,8 +5735,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6328,8 +5785,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/valid'
+          path: /http/payloads/default/A/response/200/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6362,8 +5820,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/none'
+          path: /http/payloads/default/A/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6396,8 +5855,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/valid'
+          path: /http/payloads/default/A/response/400/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6430,8 +5890,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/none'
+          path: /http/payloads/default/A/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6464,8 +5925,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/invalid'
+          path: /http/payloads/default/none/response/200/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6494,8 +5956,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/none'
+          path: /http/payloads/default/none/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6524,8 +5987,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/invalid'
+          path: /http/payloads/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6554,8 +6018,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/none'
+          path: /http/payloads/default/none/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6584,8 +6049,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/none'
+          path: /http/payloads/200/A/response/200/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6618,8 +6084,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/valid'
+          path: /http/payloads/200/A/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6652,8 +6119,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/invalid'
+          path: /http/payloads/200/A/response/200/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6686,8 +6154,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/none'
+          path: /http/payloads/200/A/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6720,8 +6189,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/valid'
+          path: /http/payloads/200/A/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6754,8 +6224,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/invalid'
+          path: /http/payloads/200/A/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6788,8 +6259,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/202/valid'
+          path: /http/payloads/200/A/response/202/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0

--- a/modelerfour/test/outputs/httpInfrastructure.quirks/modeler.yaml
+++ b/modelerfour/test/outputs/httpInfrastructure.quirks/modeler.yaml
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_6
-  - !<!ObjectSchema> &ref_78
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_79
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_34
+  - !<!ArraySchema> &ref_17
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -200,7 +200,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_18
+  - !<!BooleanSchema> &ref_14
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -208,416 +208,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: paths·http-success-200·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_19
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_20
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_21
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_22
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-201·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_23
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-201·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_24
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-202·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_25
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-202·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_26
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-202·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_27
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-202·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_28
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-204·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_29
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-204·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_31
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-204·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_30
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-204·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_37
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-301·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_41
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-302·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_43
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-303·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_54
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_48
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_50
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_52
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_56
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-400·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_57
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-400·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_58
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-400·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_59
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-400·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_60
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-404·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_61
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-405·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_62
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-406·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_63
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-407·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_64
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-409·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_65
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-413·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_66
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-414·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_67
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-415·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_68
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-417·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_69
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-server-505·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_70
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-server-505·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_71
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-500·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_72
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-500·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_74
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-503·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_75
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-503·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_76
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-504·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_77
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-504·patch·requestbody·content·application-json·schema
         description: Simple boolean value true
     protocol: !<!Protocols> {}
   constants:
@@ -638,75 +228,7 @@ schemas: !<!Schemas>
         name: paths·http-failure-emptybody-error·get·responses·200·content·application-json·schema
         description: Simple boolean value true
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_14
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_15
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_16
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·get·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_17
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·options·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -730,7 +252,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_16
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -748,43 +270,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-301·head·responses·301·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-301·get·responses·301·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -802,115 +288,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-302·head·responses·302·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-302·get·responses·302·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/failure/500
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-302·patch·responses·302·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_44
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-303·post·responses·303·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·head·responses·307·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·get·responses·307·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_47
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -928,7 +306,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_55
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -946,7 +324,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_49
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -964,7 +342,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_51
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -982,7 +360,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -999,23 +377,6 @@ schemas: !<!Schemas>
         name: paths·http-redirect-307·delete·responses·307·headers·location·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-502·options·responses·200·content·application-json·schema
-        description: Simple boolean value true
     protocol: !<!Protocols> {}
   numbers:
   - *ref_9
@@ -1039,7 +400,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: httpInfrastructure.quirks
@@ -1060,8 +421,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/emptybody/error'
+          path: /http/failure/emptybody/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1108,11 +470,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/error'
+          path: /http/failure/nomodel/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -1142,11 +505,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/empty'
+          path: /http/failure/nomodel/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -1184,8 +548,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1228,11 +593,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -1276,11 +642,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -1319,7 +686,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1338,11 +705,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1382,7 +750,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1401,11 +769,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1445,7 +814,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1464,11 +833,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1508,7 +878,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1527,11 +897,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1571,7 +942,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1590,11 +961,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1634,7 +1006,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1653,11 +1025,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1697,7 +1070,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1716,11 +1089,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1760,7 +1134,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1779,11 +1153,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1823,7 +1198,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1842,11 +1217,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1886,7 +1262,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1905,11 +1281,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1954,8 +1331,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1993,7 +1371,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2012,11 +1390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2056,7 +1435,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2075,11 +1454,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2119,7 +1499,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2138,11 +1518,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2187,8 +1568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2243,7 +1625,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2262,11 +1644,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2319,8 +1702,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2340,7 +1724,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_15
             header: Location
           statusCodes:
           - '300'
@@ -2376,8 +1760,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2389,7 +1774,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_34
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -2398,7 +1783,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_33
+            schema: *ref_16
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2437,8 +1822,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2458,7 +1844,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_15
             header: Location
           statusCodes:
           - '301'
@@ -2494,8 +1880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2515,7 +1902,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_16
             header: Location
           statusCodes:
           - '301'
@@ -2546,7 +1933,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2565,11 +1952,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2580,7 +1968,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_18
             header: Location
           statusCodes:
           - '301'
@@ -2618,8 +2006,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2639,7 +2028,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_15
             header: Location
           statusCodes:
           - '302'
@@ -2675,8 +2064,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2696,7 +2086,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_16
             header: Location
           statusCodes:
           - '302'
@@ -2727,7 +2117,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2746,11 +2136,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2761,7 +2152,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_18
             header: Location
           statusCodes:
           - '302'
@@ -2794,7 +2185,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2813,11 +2204,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/303'
+          path: /http/redirect/303
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2837,7 +2229,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_16
             header: Location
           statusCodes:
           - '303'
@@ -2875,8 +2267,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2896,7 +2289,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_15
             header: Location
           statusCodes:
           - '307'
@@ -2932,8 +2325,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2953,7 +2347,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_16
             header: Location
           statusCodes:
           - '307'
@@ -2989,8 +2383,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: options
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3010,7 +2405,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_19
             header: Location
           statusCodes:
           - '307'
@@ -3041,7 +2436,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3060,11 +2455,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3084,7 +2480,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_20
             header: Location
           statusCodes:
           - '307'
@@ -3117,7 +2513,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3136,11 +2532,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3160,7 +2557,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_21
             header: Location
           statusCodes:
           - '307'
@@ -3193,7 +2590,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3212,11 +2609,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3236,7 +2634,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_22
             header: Location
           statusCodes:
           - '307'
@@ -3277,7 +2675,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3296,11 +2694,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3320,7 +2719,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_23
             header: Location
           statusCodes:
           - '307'
@@ -3366,8 +2765,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3400,8 +2800,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3434,8 +2835,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3463,7 +2865,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3482,11 +2884,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3516,7 +2919,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3535,11 +2938,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3569,7 +2973,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3588,11 +2992,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3622,7 +3027,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3641,11 +3046,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3680,8 +3086,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/401'
+          path: /http/failure/client/401
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3714,8 +3121,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/402'
+          path: /http/failure/client/402
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3748,8 +3156,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3782,8 +3191,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3811,7 +3221,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3830,11 +3240,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/404'
+          path: /http/failure/client/404
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3864,7 +3275,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3883,11 +3294,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/405'
+          path: /http/failure/client/405
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3917,7 +3329,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3936,11 +3348,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/406'
+          path: /http/failure/client/406
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3970,7 +3383,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3989,11 +3402,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/407'
+          path: /http/failure/client/407
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4023,7 +3437,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4042,11 +3456,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/409'
+          path: /http/failure/client/409
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4081,8 +3496,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/410'
+          path: /http/failure/client/410
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4115,8 +3531,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/411'
+          path: /http/failure/client/411
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4149,8 +3566,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4183,8 +3601,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4212,7 +3631,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4231,11 +3650,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/413'
+          path: /http/failure/client/413
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4265,7 +3685,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4284,11 +3704,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/414'
+          path: /http/failure/client/414
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4318,7 +3739,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4337,11 +3758,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/415'
+          path: /http/failure/client/415
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4376,8 +3798,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/416'
+          path: /http/failure/client/416
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4405,7 +3828,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4424,11 +3847,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/417'
+          path: /http/failure/client/417
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4463,8 +3887,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/429'
+          path: /http/failure/client/429
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4505,8 +3930,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4539,8 +3965,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4568,7 +3995,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4587,11 +4014,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4621,7 +4049,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4640,11 +4068,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4687,8 +4116,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/408'
+          path: /http/retry/408
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4726,7 +4156,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4745,11 +4175,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4789,7 +4220,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4808,11 +4239,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4857,8 +4289,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4901,11 +4334,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -4944,7 +4378,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4963,11 +4397,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5007,7 +4442,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5026,11 +4461,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5070,7 +4506,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5089,11 +4525,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5133,7 +4570,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5152,11 +4589,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5209,8 +4647,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/200/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5266,8 +4705,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/204/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5323,8 +4763,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/201/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5380,8 +4821,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/202/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5437,8 +4879,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/400/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5494,8 +4937,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5555,8 +4999,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5616,8 +5061,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5677,8 +5123,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5694,7 +5141,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5707,7 +5154,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5751,8 +5198,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5768,7 +5216,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5781,7 +5229,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5825,8 +5273,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/404/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5842,7 +5291,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5855,7 +5304,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5899,8 +5348,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5916,7 +5366,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5929,7 +5379,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5973,8 +5423,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/202/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6026,8 +5477,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/204/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6079,8 +5531,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/400/valid'
+          path: /http/payloads/202/none/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6132,8 +5585,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/202/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/202/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6181,8 +5635,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/204/none'
+          path: /http/payloads/202/none/204/none/default/none/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6230,8 +5685,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/none'
+          path: /http/payloads/202/none/204/none/default/none/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6279,8 +5735,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6328,8 +5785,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/valid'
+          path: /http/payloads/default/A/response/200/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6362,8 +5820,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/none'
+          path: /http/payloads/default/A/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6396,8 +5855,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/valid'
+          path: /http/payloads/default/A/response/400/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6430,8 +5890,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/none'
+          path: /http/payloads/default/A/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6464,8 +5925,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/invalid'
+          path: /http/payloads/default/none/response/200/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6494,8 +5956,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/none'
+          path: /http/payloads/default/none/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6524,8 +5987,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/invalid'
+          path: /http/payloads/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6554,8 +6018,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/none'
+          path: /http/payloads/default/none/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6584,8 +6049,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/none'
+          path: /http/payloads/200/A/response/200/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6618,8 +6084,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/valid'
+          path: /http/payloads/200/A/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6652,8 +6119,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/invalid'
+          path: /http/payloads/200/A/response/200/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6686,8 +6154,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/none'
+          path: /http/payloads/200/A/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6720,8 +6189,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/valid'
+          path: /http/payloads/200/A/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6754,8 +6224,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/invalid'
+          path: /http/payloads/200/A/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6788,8 +6259,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/202/valid'
+          path: /http/payloads/200/A/response/202/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5

--- a/modelerfour/test/outputs/httpInfrastructure.quirks/namer.yaml
+++ b/modelerfour/test/outputs/httpInfrastructure.quirks/namer.yaml
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_1
-  - !<!ObjectSchema> &ref_78
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_79
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_33
+  - !<!ArraySchema> &ref_16
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -200,417 +200,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_18
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_19
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_20
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_21
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_22
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_23
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_24
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_25
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_26
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_27
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_28
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_29
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_31
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_30
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_37
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_41
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_43
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_54
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_48
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_50
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_52
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_56
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_57
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_58
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_59
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_60
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_61
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_62
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_63
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_64
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_65
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_66
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_67
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_68
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_69
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_70
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_71
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_72
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_74
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_75
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_76
-    type: boolean
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: boolean
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_77
+  - !<!BooleanSchema> &ref_14
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -638,75 +228,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: Simple boolean value true
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_14
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant1
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_15
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant2
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_16
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant3
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_17
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant4
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -726,11 +248,11 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant5
+        name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_17
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -744,47 +266,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant6
+        name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant7
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant8
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -798,119 +284,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant9
+        name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant10
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant11
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/failure/500
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant12
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_44
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant13
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant14
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant15
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_47
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -924,11 +302,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant16
+        name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_55
+  - !<!ConstantSchema> &ref_23
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -942,11 +320,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant17
+        name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_49
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -960,11 +338,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant18
+        name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_51
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -978,11 +356,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant19
+        name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -996,26 +374,9 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant20
+        name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant21
-        description: Simple boolean value true
     protocol: !<!Protocols> {}
   numbers:
   - *ref_4
@@ -1039,7 +400,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: httpInfrastructure.quirks
@@ -1060,8 +421,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/emptybody/error'
+          path: /http/failure/emptybody/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -1108,11 +470,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/error'
+          path: /http/failure/nomodel/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1142,11 +505,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/empty'
+          path: /http/failure/nomodel/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1184,8 +548,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1228,11 +593,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1276,11 +642,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1319,7 +686,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1338,11 +705,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1382,7 +750,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1401,11 +769,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1445,7 +814,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1464,11 +833,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1508,7 +878,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1527,11 +897,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1571,7 +942,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1590,11 +961,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1634,7 +1006,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1653,11 +1025,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1697,7 +1070,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1716,11 +1089,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1760,7 +1134,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1779,11 +1153,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1823,7 +1198,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1842,11 +1217,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1886,7 +1262,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -1905,11 +1281,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1954,8 +1331,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1993,7 +1371,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2012,11 +1390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2056,7 +1435,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2075,11 +1454,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2119,7 +1499,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2138,11 +1518,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2187,8 +1568,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2243,7 +1625,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2262,11 +1644,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2319,8 +1702,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2340,7 +1724,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_15
             header: Location
           statusCodes:
           - '300'
@@ -2376,8 +1760,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2389,7 +1774,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_16
       language: !<!Languages> 
         default:
           name: ''
@@ -2398,7 +1783,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_17
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2437,8 +1822,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2458,7 +1844,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_15
             header: Location
           statusCodes:
           - '301'
@@ -2494,8 +1880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2515,7 +1902,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_17
             header: Location
           statusCodes:
           - '301'
@@ -2546,7 +1933,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2565,11 +1952,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2580,7 +1968,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_18
             header: Location
           statusCodes:
           - '301'
@@ -2618,8 +2006,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2639,7 +2028,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_15
             header: Location
           statusCodes:
           - '302'
@@ -2675,8 +2064,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2696,7 +2086,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_17
             header: Location
           statusCodes:
           - '302'
@@ -2727,7 +2117,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2746,11 +2136,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2761,7 +2152,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_18
             header: Location
           statusCodes:
           - '302'
@@ -2794,7 +2185,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -2813,11 +2204,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/303'
+          path: /http/redirect/303
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2837,7 +2229,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_17
             header: Location
           statusCodes:
           - '303'
@@ -2875,8 +2267,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2896,7 +2289,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_15
             header: Location
           statusCodes:
           - '307'
@@ -2932,8 +2325,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2953,7 +2347,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_17
             header: Location
           statusCodes:
           - '307'
@@ -2989,8 +2383,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: options
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3010,7 +2405,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_19
             header: Location
           statusCodes:
           - '307'
@@ -3041,7 +2436,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3060,11 +2455,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3084,7 +2480,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_20
             header: Location
           statusCodes:
           - '307'
@@ -3117,7 +2513,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3136,11 +2532,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3160,7 +2557,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_21
             header: Location
           statusCodes:
           - '307'
@@ -3193,7 +2590,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3212,11 +2609,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3236,7 +2634,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_22
             header: Location
           statusCodes:
           - '307'
@@ -3277,7 +2675,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3296,11 +2694,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3320,7 +2719,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_23
             header: Location
           statusCodes:
           - '307'
@@ -3366,8 +2765,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3400,8 +2800,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3434,8 +2835,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3463,7 +2865,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3482,11 +2884,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3516,7 +2919,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3535,11 +2938,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3569,7 +2973,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3588,11 +2992,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3622,7 +3027,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3641,11 +3046,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3680,8 +3086,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/401'
+          path: /http/failure/client/401
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3714,8 +3121,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/402'
+          path: /http/failure/client/402
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3748,8 +3156,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3782,8 +3191,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3811,7 +3221,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3830,11 +3240,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/404'
+          path: /http/failure/client/404
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3864,7 +3275,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3883,11 +3294,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/405'
+          path: /http/failure/client/405
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3917,7 +3329,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3936,11 +3348,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/406'
+          path: /http/failure/client/406
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3970,7 +3383,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -3989,11 +3402,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/407'
+          path: /http/failure/client/407
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4023,7 +3437,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4042,11 +3456,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/409'
+          path: /http/failure/client/409
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4081,8 +3496,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/410'
+          path: /http/failure/client/410
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4115,8 +3531,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/411'
+          path: /http/failure/client/411
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4149,8 +3566,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4183,8 +3601,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4212,7 +3631,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4231,11 +3650,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/413'
+          path: /http/failure/client/413
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4265,7 +3685,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4284,11 +3704,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/414'
+          path: /http/failure/client/414
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4318,7 +3739,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4337,11 +3758,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/415'
+          path: /http/failure/client/415
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4376,8 +3798,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/416'
+          path: /http/failure/client/416
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4405,7 +3828,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4424,11 +3847,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/417'
+          path: /http/failure/client/417
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4463,8 +3887,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/429'
+          path: /http/failure/client/429
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4505,8 +3930,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4539,8 +3965,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4568,7 +3995,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4587,11 +4014,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4621,7 +4049,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4640,11 +4068,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4687,8 +4116,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/408'
+          path: /http/retry/408
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4726,7 +4156,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4745,11 +4175,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4789,7 +4220,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4808,11 +4239,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4857,8 +4289,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4901,11 +4334,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -4944,7 +4378,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -4963,11 +4397,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5007,7 +4442,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5026,11 +4461,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5070,7 +4506,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5089,11 +4525,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5133,7 +4570,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_14
         implementation: Method
         required: true
         extensions:
@@ -5152,11 +4589,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5209,8 +4647,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/200/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5266,8 +4705,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/204/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5323,8 +4763,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/201/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5380,8 +4821,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/202/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5437,8 +4879,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/400/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5494,8 +4937,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5555,8 +4999,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5616,8 +5061,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5677,8 +5123,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5694,7 +5141,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5707,7 +5154,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5751,8 +5198,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5768,7 +5216,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5781,7 +5229,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5825,8 +5273,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/404/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5842,7 +5291,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5855,7 +5304,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5899,8 +5348,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5916,7 +5366,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -5929,7 +5379,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5973,8 +5423,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/202/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6026,8 +5477,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/204/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6079,8 +5531,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/400/valid'
+          path: /http/payloads/202/none/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6132,8 +5585,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/202/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/202/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6181,8 +5635,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/204/none'
+          path: /http/payloads/202/none/204/none/default/none/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6230,8 +5685,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/none'
+          path: /http/payloads/202/none/204/none/default/none/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6279,8 +5735,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6328,8 +5785,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/valid'
+          path: /http/payloads/default/A/response/200/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6362,8 +5820,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/none'
+          path: /http/payloads/default/A/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6396,8 +5855,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/valid'
+          path: /http/payloads/default/A/response/400/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6430,8 +5890,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/none'
+          path: /http/payloads/default/A/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6464,8 +5925,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/invalid'
+          path: /http/payloads/default/none/response/200/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6494,8 +5956,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/none'
+          path: /http/payloads/default/none/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6524,8 +5987,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/invalid'
+          path: /http/payloads/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6554,8 +6018,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/none'
+          path: /http/payloads/default/none/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6584,8 +6049,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/none'
+          path: /http/payloads/200/A/response/200/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6618,8 +6084,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/valid'
+          path: /http/payloads/200/A/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6652,8 +6119,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/invalid'
+          path: /http/payloads/200/A/response/200/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6686,8 +6154,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/none'
+          path: /http/payloads/200/A/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6720,8 +6189,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/valid'
+          path: /http/payloads/200/A/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6754,8 +6224,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/invalid'
+          path: /http/payloads/200/A/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6788,8 +6259,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/202/valid'
+          path: /http/payloads/200/A/response/202/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0

--- a/modelerfour/test/outputs/httpInfrastructure/flattened.yaml
+++ b/modelerfour/test/outputs/httpInfrastructure/flattened.yaml
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_1
-  - !<!ObjectSchema> &ref_78
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_79
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_33
+  - !<!ArraySchema> &ref_15
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -224,312 +224,6 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant1
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_15
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant2
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_16
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant3
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_17
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant4
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_18
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant5
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_19
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant6
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_20
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant7
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant8
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_22
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant9
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant10
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_24
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant11
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_25
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant12
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant13
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant14
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant15
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant16
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant17
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant18
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
       value: /http/success/head/200
       language:
         default:
@@ -544,11 +238,11 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant19
+        name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_16
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -562,64 +256,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant20
+        name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant21
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant22
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant23
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_17
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -633,153 +274,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant24
+        name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant25
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant26
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_41
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant27
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/failure/500
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant28
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_43
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant29
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_44
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant30
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant31
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant32
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_47
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -793,28 +292,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant33
+        name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_54
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant34
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_55
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -828,28 +310,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant35
+        name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_48
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant36
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_49
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -863,28 +328,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant37
+        name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_50
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant38
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_51
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -898,28 +346,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant39
+        name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_52
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant40
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -933,383 +364,9 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant41
+        name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_56
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant42
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_57
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant43
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_58
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant44
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_59
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant45
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_60
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant46
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_61
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant47
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant48
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_63
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant49
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_64
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant50
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_65
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant51
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant52
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_67
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant53
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant54
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_69
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant55
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant56
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_71
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant57
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant58
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant59
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_74
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant60
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_75
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant61
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_76
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant62
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_77
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant63
-        description: Simple boolean value true
     protocol: !<!Protocols> {}
   numbers:
   - *ref_4
@@ -1333,7 +390,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: httpInfrastructure
@@ -1354,8 +411,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/emptybody/error'
+          path: /http/failure/emptybody/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -1402,11 +460,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/error'
+          path: /http/failure/nomodel/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1436,11 +495,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/empty'
+          path: /http/failure/nomodel/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1478,8 +538,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1522,11 +583,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1570,11 +632,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1613,7 +676,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1632,11 +695,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1676,7 +740,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1695,11 +759,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1739,7 +804,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1758,11 +823,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1802,7 +868,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1821,11 +887,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1865,7 +932,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1884,11 +951,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1928,7 +996,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1947,11 +1015,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1991,7 +1060,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2010,11 +1079,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2054,7 +1124,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2073,11 +1143,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2117,7 +1188,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2136,11 +1207,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2180,7 +1252,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2199,11 +1271,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2248,8 +1321,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2287,7 +1361,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2306,11 +1380,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2350,7 +1425,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2369,11 +1444,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2413,7 +1489,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2432,11 +1508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2481,8 +1558,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2537,7 +1615,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2556,11 +1634,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2613,8 +1692,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2634,7 +1714,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_14
             header: Location
           statusCodes:
           - '300'
@@ -2670,8 +1750,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2683,7 +1764,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -2692,7 +1773,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_16
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2731,8 +1812,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2752,7 +1834,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_14
             header: Location
           statusCodes:
           - '301'
@@ -2788,8 +1870,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2809,7 +1892,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_16
             header: Location
           statusCodes:
           - '301'
@@ -2840,7 +1923,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2859,11 +1942,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2874,7 +1958,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_17
             header: Location
           statusCodes:
           - '301'
@@ -2912,8 +1996,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2933,7 +2018,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_14
             header: Location
           statusCodes:
           - '302'
@@ -2969,8 +2054,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2990,7 +2076,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_16
             header: Location
           statusCodes:
           - '302'
@@ -3021,7 +2107,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3040,11 +2126,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3055,7 +2142,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_17
             header: Location
           statusCodes:
           - '302'
@@ -3088,7 +2175,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3107,11 +2194,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/303'
+          path: /http/redirect/303
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3131,7 +2219,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_16
             header: Location
           statusCodes:
           - '303'
@@ -3169,8 +2257,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3190,7 +2279,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_14
             header: Location
           statusCodes:
           - '307'
@@ -3226,8 +2315,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3247,7 +2337,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_16
             header: Location
           statusCodes:
           - '307'
@@ -3283,8 +2373,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: options
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3304,7 +2395,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_18
             header: Location
           statusCodes:
           - '307'
@@ -3335,7 +2426,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3354,11 +2445,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3378,7 +2470,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_19
             header: Location
           statusCodes:
           - '307'
@@ -3411,7 +2503,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3430,11 +2522,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3454,7 +2547,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_20
             header: Location
           statusCodes:
           - '307'
@@ -3487,7 +2580,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3506,11 +2599,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3530,7 +2624,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_21
             header: Location
           statusCodes:
           - '307'
@@ -3571,7 +2665,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3590,11 +2684,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3614,7 +2709,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_22
             header: Location
           statusCodes:
           - '307'
@@ -3660,8 +2755,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3694,8 +2790,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3728,8 +2825,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3757,7 +2855,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3776,11 +2874,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3810,7 +2909,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3829,11 +2928,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3863,7 +2963,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3882,11 +2982,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3916,7 +3017,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3935,11 +3036,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3974,8 +3076,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/401'
+          path: /http/failure/client/401
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4008,8 +3111,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/402'
+          path: /http/failure/client/402
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4042,8 +3146,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4076,8 +3181,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4105,7 +3211,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4124,11 +3230,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/404'
+          path: /http/failure/client/404
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4158,7 +3265,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4177,11 +3284,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/405'
+          path: /http/failure/client/405
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4211,7 +3319,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4230,11 +3338,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/406'
+          path: /http/failure/client/406
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4264,7 +3373,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4283,11 +3392,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/407'
+          path: /http/failure/client/407
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4317,7 +3427,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4336,11 +3446,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/409'
+          path: /http/failure/client/409
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4375,8 +3486,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/410'
+          path: /http/failure/client/410
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4409,8 +3521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/411'
+          path: /http/failure/client/411
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4443,8 +3556,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4477,8 +3591,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4506,7 +3621,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4525,11 +3640,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/413'
+          path: /http/failure/client/413
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4559,7 +3675,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4578,11 +3694,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/414'
+          path: /http/failure/client/414
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4612,7 +3729,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4631,11 +3748,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/415'
+          path: /http/failure/client/415
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4670,8 +3788,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/416'
+          path: /http/failure/client/416
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4699,7 +3818,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4718,11 +3837,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/417'
+          path: /http/failure/client/417
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4757,8 +3877,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/429'
+          path: /http/failure/client/429
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4799,8 +3920,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4833,8 +3955,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4862,7 +3985,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4881,11 +4004,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4915,7 +4039,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4934,11 +4058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4981,8 +4106,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/408'
+          path: /http/retry/408
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5020,7 +4146,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5039,11 +4165,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5083,7 +4210,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5102,11 +4229,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5151,8 +4279,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5195,11 +4324,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -5238,7 +4368,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5257,11 +4387,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5301,7 +4432,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5320,11 +4451,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5364,7 +4496,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5383,11 +4515,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5427,7 +4560,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5446,11 +4579,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5503,8 +4637,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/200/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5560,8 +4695,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/204/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5617,8 +4753,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/201/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5674,8 +4811,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/202/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5731,8 +4869,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/400/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5788,8 +4927,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5849,8 +4989,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5910,8 +5051,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5971,8 +5113,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5988,7 +5131,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6001,7 +5144,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6045,8 +5188,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6062,7 +5206,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6075,7 +5219,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6119,8 +5263,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/404/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6136,7 +5281,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6149,7 +5294,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6193,8 +5338,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6210,7 +5356,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6223,7 +5369,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6267,8 +5413,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/202/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6320,8 +5467,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/204/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6373,8 +5521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/400/valid'
+          path: /http/payloads/202/none/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6426,8 +5575,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/202/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/202/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6475,8 +5625,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/204/none'
+          path: /http/payloads/202/none/204/none/default/none/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6524,8 +5675,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/none'
+          path: /http/payloads/202/none/204/none/default/none/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6573,8 +5725,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6622,8 +5775,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/valid'
+          path: /http/payloads/default/A/response/200/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6656,8 +5810,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/none'
+          path: /http/payloads/default/A/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6690,8 +5845,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/valid'
+          path: /http/payloads/default/A/response/400/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6724,8 +5880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/none'
+          path: /http/payloads/default/A/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6758,8 +5915,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/invalid'
+          path: /http/payloads/default/none/response/200/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6788,8 +5946,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/none'
+          path: /http/payloads/default/none/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6818,8 +5977,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/invalid'
+          path: /http/payloads/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6848,8 +6008,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/none'
+          path: /http/payloads/default/none/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6878,8 +6039,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/none'
+          path: /http/payloads/200/A/response/200/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6912,8 +6074,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/valid'
+          path: /http/payloads/200/A/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6946,8 +6109,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/invalid'
+          path: /http/payloads/200/A/response/200/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6980,8 +6144,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/none'
+          path: /http/payloads/200/A/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -7014,8 +6179,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/valid'
+          path: /http/payloads/200/A/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -7048,8 +6214,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/invalid'
+          path: /http/payloads/200/A/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -7082,8 +6249,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/202/valid'
+          path: /http/payloads/200/A/response/202/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0

--- a/modelerfour/test/outputs/httpInfrastructure/modeler.yaml
+++ b/modelerfour/test/outputs/httpInfrastructure/modeler.yaml
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_6
-  - !<!ObjectSchema> &ref_78
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_79
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_34
+  - !<!ArraySchema> &ref_16
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -224,312 +224,6 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-nomodel-error·get·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_15
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-nomodel-empty·get·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_16
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·get·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_17
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·options·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_18
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_19
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_20
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-200·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_22
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-201·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-201·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_24
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-202·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_25
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-202·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-202·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-202·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-204·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-204·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-204·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-success-204·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
       value: /http/success/head/200
       language:
         default:
@@ -548,7 +242,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_15
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -566,60 +260,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-301·head·responses·301·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-301·get·responses·301·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-301·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_17
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -637,149 +278,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-302·head·responses·302·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-302·get·responses·302·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_41
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-302·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/failure/500
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-302·patch·responses·302·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_43
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-303·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_44
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-303·post·responses·303·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·head·responses·307·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·get·responses·307·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_47
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -797,24 +296,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_54
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_55
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -832,24 +314,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_48
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_49
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -867,24 +332,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_50
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_51
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -902,24 +350,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_52
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-redirect-307·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -936,380 +367,6 @@ schemas: !<!Schemas>
         name: paths·http-redirect-307·delete·responses·307·headers·location·schema
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_56
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-400·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_57
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-400·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_58
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-400·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_59
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-400·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_60
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-404·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_61
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-405·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-406·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_63
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-407·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_64
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-409·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_65
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-413·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-414·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_67
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-415·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-client-417·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_69
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-server-505·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-failure-server-505·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_71
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-500·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-500·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-502·options·responses·200·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_74
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-503·post·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_75
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-503·delete·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_76
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-504·put·requestbody·content·application-json·schema
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_77
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: paths·http-retry-504·patch·requestbody·content·application-json·schema
-        description: Simple boolean value true
     protocol: !<!Protocols> {}
   numbers:
   - *ref_9
@@ -1333,7 +390,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: httpInfrastructure
@@ -1354,8 +411,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/emptybody/error'
+          path: /http/failure/emptybody/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1402,11 +460,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/error'
+          path: /http/failure/nomodel/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -1436,11 +495,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/empty'
+          path: /http/failure/nomodel/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -1478,8 +538,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1522,11 +583,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -1570,11 +632,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -1613,7 +676,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -1632,11 +695,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1676,7 +740,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -1695,11 +759,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1739,7 +804,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -1758,11 +823,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1802,7 +868,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -1821,11 +887,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1865,7 +932,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -1884,11 +951,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1928,7 +996,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -1947,11 +1015,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1991,7 +1060,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2010,11 +1079,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2054,7 +1124,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2073,11 +1143,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2117,7 +1188,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2136,11 +1207,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2180,7 +1252,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2199,11 +1271,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2248,8 +1321,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2287,7 +1361,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2306,11 +1380,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2350,7 +1425,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2369,11 +1444,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2413,7 +1489,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2432,11 +1508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2481,8 +1558,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2537,7 +1615,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2556,11 +1634,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2613,8 +1692,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2634,7 +1714,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_14
             header: Location
           statusCodes:
           - '300'
@@ -2670,8 +1750,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2683,7 +1764,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_34
+      schema: *ref_16
       language: !<!Languages> 
         default:
           name: ''
@@ -2692,7 +1773,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_33
+            schema: *ref_15
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2731,8 +1812,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2752,7 +1834,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_14
             header: Location
           statusCodes:
           - '301'
@@ -2788,8 +1870,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2809,7 +1892,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_15
             header: Location
           statusCodes:
           - '301'
@@ -2840,7 +1923,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -2859,11 +1942,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2874,7 +1958,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_17
             header: Location
           statusCodes:
           - '301'
@@ -2912,8 +1996,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2933,7 +2018,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_14
             header: Location
           statusCodes:
           - '302'
@@ -2969,8 +2054,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2990,7 +2076,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_15
             header: Location
           statusCodes:
           - '302'
@@ -3021,7 +2107,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3040,11 +2126,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3055,7 +2142,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_17
             header: Location
           statusCodes:
           - '302'
@@ -3088,7 +2175,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3107,11 +2194,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/303'
+          path: /http/redirect/303
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3131,7 +2219,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_15
             header: Location
           statusCodes:
           - '303'
@@ -3169,8 +2257,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3190,7 +2279,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_14
             header: Location
           statusCodes:
           - '307'
@@ -3226,8 +2315,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3247,7 +2337,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_15
             header: Location
           statusCodes:
           - '307'
@@ -3283,8 +2373,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: options
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3304,7 +2395,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_18
             header: Location
           statusCodes:
           - '307'
@@ -3335,7 +2426,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3354,11 +2445,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3378,7 +2470,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_19
             header: Location
           statusCodes:
           - '307'
@@ -3411,7 +2503,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3430,11 +2522,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3454,7 +2547,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_20
             header: Location
           statusCodes:
           - '307'
@@ -3487,7 +2580,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3506,11 +2599,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3530,7 +2624,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_21
             header: Location
           statusCodes:
           - '307'
@@ -3571,7 +2665,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3590,11 +2684,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3614,7 +2709,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_22
             header: Location
           statusCodes:
           - '307'
@@ -3660,8 +2755,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3694,8 +2790,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3728,8 +2825,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3757,7 +2855,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3776,11 +2874,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3810,7 +2909,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3829,11 +2928,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3863,7 +2963,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3882,11 +2982,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3916,7 +3017,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -3935,11 +3036,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -3974,8 +3076,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/401'
+          path: /http/failure/client/401
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4008,8 +3111,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/402'
+          path: /http/failure/client/402
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4042,8 +3146,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4076,8 +3181,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4105,7 +3211,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4124,11 +3230,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/404'
+          path: /http/failure/client/404
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4158,7 +3265,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4177,11 +3284,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/405'
+          path: /http/failure/client/405
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4211,7 +3319,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4230,11 +3338,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/406'
+          path: /http/failure/client/406
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4264,7 +3373,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4283,11 +3392,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/407'
+          path: /http/failure/client/407
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4317,7 +3427,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4336,11 +3446,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/409'
+          path: /http/failure/client/409
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4375,8 +3486,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/410'
+          path: /http/failure/client/410
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4409,8 +3521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/411'
+          path: /http/failure/client/411
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4443,8 +3556,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4477,8 +3591,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4506,7 +3621,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4525,11 +3640,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/413'
+          path: /http/failure/client/413
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4559,7 +3675,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4578,11 +3694,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/414'
+          path: /http/failure/client/414
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4612,7 +3729,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4631,11 +3748,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/415'
+          path: /http/failure/client/415
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4670,8 +3788,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/416'
+          path: /http/failure/client/416
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4699,7 +3818,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4718,11 +3837,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/417'
+          path: /http/failure/client/417
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4757,8 +3877,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/429'
+          path: /http/failure/client/429
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4799,8 +3920,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4833,8 +3955,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4862,7 +3985,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4881,11 +4004,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4915,7 +4039,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -4934,11 +4058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -4981,8 +4106,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/408'
+          path: /http/retry/408
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5020,7 +4146,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -5039,11 +4165,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5083,7 +4210,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -5102,11 +4229,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5151,8 +4279,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5195,11 +4324,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_11
       language: !<!Languages> 
         default:
           name: ''
@@ -5238,7 +4368,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -5257,11 +4387,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5301,7 +4432,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -5320,11 +4451,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5364,7 +4496,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -5383,11 +4515,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5427,7 +4560,7 @@ operationGroups:
       parameters:
       - *ref_13
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_11
         implementation: Method
         required: true
         extensions:
@@ -5446,11 +4579,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5503,8 +4637,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/200/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5560,8 +4695,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/204/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5617,8 +4753,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/201/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5674,8 +4811,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/202/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5731,8 +4869,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/400/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5788,8 +4927,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5849,8 +4989,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5910,8 +5051,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5971,8 +5113,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -5988,7 +5131,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6001,7 +5144,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6045,8 +5188,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6062,7 +5206,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6075,7 +5219,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6119,8 +5263,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/404/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6136,7 +5281,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6149,7 +5294,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6193,8 +5338,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6210,7 +5356,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6223,7 +5369,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6267,8 +5413,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/202/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6320,8 +5467,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/204/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6373,8 +5521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/400/valid'
+          path: /http/payloads/202/none/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6426,8 +5575,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/202/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/202/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6475,8 +5625,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/204/none'
+          path: /http/payloads/202/none/204/none/default/none/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6524,8 +5675,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/none'
+          path: /http/payloads/202/none/204/none/default/none/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6573,8 +5725,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6622,8 +5775,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/valid'
+          path: /http/payloads/default/A/response/200/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6656,8 +5810,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/none'
+          path: /http/payloads/default/A/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6690,8 +5845,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/valid'
+          path: /http/payloads/default/A/response/400/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6724,8 +5880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/none'
+          path: /http/payloads/default/A/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6758,8 +5915,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/invalid'
+          path: /http/payloads/default/none/response/200/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6788,8 +5946,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/none'
+          path: /http/payloads/default/none/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6818,8 +5977,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/invalid'
+          path: /http/payloads/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6848,8 +6008,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/none'
+          path: /http/payloads/default/none/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6878,8 +6039,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/none'
+          path: /http/payloads/200/A/response/200/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6912,8 +6074,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/valid'
+          path: /http/payloads/200/A/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6946,8 +6109,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/invalid'
+          path: /http/payloads/200/A/response/200/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -6980,8 +6144,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/none'
+          path: /http/payloads/200/A/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -7014,8 +6179,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/valid'
+          path: /http/payloads/200/A/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -7048,8 +6214,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/invalid'
+          path: /http/payloads/200/A/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -7082,8 +6249,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/202/valid'
+          path: /http/payloads/200/A/response/202/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5

--- a/modelerfour/test/outputs/httpInfrastructure/namer.yaml
+++ b/modelerfour/test/outputs/httpInfrastructure/namer.yaml
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_1
-  - !<!ObjectSchema> &ref_78
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_79
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_33
+  - !<!ArraySchema> &ref_15
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -224,312 +224,6 @@ schemas: !<!Schemas>
     - !<!ApiVersion> 
       version: 1.0.0
     value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant1
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_15
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant2
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_16
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant3
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_17
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant4
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_18
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant5
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_19
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant6
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_20
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant7
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_21
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant8
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_22
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant9
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_23
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant10
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_24
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant11
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_25
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant12
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_26
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant13
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_27
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant14
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant15
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant16
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant17
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant18
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
       value: /http/success/head/200
       language:
         default:
@@ -544,11 +238,11 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant19
+        name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_16
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -562,64 +256,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant20
+        name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant21
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant22
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant23
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_17
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -633,153 +274,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant24
+        name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant25
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant26
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_41
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant27
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_42
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/failure/500
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant28
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_43
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant29
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_44
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant30
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/head/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant31
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: /http/success/get/200
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant32
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_47
+  - !<!ConstantSchema> &ref_18
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -793,28 +292,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant33
+        name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_54
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant34
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_55
+  - !<!ConstantSchema> &ref_22
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -828,28 +310,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant35
+        name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_48
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant36
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_49
+  - !<!ConstantSchema> &ref_19
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -863,28 +328,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant37
+        name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_50
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant38
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_51
+  - !<!ConstantSchema> &ref_20
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -898,28 +346,11 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant39
+        name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_52
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant40
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_21
     type: constant
     apiVersions:
     - !<!ApiVersion> 
@@ -933,383 +364,9 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant41
+        name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
         header: Location
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_56
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant42
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_57
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant43
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_58
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant44
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_59
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant45
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_60
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant46
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_61
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant47
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant48
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_63
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant49
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_64
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant50
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_65
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant51
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant52
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_67
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant53
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant54
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_69
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant55
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant56
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_71
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant57
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant58
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant59
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_74
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant60
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_75
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant61
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_76
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant62
-        description: Simple boolean value true
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_77
-    type: constant
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    value: !<!ConstantValue> 
-      value: true
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_2
-    language: !<!Languages> 
-      default:
-        name: Constant63
-        description: Simple boolean value true
     protocol: !<!Protocols> {}
   numbers:
   - *ref_4
@@ -1333,7 +390,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: httpInfrastructure
@@ -1354,8 +411,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/emptybody/error'
+          path: /http/failure/emptybody/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -1402,11 +460,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/error'
+          path: /http/failure/nomodel/error
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1436,11 +495,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/nomodel/empty'
+          path: /http/failure/nomodel/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_15
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1478,8 +538,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1522,11 +583,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_16
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1570,11 +632,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_17
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1613,7 +676,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1632,11 +695,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1676,7 +740,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1695,11 +759,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1739,7 +804,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1758,11 +823,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1802,7 +868,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1821,11 +887,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/200'
+          path: /http/success/200
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1865,7 +932,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1884,11 +951,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1928,7 +996,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1947,11 +1015,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/201'
+          path: /http/success/201
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1991,7 +1060,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2010,11 +1079,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2054,7 +1124,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2073,11 +1143,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2117,7 +1188,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2136,11 +1207,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2180,7 +1252,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2199,11 +1271,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/202'
+          path: /http/success/202
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2248,8 +1321,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2287,7 +1361,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2306,11 +1380,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2350,7 +1425,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2369,11 +1444,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2413,7 +1489,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2432,11 +1508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2481,8 +1558,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/success/404'
+          path: /http/success/404
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2537,7 +1615,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2556,11 +1634,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/success/204'
+          path: /http/success/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2613,8 +1692,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2634,7 +1714,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_14
             header: Location
           statusCodes:
           - '300'
@@ -2670,8 +1750,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/300'
+          path: /http/redirect/300
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2683,7 +1764,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_33
+      schema: *ref_15
       language: !<!Languages> 
         default:
           name: ''
@@ -2692,7 +1773,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_16
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2731,8 +1812,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2752,7 +1834,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_14
             header: Location
           statusCodes:
           - '301'
@@ -2788,8 +1870,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2809,7 +1892,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_16
             header: Location
           statusCodes:
           - '301'
@@ -2840,7 +1923,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -2859,11 +1942,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/301'
+          path: /http/redirect/301
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2874,7 +1958,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_17
             header: Location
           statusCodes:
           - '301'
@@ -2912,8 +1996,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2933,7 +2018,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_14
             header: Location
           statusCodes:
           - '302'
@@ -2969,8 +2054,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2990,7 +2076,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_40
+            schema: *ref_16
             header: Location
           statusCodes:
           - '302'
@@ -3021,7 +2107,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3040,11 +2126,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/302'
+          path: /http/redirect/302
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3055,7 +2142,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_17
             header: Location
           statusCodes:
           - '302'
@@ -3088,7 +2175,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3107,11 +2194,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/303'
+          path: /http/redirect/303
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3131,7 +2219,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_16
             header: Location
           statusCodes:
           - '303'
@@ -3169,8 +2257,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3190,7 +2279,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_14
             header: Location
           statusCodes:
           - '307'
@@ -3226,8 +2315,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3247,7 +2337,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_16
             header: Location
           statusCodes:
           - '307'
@@ -3283,8 +2373,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: options
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3304,7 +2395,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_18
             header: Location
           statusCodes:
           - '307'
@@ -3335,7 +2426,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3354,11 +2445,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3378,7 +2470,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_19
             header: Location
           statusCodes:
           - '307'
@@ -3411,7 +2503,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3430,11 +2522,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3454,7 +2547,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_20
             header: Location
           statusCodes:
           - '307'
@@ -3487,7 +2580,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3506,11 +2599,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3530,7 +2624,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_21
             header: Location
           statusCodes:
           - '307'
@@ -3571,7 +2665,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3590,11 +2684,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/redirect/307'
+          path: /http/redirect/307
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3614,7 +2709,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_22
             header: Location
           statusCodes:
           - '307'
@@ -3660,8 +2755,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3694,8 +2790,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3728,8 +2825,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3757,7 +2855,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3776,11 +2874,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3810,7 +2909,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3829,11 +2928,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3863,7 +2963,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3882,11 +2982,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3916,7 +3017,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -3935,11 +3036,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/400'
+          path: /http/failure/client/400
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -3974,8 +3076,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/401'
+          path: /http/failure/client/401
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4008,8 +3111,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/402'
+          path: /http/failure/client/402
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4042,8 +3146,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4076,8 +3181,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/403'
+          path: /http/failure/client/403
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4105,7 +3211,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4124,11 +3230,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/404'
+          path: /http/failure/client/404
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4158,7 +3265,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4177,11 +3284,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/405'
+          path: /http/failure/client/405
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4211,7 +3319,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4230,11 +3338,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/406'
+          path: /http/failure/client/406
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4264,7 +3373,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4283,11 +3392,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/407'
+          path: /http/failure/client/407
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4317,7 +3427,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4336,11 +3446,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/409'
+          path: /http/failure/client/409
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4375,8 +3486,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/410'
+          path: /http/failure/client/410
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4409,8 +3521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/411'
+          path: /http/failure/client/411
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4443,8 +3556,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: options
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4477,8 +3591,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/412'
+          path: /http/failure/client/412
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4506,7 +3621,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4525,11 +3640,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/413'
+          path: /http/failure/client/413
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4559,7 +3675,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4578,11 +3694,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/414'
+          path: /http/failure/client/414
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4612,7 +3729,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4631,11 +3748,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/415'
+          path: /http/failure/client/415
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4670,8 +3788,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/416'
+          path: /http/failure/client/416
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4699,7 +3818,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4718,11 +3837,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/client/417'
+          path: /http/failure/client/417
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4757,8 +3877,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/client/429'
+          path: /http/failure/client/429
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4799,8 +3920,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: head
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4833,8 +3955,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/failure/server/501'
+          path: /http/failure/server/501
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4862,7 +3985,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4881,11 +4004,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4915,7 +4039,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -4934,11 +4058,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/failure/server/505'
+          path: /http/failure/server/505
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -4981,8 +4106,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/408'
+          path: /http/retry/408
           method: head
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5020,7 +4146,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5039,11 +4165,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5083,7 +4210,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5102,11 +4229,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/500'
+          path: /http/retry/500
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5151,8 +4279,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5195,11 +4324,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/retry/502'
+          path: /http/retry/502
           method: options
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -5238,7 +4368,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5257,11 +4387,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5301,7 +4432,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5320,11 +4451,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/503'
+          path: /http/retry/503
           method: delete
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5364,7 +4496,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5383,11 +4515,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5427,7 +4560,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -5446,11 +4579,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/http/retry/504'
+          path: /http/retry/504
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5503,8 +4637,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/200/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5560,8 +4695,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/204/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5617,8 +4753,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/201/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5674,8 +4811,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/202/none'
+          path: /http/payloads/200/A/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5731,8 +4869,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/204/none/default/Error/response/400/valid'
+          path: /http/payloads/200/A/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5788,8 +4927,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5849,8 +4989,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5910,8 +5051,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/B/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/B/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5971,8 +5113,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -5988,7 +5131,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6001,7 +5144,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6045,8 +5188,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/201/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6062,7 +5206,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6075,7 +5219,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6119,8 +5263,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/404/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6136,7 +5281,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6149,7 +5294,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6193,8 +5338,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid'
+          path: /http/payloads/200/A/201/C/404/D/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6210,7 +5356,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_78
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -6223,7 +5369,7 @@ operationGroups:
           statusCodes:
           - '201'
     - !<!SchemaResponse> 
-      schema: *ref_79
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -6267,8 +5413,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/202/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/202/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6320,8 +5467,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/204/none'
+          path: /http/payloads/202/none/204/none/default/Error/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6373,8 +5521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/Error/response/400/valid'
+          path: /http/payloads/202/none/204/none/default/Error/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6426,8 +5575,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/202/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/202/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6475,8 +5625,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/204/none'
+          path: /http/payloads/202/none/204/none/default/none/response/204/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6524,8 +5675,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/none'
+          path: /http/payloads/202/none/204/none/default/none/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6573,8 +5725,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/202/none/204/none/default/none/response/400/invalid'
+          path: /http/payloads/202/none/204/none/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6622,8 +5775,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/valid'
+          path: /http/payloads/default/A/response/200/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6656,8 +5810,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/200/none'
+          path: /http/payloads/default/A/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6690,8 +5845,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/valid'
+          path: /http/payloads/default/A/response/400/valid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6724,8 +5880,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/A/response/400/none'
+          path: /http/payloads/default/A/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6758,8 +5915,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/invalid'
+          path: /http/payloads/default/none/response/200/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6788,8 +5946,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/200/none'
+          path: /http/payloads/default/none/response/200/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6818,8 +5977,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/invalid'
+          path: /http/payloads/default/none/response/400/invalid
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6848,8 +6008,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/default/none/response/400/none'
+          path: /http/payloads/default/none/response/400/none
           method: get
+          url: '{$host}'
     exceptions:
     - !<!Response> 
       language: !<!Languages> 
@@ -6878,8 +6039,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/none'
+          path: /http/payloads/200/A/response/200/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6912,8 +6074,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/valid'
+          path: /http/payloads/200/A/response/200/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6946,8 +6109,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/200/invalid'
+          path: /http/payloads/200/A/response/200/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -6980,8 +6144,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/none'
+          path: /http/payloads/200/A/response/400/none
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -7014,8 +6179,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/valid'
+          path: /http/payloads/200/A/response/400/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -7048,8 +6214,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/400/invalid'
+          path: /http/payloads/200/A/response/400/invalid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0
@@ -7082,8 +6249,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/http/payloads/200/A/response/202/valid'
+          path: /http/payloads/200/A/response/202/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_0

--- a/modelerfour/test/outputs/lro/flattened.yaml
+++ b/modelerfour/test/outputs/lro/flattened.yaml
@@ -20,134 +20,119 @@ schemas: !<!Schemas>
           - *ref_0
         properties:
         - !<!Property> 
-          schema: !<!ObjectSchema> &ref_2
-            type: object
+          schema: !<!StringSchema> &ref_2
+            type: string
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            properties:
-            - !<!Property> 
-              schema: !<!StringSchema> &ref_19
-                type: string
-                apiVersions:
-                - !<!ApiVersion> 
-                  version: 1.0.0
-                language: !<!Languages> 
-                  default:
-                    name: Product-properties-provisioningState
-                    description: MISSING·SCHEMA-DESCRIPTION-STRING
-                protocol: !<!Protocols> {}
-              serializedName: provisioningState
-              language: !<!Languages> 
-                default:
-                  name: provisioningState
-                  description: MISSING·SCHEMA-DESCRIPTION-STRING
-              protocol: !<!Protocols> {}
-            - !<!Property> 
-              schema: !<!SealedChoiceSchema> &ref_11
-                choices:
-                - !<!ChoiceValue> 
-                  value: Succeeded
-                  language:
-                    default:
-                      name: Succeeded
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Failed
-                  language:
-                    default:
-                      name: Failed
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: canceled
-                  language:
-                    default:
-                      name: canceled
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Accepted
-                  language:
-                    default:
-                      name: Accepted
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Creating
-                  language:
-                    default:
-                      name: Creating
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Created
-                  language:
-                    default:
-                      name: Created
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Updating
-                  language:
-                    default:
-                      name: Updating
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Updated
-                  language:
-                    default:
-                      name: Updated
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Deleting
-                  language:
-                    default:
-                      name: Deleting
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Deleted
-                  language:
-                    default:
-                      name: Deleted
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: OK
-                  language:
-                    default:
-                      name: OK
-                      description: ''
-                type: sealed-choice
-                apiVersions:
-                - !<!ApiVersion> 
-                  version: 1.0.0
-                choiceType: !<!StringSchema> &ref_4
-                  type: string
-                  language: !<!Languages> 
-                    default:
-                      name: string
-                      description: simple string
-                  protocol: !<!Protocols> {}
-                language: !<!Languages> 
-                  default:
-                    name: Product-properties-provisioningStateValues
-                    description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-                protocol: !<!Protocols> {}
-              readOnly: true
-              serializedName: provisioningStateValues
-              language: !<!Languages> 
-                default:
-                  name: provisioningStateValues
-                  description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-              protocol: !<!Protocols> {}
-            extensions:
-              x-ms-client-flatten: true
             language: !<!Languages> 
               default:
-                name: Product-properties
-                description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
-                namespace: Api100
+                name: Product-properties-provisioningState
+                description: MISSING·SCHEMA-DESCRIPTION-STRING
             protocol: !<!Protocols> {}
-          serializedName: properties
+          flattenedNames:
+          - properties
+          - provisioningState
+          serializedName: provisioningState
           language: !<!Languages> 
             default:
-              name: properties
-              description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
+              name: provisioningState
+              description: MISSING·SCHEMA-DESCRIPTION-STRING
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: !<!SealedChoiceSchema> &ref_3
+            choices:
+            - !<!ChoiceValue> 
+              value: Succeeded
+              language:
+                default:
+                  name: Succeeded
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Failed
+              language:
+                default:
+                  name: Failed
+                  description: ''
+            - !<!ChoiceValue> 
+              value: canceled
+              language:
+                default:
+                  name: canceled
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Accepted
+              language:
+                default:
+                  name: Accepted
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Creating
+              language:
+                default:
+                  name: Creating
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Created
+              language:
+                default:
+                  name: Created
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Updating
+              language:
+                default:
+                  name: Updating
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Updated
+              language:
+                default:
+                  name: Updated
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Deleting
+              language:
+                default:
+                  name: Deleting
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Deleted
+              language:
+                default:
+                  name: Deleted
+                  description: ''
+            - !<!ChoiceValue> 
+              value: OK
+              language:
+                default:
+                  name: OK
+                  description: ''
+            type: sealed-choice
+            apiVersions:
+            - !<!ApiVersion> 
+              version: 1.0.0
+            choiceType: !<!StringSchema> &ref_5
+              type: string
+              language: !<!Languages> 
+                default:
+                  name: string
+                  description: simple string
+              protocol: !<!Protocols> {}
+            language: !<!Languages> 
+              default:
+                name: Product-properties-provisioningStateValues
+                description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+            protocol: !<!Protocols> {}
+          flattenedNames:
+          - properties
+          - provisioningStateValues
+          readOnly: true
+          serializedName: provisioningStateValues
+          language: !<!Languages> 
+            default:
+              name: provisioningStateValues
+              description: MISSING·SCHEMA-DESCRIPTION-CHOICE
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -195,7 +180,7 @@ schemas: !<!Schemas>
           description: Resource Type
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_8
+      schema: !<!DictionarySchema> &ref_10
         type: dictionary
         elementType: !<!StringSchema> &ref_16
           type: string
@@ -206,6 +191,7 @@ schemas: !<!Schemas>
             default:
               name: string
               description: MISSING·SCHEMA-DESCRIPTION-STRING
+              header: Location
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -262,15 +248,45 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_1
-  - *ref_2
-  - !<!ObjectSchema> &ref_27
+  - !<!ObjectSchema> 
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_9
+      schema: *ref_2
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: MISSING·SCHEMA-DESCRIPTION-STRING
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_3
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+      protocol: !<!Protocols> {}
+    extensions:
+      x-ms-client-flatten: true
+    language: !<!Languages> 
+      default:
+        name: Product-properties
+        description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
+        namespace: Api100
+    protocol: !<!Protocols> {}
+  - !<!ObjectSchema> &ref_25
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: !<!NumberSchema> &ref_11
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -285,7 +301,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_20
+      schema: !<!StringSchema> &ref_19
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -309,14 +325,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_40
+  - !<!ObjectSchema> &ref_27
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_21
+      schema: !<!StringSchema> &ref_20
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -333,7 +349,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_22
+      schema: !<!StringSchema> &ref_21
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -355,147 +371,132 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_3
+  - !<!ObjectSchema> &ref_4
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     children: !<!Relations> 
       all:
-      - !<!ObjectSchema> &ref_5
+      - !<!ObjectSchema> &ref_6
         type: object
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
         parents: !<!Relations> 
           all:
-          - *ref_3
+          - *ref_4
           immediate:
-          - *ref_3
+          - *ref_4
         properties:
         - !<!Property> 
-          schema: !<!ObjectSchema> &ref_6
-            type: object
+          schema: !<!StringSchema> &ref_7
+            type: string
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            properties:
-            - !<!Property> 
-              schema: !<!StringSchema> &ref_24
-                type: string
-                apiVersions:
-                - !<!ApiVersion> 
-                  version: 1.0.0
-                language: !<!Languages> 
-                  default:
-                    name: SubProduct-properties-provisioningState
-                    description: MISSING·SCHEMA-DESCRIPTION-STRING
-                protocol: !<!Protocols> {}
-              serializedName: provisioningState
-              language: !<!Languages> 
-                default:
-                  name: provisioningState
-                  description: MISSING·SCHEMA-DESCRIPTION-STRING
-              protocol: !<!Protocols> {}
-            - !<!Property> 
-              schema: !<!SealedChoiceSchema> &ref_12
-                choices:
-                - !<!ChoiceValue> 
-                  value: Succeeded
-                  language:
-                    default:
-                      name: Succeeded
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Failed
-                  language:
-                    default:
-                      name: Failed
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: canceled
-                  language:
-                    default:
-                      name: canceled
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Accepted
-                  language:
-                    default:
-                      name: Accepted
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Creating
-                  language:
-                    default:
-                      name: Creating
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Created
-                  language:
-                    default:
-                      name: Created
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Updating
-                  language:
-                    default:
-                      name: Updating
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Updated
-                  language:
-                    default:
-                      name: Updated
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Deleting
-                  language:
-                    default:
-                      name: Deleting
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Deleted
-                  language:
-                    default:
-                      name: Deleted
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: OK
-                  language:
-                    default:
-                      name: OK
-                      description: ''
-                type: sealed-choice
-                apiVersions:
-                - !<!ApiVersion> 
-                  version: 1.0.0
-                choiceType: *ref_4
-                language: !<!Languages> 
-                  default:
-                    name: SubProduct-properties-provisioningStateValues
-                    description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-                protocol: !<!Protocols> {}
-              readOnly: true
-              serializedName: provisioningStateValues
-              language: !<!Languages> 
-                default:
-                  name: provisioningStateValues
-                  description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-              protocol: !<!Protocols> {}
-            extensions:
-              x-ms-client-flatten: true
             language: !<!Languages> 
               default:
-                name: SubProduct-properties
-                description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
-                namespace: Api100
+                name: SubProduct-properties-provisioningState
+                description: MISSING·SCHEMA-DESCRIPTION-STRING
             protocol: !<!Protocols> {}
-          serializedName: properties
+          flattenedNames:
+          - properties
+          - provisioningState
+          serializedName: provisioningState
           language: !<!Languages> 
             default:
-              name: properties
-              description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
+              name: provisioningState
+              description: MISSING·SCHEMA-DESCRIPTION-STRING
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: !<!SealedChoiceSchema> &ref_8
+            choices:
+            - !<!ChoiceValue> 
+              value: Succeeded
+              language:
+                default:
+                  name: Succeeded
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Failed
+              language:
+                default:
+                  name: Failed
+                  description: ''
+            - !<!ChoiceValue> 
+              value: canceled
+              language:
+                default:
+                  name: canceled
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Accepted
+              language:
+                default:
+                  name: Accepted
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Creating
+              language:
+                default:
+                  name: Creating
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Created
+              language:
+                default:
+                  name: Created
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Updating
+              language:
+                default:
+                  name: Updating
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Updated
+              language:
+                default:
+                  name: Updated
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Deleting
+              language:
+                default:
+                  name: Deleting
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Deleted
+              language:
+                default:
+                  name: Deleted
+                  description: ''
+            - !<!ChoiceValue> 
+              value: OK
+              language:
+                default:
+                  name: OK
+                  description: ''
+            type: sealed-choice
+            apiVersions:
+            - !<!ApiVersion> 
+              version: 1.0.0
+            choiceType: *ref_5
+            language: !<!Languages> 
+              default:
+                name: SubProduct-properties-provisioningStateValues
+                description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+            protocol: !<!Protocols> {}
+          flattenedNames:
+          - properties
+          - provisioningStateValues
+          readOnly: true
+          serializedName: provisioningStateValues
+          language: !<!Languages> 
+            default:
+              name: provisioningStateValues
+              description: MISSING·SCHEMA-DESCRIPTION-CHOICE
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -504,10 +505,10 @@ schemas: !<!Schemas>
             namespace: Api100
         protocol: !<!Protocols> {}
       immediate:
-      - *ref_5
+      - *ref_6
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_23
+      schema: !<!StringSchema> &ref_22
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -532,8 +533,38 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - *ref_5
   - *ref_6
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_7
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: MISSING·SCHEMA-DESCRIPTION-STRING
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_8
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+      protocol: !<!Protocols> {}
+    extensions:
+      x-ms-client-flatten: true
+    language: !<!Languages> 
+      default:
+        name: SubProduct-properties
+        description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
+        namespace: Api100
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> 
     type: object
     apiVersions:
@@ -613,7 +644,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        choiceType: *ref_4
+        choiceType: *ref_5
         language: !<!Languages> 
           default:
             name: OperationResult-status
@@ -626,14 +657,14 @@ schemas: !<!Schemas>
           description: The status of the request
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ObjectSchema> &ref_7
+      schema: !<!ObjectSchema> &ref_9
         type: object
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
         properties:
         - !<!Property> 
-          schema: !<!NumberSchema> &ref_10
+          schema: !<!NumberSchema> &ref_12
             type: integer
             precision: 32
             language: !<!Languages> 
@@ -648,7 +679,7 @@ schemas: !<!Schemas>
               description: The error code for an operation failure
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!StringSchema> &ref_25
+          schema: !<!StringSchema> &ref_23
             type: string
             apiVersions:
             - !<!ApiVersion> 
@@ -682,1487 +713,45 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - *ref_7
-  dictionaries:
-  - *ref_8
-  numbers:
   - *ref_9
-  - !<!NumberSchema> &ref_31
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_36
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_42
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_44
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_46
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_48
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_50
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_55
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_58
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_61
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_64
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_66
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_68
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_71
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_74
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_77
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_80
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_83
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_85
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_87
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_90
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_92
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_95
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_98
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_100
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_102
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_105
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_107
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_109
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_112
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_115
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_118
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_121
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_123
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_126
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_129
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_132
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_134
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_137
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_140
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_142
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_145
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_148
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_151
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_153
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_156
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
+  dictionaries:
   - *ref_10
-  sealedChoices:
+  numbers:
   - *ref_11
+  - !<!NumberSchema> &ref_26
+    type: integer
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    precision: 32
+    language: !<!Languages> 
+      default:
+        name: integer
+        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
+        header: Retry-After
+    protocol: !<!Protocols> {}
   - *ref_12
+  sealedChoices:
+  - *ref_3
+  - *ref_8
   - *ref_13
   strings:
-  - *ref_4
+  - *ref_5
   - *ref_14
   - *ref_15
   - *ref_16
   - *ref_17
   - *ref_18
+  - *ref_2
   - *ref_19
   - *ref_20
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
   - *ref_21
   - *ref_22
+  - *ref_7
   - *ref_23
-  - *ref_24
-  - !<!StringSchema> &ref_41
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_43
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_45
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_49
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_51
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_52
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_53
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_54
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_56
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_57
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_59
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_60
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_62
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_63
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_65
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_67
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_69
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_70
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_72
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_73
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_75
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_76
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_78
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_79
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_81
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_82
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_84
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_86
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_88
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_89
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_91
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_93
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_94
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_96
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_97
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_99
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_101
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_103
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_104
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_106
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_108
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_110
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_111
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_113
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_114
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_116
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_117
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_119
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_120
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_122
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_124
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_125
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_127
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_128
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_130
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_131
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_133
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_135
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_136
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_138
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_139
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_141
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_143
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_144
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_146
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_147
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_149
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_150
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_152
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_154
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_155
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - *ref_25
 globalParameters:
-- !<!Parameter> &ref_26
-  schema: *ref_4
+- !<!Parameter> &ref_24
+  schema: *ref_5
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -2172,7 +761,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Long-running Operation for AutoRest
   title: lro
@@ -2186,7 +775,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2207,11 +796,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/succeeded'
+          path: /lro/put/200/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2237,7 +827,7 @@ operationGroups:
           - '204'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2263,7 +853,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2284,11 +874,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/succeeded/nostate'
+          path: /lro/put/200/succeeded/nostate
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2305,7 +896,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2331,7 +922,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2352,11 +943,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/202/retry/200'
+          path: /lro/put/202/retry/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2373,7 +965,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2399,7 +991,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2420,11 +1012,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/201/creating/succeeded/200'
+          path: /lro/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2454,7 +1047,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2480,7 +1073,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2501,11 +1094,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/updating/succeeded/200'
+          path: /lro/put/200/updating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2522,7 +1116,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2548,7 +1142,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2569,11 +1163,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/201/created/failed/200'
+          path: /lro/put/201/created/failed/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2603,7 +1198,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2629,7 +1224,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2650,11 +1245,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/accepted/canceled/200'
+          path: /lro/put/200/accepted/canceled/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2671,7 +1267,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2697,7 +1293,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2718,11 +1314,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/noheader/202/200'
+          path: /lro/put/noheader/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2734,7 +1331,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_28
+            schema: *ref_16
             header: location
           knownMediaType: json
           mediaTypes:
@@ -2743,7 +1340,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2769,7 +1366,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2790,11 +1387,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/retry/succeeded'
+          path: /lro/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2806,13 +1404,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_29
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_30
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_31
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -2821,7 +1419,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2847,7 +1445,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2868,11 +1466,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noretry/succeeded'
+          path: /lro/putasync/noretry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2884,10 +1483,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_33
+            schema: *ref_16
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2896,7 +1495,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -2922,7 +1521,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -2943,11 +1542,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/retry/failed'
+          path: /lro/putasync/retry/failed
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2959,13 +1559,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -2974,7 +1574,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3000,7 +1600,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -3021,11 +1621,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noretry/canceled'
+          path: /lro/putasync/noretry/canceled
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3037,10 +1638,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_16
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -3049,7 +1650,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3075,7 +1676,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -3096,11 +1697,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noheader/201/200'
+          path: /lro/putasync/noheader/201/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3112,7 +1714,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_16
             header: Azure-AsyncOperation
           knownMediaType: json
           mediaTypes:
@@ -3121,7 +1723,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3147,9 +1749,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_27
         implementation: Method
         required: true
         extensions:
@@ -3168,14 +1770,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putnonresource/202/200'
+          path: /lro/putnonresource/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -3189,7 +1792,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3215,9 +1818,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_27
         implementation: Method
         required: true
         extensions:
@@ -3225,7 +1828,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: sku
-            description: Sku to put
+            description: sku to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3236,14 +1839,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putnonresourceasync/202/200'
+          path: /lro/putnonresourceasync/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -3257,7 +1861,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3283,9 +1887,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_5
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -3304,14 +1908,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putsubresource/202/200'
+          path: /lro/putsubresource/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_5
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -3325,7 +1930,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3351,9 +1956,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_5
+        schema: *ref_6
         implementation: Method
         required: true
         extensions:
@@ -3372,14 +1977,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putsubresourceasync/202/200'
+          path: /lro/putsubresourceasync/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_5
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -3393,7 +1999,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3419,15 +2025,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/accepted/200/succeeded'
+          path: /lro/delete/provisioning/202/accepted/200/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3452,10 +2059,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_41
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3464,7 +2071,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3489,15 +2096,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/deleting/200/failed'
+          path: /lro/delete/provisioning/202/deleting/200/failed
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3522,10 +2130,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_43
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3534,7 +2142,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3559,15 +2167,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/deleting/200/canceled'
+          path: /lro/delete/provisioning/202/deleting/200/canceled
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3592,10 +2201,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3604,7 +2213,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3629,15 +2238,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/204/succeeded'
+          path: /lro/delete/204/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3650,7 +2260,7 @@ operationGroups:
           - '204'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3675,15 +2285,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/202/retry/200'
+          path: /lro/delete/202/retry/200
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3707,16 +2318,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_48
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3741,15 +2352,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/202/noretry/204'
+          path: /lro/delete/202/noretry/204
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3773,16 +2385,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_50
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3807,15 +2419,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/noheader'
+          path: /lro/delete/noheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3826,7 +2439,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_16
             header: Location
           statusCodes:
           - '202'
@@ -3841,7 +2454,7 @@ operationGroups:
           - '204'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3866,15 +2479,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/noheader/202/204'
+          path: /lro/deleteasync/noheader/202/204
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3885,7 +2499,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_52
+            schema: *ref_16
             header: Location
           statusCodes:
           - '202'
@@ -3900,7 +2514,7 @@ operationGroups:
           - '204'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3925,15 +2539,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/succeeded'
+          path: /lro/deleteasync/retry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3944,19 +2559,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_54
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -3981,15 +2596,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/noretry/succeeded'
+          path: /lro/deleteasync/noretry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4000,19 +2616,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_56
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_57
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_58
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4037,15 +2653,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/failed'
+          path: /lro/deleteasync/retry/failed
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4056,19 +2673,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_59
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_60
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_61
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4093,15 +2710,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/canceled'
+          path: /lro/deleteasync/retry/canceled
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4112,19 +2730,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_62
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_63
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_64
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4149,18 +2767,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/post/payload/200'
+          path: /lro/post/payload/200
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -4173,7 +2792,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''
@@ -4187,7 +2806,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4212,7 +2831,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -4233,11 +2852,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/post/202/retry/200'
+          path: /lro/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4248,16 +2868,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_65
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_66
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4283,7 +2903,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -4304,11 +2924,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/post/202/noretry/204'
+          path: /lro/post/202/noretry/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4320,10 +2941,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_67
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_68
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -4332,7 +2953,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4358,15 +2979,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalLocationGet'
+          path: /lro/LROPostDoubleHeadersFinalLocationGet
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4383,7 +3005,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4410,15 +3032,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalAzureHeaderGet'
+          path: /lro/LROPostDoubleHeadersFinalAzureHeaderGet
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4435,7 +3058,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4462,15 +3085,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault'
+          path: /lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4487,7 +3111,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4514,7 +3138,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -4535,11 +3159,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/succeeded'
+          path: /lro/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4563,19 +3188,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_69
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_70
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_71
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4601,7 +3226,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -4622,11 +3247,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/noretry/succeeded'
+          path: /lro/postasync/noretry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4650,19 +3276,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_72
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_73
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_74
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4688,7 +3314,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -4709,11 +3335,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/failed'
+          path: /lro/postasync/retry/failed
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4724,19 +3351,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_75
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_76
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_77
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4762,7 +3389,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -4783,11 +3410,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/canceled'
+          path: /lro/postasync/retry/canceled
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4798,19 +3426,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_78
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_79
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_80
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4844,7 +3472,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -4865,11 +3493,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/put/201/creating/succeeded/200'
+          path: /lro/retryerror/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4899,7 +3528,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -4927,7 +3556,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -4948,11 +3577,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/putasync/retry/succeeded'
+          path: /lro/retryerror/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4964,13 +3594,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_81
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_82
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_83
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -4979,7 +3609,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5005,15 +3635,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/delete/provisioning/202/accepted/200/succeeded'
+          path: /lro/retryerror/delete/provisioning/202/accepted/200/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5038,10 +3669,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_84
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_85
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -5050,7 +3681,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5077,15 +3708,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/delete/202/retry/200'
+          path: /lro/retryerror/delete/202/retry/200
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5096,16 +3728,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_86
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_87
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5130,15 +3762,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/deleteasync/retry/succeeded'
+          path: /lro/retryerror/deleteasync/retry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5149,19 +3782,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_88
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_89
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_90
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5186,7 +3819,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5207,11 +3840,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/post/202/retry/200'
+          path: /lro/retryerror/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5222,16 +3856,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_91
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_92
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5257,7 +3891,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5278,11 +3912,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/postasync/retry/succeeded'
+          path: /lro/retryerror/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5293,19 +3928,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_93
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_94
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_95
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5339,7 +3974,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5360,11 +3995,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/400'
+          path: /lro/nonretryerror/put/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5394,7 +4030,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5420,7 +4056,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5441,11 +4077,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/201/creating/400'
+          path: /lro/nonretryerror/put/201/creating/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5475,7 +4112,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5501,7 +4138,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5522,11 +4159,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/201/creating/400/invalidjson'
+          path: /lro/nonretryerror/put/201/creating/400/invalidjson
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5556,7 +4194,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5582,7 +4220,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5603,11 +4241,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/putasync/retry/400'
+          path: /lro/nonretryerror/putasync/retry/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5619,13 +4258,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_96
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_97
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_98
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -5634,7 +4273,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5660,15 +4299,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/delete/400'
+          path: /lro/nonretryerror/delete/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5679,16 +4319,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_99
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_100
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5713,15 +4353,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/delete/202/retry/400'
+          path: /lro/nonretryerror/delete/202/retry/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5732,16 +4373,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_101
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_102
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5766,15 +4407,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/deleteasync/retry/400'
+          path: /lro/nonretryerror/deleteasync/retry/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5785,19 +4427,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_103
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_104
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_105
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5822,7 +4464,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5843,11 +4485,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/post/400'
+          path: /lro/nonretryerror/post/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5858,16 +4501,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_106
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_107
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5893,7 +4536,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5914,11 +4557,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/post/202/retry/400'
+          path: /lro/nonretryerror/post/202/retry/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5929,16 +4573,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_108
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_109
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -5964,7 +4608,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -5985,11 +4629,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/postasync/retry/400'
+          path: /lro/nonretryerror/postasync/retry/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6000,19 +4645,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_110
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_111
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_112
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6038,7 +4683,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6059,11 +4704,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/put/201/noprovisioningstatepayload'
+          path: /lro/error/put/201/noprovisioningstatepayload
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6093,7 +4739,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6119,7 +4765,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6140,11 +4786,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/nostatus'
+          path: /lro/error/putasync/retry/nostatus
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6156,13 +4803,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_113
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_114
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_115
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6171,7 +4818,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6197,7 +4844,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6218,11 +4865,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/nostatuspayload'
+          path: /lro/error/putasync/retry/nostatuspayload
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6234,13 +4882,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_116
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_117
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_118
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6249,7 +4897,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6275,15 +4923,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/delete/204/nolocation'
+          path: /lro/error/delete/204/nolocation
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6296,7 +4945,7 @@ operationGroups:
           - '204'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6321,15 +4970,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/nostatus'
+          path: /lro/error/deleteasync/retry/nostatus
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6340,19 +4990,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_119
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_120
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_121
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6377,7 +5027,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6398,11 +5048,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/post/202/nolocation'
+          path: /lro/error/post/202/nolocation
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6413,16 +5064,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_122
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_123
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6448,7 +5099,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6469,11 +5120,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/nopayload'
+          path: /lro/error/postasync/retry/nopayload
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6484,19 +5136,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_124
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_125
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_126
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6522,7 +5174,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6543,11 +5195,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/put/200/invalidjson'
+          path: /lro/error/put/200/invalidjson
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6573,7 +5226,7 @@ operationGroups:
           - '204'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6599,7 +5252,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6620,11 +5273,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/invalidheader'
+          path: /lro/error/putasync/retry/invalidheader
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6636,13 +5290,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_127
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_128
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_129
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6651,7 +5305,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6677,7 +5331,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6698,11 +5352,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/invalidjsonpolling'
+          path: /lro/error/putasync/retry/invalidjsonpolling
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6714,13 +5369,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_130
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_131
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_132
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6729,7 +5384,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6755,15 +5410,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/delete/202/retry/invalidheader'
+          path: /lro/error/delete/202/retry/invalidheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6774,16 +5430,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_133
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_134
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6808,15 +5464,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/invalidheader'
+          path: /lro/error/deleteasync/retry/invalidheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6827,19 +5484,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_135
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_136
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_137
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6864,15 +5521,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/invalidjsonpolling'
+          path: /lro/error/deleteasync/retry/invalidjsonpolling
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6883,19 +5541,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_138
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_139
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_140
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6920,7 +5578,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -6941,11 +5599,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/post/202/retry/invalidheader'
+          path: /lro/error/post/202/retry/invalidheader
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6956,16 +5615,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_141
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_142
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -6991,7 +5650,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -7012,11 +5671,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/invalidheader'
+          path: /lro/error/postasync/retry/invalidheader
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7027,19 +5687,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_143
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_144
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_145
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -7065,7 +5725,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -7086,11 +5746,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/invalidjsonpolling'
+          path: /lro/error/postasync/retry/invalidjsonpolling
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7101,19 +5762,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_146
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_147
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_148
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -7147,7 +5808,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -7168,11 +5829,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/putasync/retry/succeeded'
+          path: /lro/customheader/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -7184,13 +5846,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_149
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_150
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_151
+            schema: *ref_26
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -7199,7 +5861,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -7227,7 +5889,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -7248,11 +5910,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/put/201/creating/succeeded/200'
+          path: /lro/customheader/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -7282,7 +5945,7 @@ operationGroups:
           - '201'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -7310,7 +5973,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -7331,11 +5994,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/post/202/retry/200'
+          path: /lro/customheader/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7346,16 +6010,16 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_152
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_153
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''
@@ -7383,7 +6047,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_26
+      - *ref_24
       - !<!Parameter> 
         schema: *ref_1
         implementation: Method
@@ -7404,11 +6068,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/postasync/retry/succeeded'
+          path: /lro/customheader/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7419,19 +6084,19 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_154
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_155
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_156
+            schema: *ref_26
             header: Retry-After
           statusCodes:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_25
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/lro/modeler.yaml
+++ b/modelerfour/test/outputs/lro/modeler.yaml
@@ -144,6 +144,8 @@ schemas: !<!Schemas>
                 namespace: Api100
             protocol: !<!Protocols> {}
           serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
               name: properties
@@ -206,6 +208,7 @@ schemas: !<!Schemas>
             default:
               name: components·schemas·resource·properties·tags·additionalproperties
               description: MISSING·SCHEMA-DESCRIPTION-STRING
+              header: Location
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -309,7 +312,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_40
+  - !<!ObjectSchema> &ref_29
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -492,6 +495,8 @@ schemas: !<!Schemas>
                 namespace: Api100
             protocol: !<!Protocols> {}
           serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
               name: properties
@@ -687,7 +692,7 @@ schemas: !<!Schemas>
   - *ref_20
   numbers:
   - *ref_24
-  - !<!NumberSchema> &ref_31
+  - !<!NumberSchema> &ref_28
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -696,546 +701,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: paths·lro-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_36
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-retry-failed·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_42
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_44
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_46
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_48
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-202-retry-200·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_50
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-202-noretry-204·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_55
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_58
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_61
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-failed·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_64
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_66
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-post-202-retry-200·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_68
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-post-202-noretry-204·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_71
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_74
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-noretry-succeeded·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_77
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-failed·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_80
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-canceled·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_83
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_85
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_87
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_90
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_92
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_95
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_98
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_100
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-delete-400·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_102
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_105
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_107
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-post-400·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_109
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_112
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_115
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_118
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_121
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_123
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-post-202-nolocation·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_126
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_129
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_132
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_134
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_137
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_140
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_142
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_145
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_148
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_151
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_153
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-customheader-post-202-retry-200·post·responses·202·headers·retry_after·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_156
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·retry_after·schema
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
         header: Retry-After
     protocol: !<!Protocols> {}
@@ -1253,912 +718,10 @@ schemas: !<!Schemas>
   - *ref_4
   - *ref_5
   - *ref_10
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-put-noheader-202-200·put·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-retry-succeeded·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-noretry-succeeded·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-noretry-succeeded·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-retry-failed·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-retry-failed·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-noretry-canceled·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-noretry-canceled·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-putasync-noheader-201-200·put·responses·201·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
   - *ref_11
   - *ref_12
   - *ref_13
   - *ref_14
-  - !<!StringSchema> &ref_41
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_43
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-provisioning-202-deleting-200-failed·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_45
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-provisioning-202-deleting-200-canceled·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-202-retry-200·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_49
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-202-noretry-204·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_51
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-delete-noheader·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_52
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-noheader-202-204·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_53
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_54
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-succeeded·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_56
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_57
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-noretry-succeeded·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_59
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-failed·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_60
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-failed·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_62
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_63
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-deleteasync-retry-canceled·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_65
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-post-202-retry-200·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_67
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-post-202-noretry-204·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_69
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_70
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-succeeded·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_72
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-noretry-succeeded·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_73
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-noretry-succeeded·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_75
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-failed·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_76
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-failed·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_78
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-canceled·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_79
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-postasync-retry-canceled·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_81
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_82
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-putasync-retry-succeeded·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_84
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-delete-provisioning-202-accepted-200-succeeded·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_86
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-delete-202-retry-200·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_88
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_89
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-deleteasync-retry-succeeded·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_91
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-post-202-retry-200·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_93
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_94
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-retryerror-postasync-retry-succeeded·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_96
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_97
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-putasync-retry-400·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_99
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-delete-400·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_101
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-delete-202-retry-400·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_103
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_104
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-deleteasync-retry-400·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_106
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-post-400·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_108
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-post-202-retry-400·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_110
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_111
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-nonretryerror-postasync-retry-400·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_113
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_114
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-nostatus·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_116
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_117
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-nostatuspayload·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_119
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_120
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-nostatus·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_122
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-post-202-nolocation·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_124
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_125
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-nopayload·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_127
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_128
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-invalidheader·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_130
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_131
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-putasync-retry-invalidjsonpolling·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_133
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-delete-202-retry-invalidheader·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_135
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_136
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-invalidheader·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_138
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_139
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-deleteasync-retry-invalidjsonpolling·delete·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_141
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-post-202-retry-invalidheader·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_143
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_144
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-invalidheader·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_146
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_147
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-error-postasync-retry-invalidjsonpolling·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_149
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_150
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-customheader-putasync-retry-succeeded·put·responses·200·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_152
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-customheader-post-202-retry-200·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_154
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·azure_asyncoperation·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_155
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·lro-customheader-postasync-retry-succeeded·post·responses·202·headers·location·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
   - *ref_18
 globalParameters:
 - !<!Parameter> &ref_27
@@ -2172,7 +735,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Long-running Operation for AutoRest
   title: lro
@@ -2207,11 +770,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/succeeded'
+          path: /lro/put/200/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2284,11 +848,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/succeeded/nostate'
+          path: /lro/put/200/succeeded/nostate
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2352,11 +917,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/202/retry/200'
+          path: /lro/put/202/retry/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2420,11 +986,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/201/creating/succeeded/200'
+          path: /lro/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2501,11 +1068,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/updating/succeeded/200'
+          path: /lro/put/200/updating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2569,11 +1137,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/201/created/failed/200'
+          path: /lro/put/201/created/failed/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2650,11 +1219,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/accepted/canceled/200'
+          path: /lro/put/200/accepted/canceled/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2718,11 +1288,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/noheader/202/200'
+          path: /lro/put/noheader/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2734,7 +1305,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_28
+            schema: *ref_2
             header: location
           knownMediaType: json
           mediaTypes:
@@ -2790,11 +1361,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/retry/succeeded'
+          path: /lro/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2806,13 +1378,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_29
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_30
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_31
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -2868,11 +1440,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noretry/succeeded'
+          path: /lro/putasync/noretry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2884,10 +1457,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_33
+            schema: *ref_2
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2943,11 +1516,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/retry/failed'
+          path: /lro/putasync/retry/failed
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -2959,13 +1533,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3021,11 +1595,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noretry/canceled'
+          path: /lro/putasync/noretry/canceled
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -3037,10 +1612,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_2
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -3096,11 +1671,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noheader/201/200'
+          path: /lro/putasync/noheader/201/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -3112,7 +1688,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_2
             header: Azure-AsyncOperation
           knownMediaType: json
           mediaTypes:
@@ -3149,7 +1725,7 @@ operationGroups:
       parameters:
       - *ref_27
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -3168,14 +1744,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putnonresource/202/200'
+          path: /lro/putnonresource/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3217,7 +1794,7 @@ operationGroups:
       parameters:
       - *ref_27
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -3225,7 +1802,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: sku
-            description: Sku to put
+            description: sku to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3236,14 +1813,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putnonresourceasync/202/200'
+          path: /lro/putnonresourceasync/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3304,11 +1882,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putsubresource/202/200'
+          path: /lro/putsubresource/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_16
@@ -3372,11 +1951,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putsubresourceasync/202/200'
+          path: /lro/putsubresourceasync/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_16
@@ -3426,8 +2006,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/accepted/200/succeeded'
+          path: /lro/delete/provisioning/202/accepted/200/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -3452,10 +2033,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_41
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3496,8 +2077,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/deleting/200/failed'
+          path: /lro/delete/provisioning/202/deleting/200/failed
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -3522,10 +2104,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_43
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3566,8 +2148,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/deleting/200/canceled'
+          path: /lro/delete/provisioning/202/deleting/200/canceled
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -3592,10 +2175,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3636,8 +2219,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/204/succeeded'
+          path: /lro/delete/204/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3682,8 +2266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/202/retry/200'
+          path: /lro/delete/202/retry/200
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -3707,10 +2292,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_48
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -3748,8 +2333,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/202/noretry/204'
+          path: /lro/delete/202/noretry/204
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -3773,10 +2359,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_50
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -3814,8 +2400,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/noheader'
+          path: /lro/delete/noheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3826,7 +2413,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_2
             header: Location
           statusCodes:
           - '202'
@@ -3873,8 +2460,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/noheader/202/204'
+          path: /lro/deleteasync/noheader/202/204
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3885,7 +2473,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_52
+            schema: *ref_2
             header: Location
           statusCodes:
           - '202'
@@ -3932,8 +2520,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/succeeded'
+          path: /lro/deleteasync/retry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3944,13 +2533,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_54
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -3988,8 +2577,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/noretry/succeeded'
+          path: /lro/deleteasync/noretry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4000,13 +2590,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_56
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_57
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_58
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4044,8 +2634,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/failed'
+          path: /lro/deleteasync/retry/failed
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4056,13 +2647,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_59
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_60
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_61
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4100,8 +2691,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/canceled'
+          path: /lro/deleteasync/retry/canceled
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4112,13 +2704,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_62
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_63
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_64
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4156,11 +2748,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/post/payload/200'
+          path: /lro/post/payload/200
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4173,7 +2766,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4233,11 +2826,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/post/202/retry/200'
+          path: /lro/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4248,10 +2842,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_65
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_66
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4304,11 +2898,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/post/202/noretry/204'
+          path: /lro/post/202/noretry/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -4320,10 +2915,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_67
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_68
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -4365,8 +2960,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalLocationGet'
+          path: /lro/LROPostDoubleHeadersFinalLocationGet
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -4417,8 +3013,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalAzureHeaderGet'
+          path: /lro/LROPostDoubleHeadersFinalAzureHeaderGet
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -4469,8 +3066,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault'
+          path: /lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -4535,11 +3133,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/succeeded'
+          path: /lro/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -4563,13 +3162,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_69
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_70
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_71
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4622,11 +3221,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/noretry/succeeded'
+          path: /lro/postasync/noretry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -4650,13 +3250,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_72
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_73
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_74
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4709,11 +3309,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/failed'
+          path: /lro/postasync/retry/failed
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4724,13 +3325,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_75
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_76
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_77
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4783,11 +3384,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/canceled'
+          path: /lro/postasync/retry/canceled
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4798,13 +3400,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_78
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_79
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_80
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4865,11 +3467,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/put/201/creating/succeeded/200'
+          path: /lro/retryerror/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -4948,11 +3551,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/putasync/retry/succeeded'
+          path: /lro/retryerror/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -4964,13 +3568,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_81
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_82
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_83
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -5012,8 +3616,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/delete/provisioning/202/accepted/200/succeeded'
+          path: /lro/retryerror/delete/provisioning/202/accepted/200/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -5038,10 +3643,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_84
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_85
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -5084,8 +3689,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/delete/202/retry/200'
+          path: /lro/retryerror/delete/202/retry/200
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5096,10 +3702,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_86
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_87
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5137,8 +3743,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/deleteasync/retry/succeeded'
+          path: /lro/retryerror/deleteasync/retry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5149,13 +3756,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_88
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_89
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_90
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5207,11 +3814,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/post/202/retry/200'
+          path: /lro/retryerror/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5222,10 +3830,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_91
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_92
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5278,11 +3886,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/postasync/retry/succeeded'
+          path: /lro/retryerror/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5293,13 +3902,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_93
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_94
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_95
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5360,11 +3969,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/400'
+          path: /lro/nonretryerror/put/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -5441,11 +4051,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/201/creating/400'
+          path: /lro/nonretryerror/put/201/creating/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -5522,11 +4133,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/201/creating/400/invalidjson'
+          path: /lro/nonretryerror/put/201/creating/400/invalidjson
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -5603,11 +4215,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/putasync/retry/400'
+          path: /lro/nonretryerror/putasync/retry/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -5619,13 +4232,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_96
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_97
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_98
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -5667,8 +4280,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/delete/400'
+          path: /lro/nonretryerror/delete/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5679,10 +4293,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_99
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_100
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5720,8 +4334,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/delete/202/retry/400'
+          path: /lro/nonretryerror/delete/202/retry/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5732,10 +4347,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_101
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_102
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5773,8 +4388,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/deleteasync/retry/400'
+          path: /lro/nonretryerror/deleteasync/retry/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5785,13 +4401,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_103
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_104
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_105
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5843,11 +4459,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/post/400'
+          path: /lro/nonretryerror/post/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5858,10 +4475,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_106
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_107
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5914,11 +4531,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/post/202/retry/400'
+          path: /lro/nonretryerror/post/202/retry/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5929,10 +4547,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_108
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_109
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5985,11 +4603,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/postasync/retry/400'
+          path: /lro/nonretryerror/postasync/retry/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6000,13 +4619,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_110
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_111
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_112
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6059,11 +4678,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/put/201/noprovisioningstatepayload'
+          path: /lro/error/put/201/noprovisioningstatepayload
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -6140,11 +4760,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/nostatus'
+          path: /lro/error/putasync/retry/nostatus
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -6156,13 +4777,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_113
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_114
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_115
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6218,11 +4839,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/nostatuspayload'
+          path: /lro/error/putasync/retry/nostatuspayload
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -6234,13 +4856,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_116
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_117
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_118
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6282,8 +4904,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/delete/204/nolocation'
+          path: /lro/error/delete/204/nolocation
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6328,8 +4951,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/nostatus'
+          path: /lro/error/deleteasync/retry/nostatus
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6340,13 +4964,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_119
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_120
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_121
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6398,11 +5022,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/post/202/nolocation'
+          path: /lro/error/post/202/nolocation
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6413,10 +5038,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_122
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_123
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6469,11 +5094,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/nopayload'
+          path: /lro/error/postasync/retry/nopayload
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6484,13 +5110,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_124
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_125
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_126
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6543,11 +5169,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/put/200/invalidjson'
+          path: /lro/error/put/200/invalidjson
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -6620,11 +5247,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/invalidheader'
+          path: /lro/error/putasync/retry/invalidheader
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -6636,13 +5264,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_127
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_128
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_129
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6698,11 +5326,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/invalidjsonpolling'
+          path: /lro/error/putasync/retry/invalidjsonpolling
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -6714,13 +5343,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_130
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_131
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_132
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6762,8 +5391,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/delete/202/retry/invalidheader'
+          path: /lro/error/delete/202/retry/invalidheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6774,10 +5404,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_133
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_134
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6815,8 +5445,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/invalidheader'
+          path: /lro/error/deleteasync/retry/invalidheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6827,13 +5458,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_135
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_136
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_137
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6871,8 +5502,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/invalidjsonpolling'
+          path: /lro/error/deleteasync/retry/invalidjsonpolling
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6883,13 +5515,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_138
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_139
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_140
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6941,11 +5573,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/post/202/retry/invalidheader'
+          path: /lro/error/post/202/retry/invalidheader
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6956,10 +5589,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_141
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_142
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -7012,11 +5645,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/invalidheader'
+          path: /lro/error/postasync/retry/invalidheader
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7027,13 +5661,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_143
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_144
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_145
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -7086,11 +5720,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/invalidjsonpolling'
+          path: /lro/error/postasync/retry/invalidjsonpolling
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7101,13 +5736,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_146
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_147
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_148
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -7168,11 +5803,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/putasync/retry/succeeded'
+          path: /lro/customheader/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -7184,13 +5820,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_149
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_150
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_151
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -7248,11 +5884,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/put/201/creating/succeeded/200'
+          path: /lro/customheader/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_8
@@ -7331,11 +5968,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/post/202/retry/200'
+          path: /lro/customheader/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7346,10 +5984,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_152
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_153
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -7404,11 +6042,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/postasync/retry/succeeded'
+          path: /lro/customheader/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7419,13 +6058,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_154
+            schema: *ref_2
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_155
+            schema: *ref_2
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_156
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'

--- a/modelerfour/test/outputs/lro/namer.yaml
+++ b/modelerfour/test/outputs/lro/namer.yaml
@@ -144,6 +144,8 @@ schemas: !<!Schemas>
                 namespace: Api100
             protocol: !<!Protocols> {}
           serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
               name: properties
@@ -206,6 +208,7 @@ schemas: !<!Schemas>
             default:
               name: string
               description: MISSING·SCHEMA-DESCRIPTION-STRING
+              header: Location
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -309,7 +312,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_40
+  - !<!ObjectSchema> &ref_29
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -492,6 +495,8 @@ schemas: !<!Schemas>
                 namespace: Api100
             protocol: !<!Protocols> {}
           serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
               name: properties
@@ -687,547 +692,7 @@ schemas: !<!Schemas>
   - *ref_8
   numbers:
   - *ref_9
-  - !<!NumberSchema> &ref_31
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_36
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_42
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_44
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_46
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_48
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_50
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_55
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_58
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_61
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_64
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_66
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_68
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_71
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_74
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_77
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_80
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_83
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_85
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_87
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_90
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_92
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_95
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_98
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_100
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_102
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_105
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_107
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_109
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_112
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_115
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_118
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_121
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_123
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_126
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_129
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_132
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_134
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_137
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_140
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_142
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_145
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_148
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_151
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_153
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-        header: Retry-After
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_156
+  - !<!NumberSchema> &ref_28
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -1253,912 +718,10 @@ schemas: !<!Schemas>
   - *ref_18
   - *ref_19
   - *ref_20
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
   - *ref_21
   - *ref_22
   - *ref_23
   - *ref_24
-  - !<!StringSchema> &ref_41
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_43
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_45
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_49
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_51
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_52
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_53
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_54
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_56
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_57
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_59
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_60
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_62
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_63
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_65
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_67
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_69
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_70
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_72
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_73
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_75
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_76
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_78
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_79
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_81
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_82
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_84
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_86
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_88
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_89
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_91
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_93
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_94
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_96
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_97
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_99
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_101
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_103
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_104
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_106
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_108
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_110
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_111
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_113
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_114
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_116
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_117
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_119
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_120
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_122
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_124
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_125
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_127
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_128
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_130
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_131
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_133
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_135
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_136
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_138
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_139
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_141
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_143
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_144
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_146
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_147
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_149
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_150
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_152
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_154
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Azure-AsyncOperation
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_155
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Location
-    protocol: !<!Protocols> {}
   - *ref_25
 globalParameters:
 - !<!Parameter> &ref_26
@@ -2172,7 +735,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Long-running Operation for AutoRest
   title: lro
@@ -2207,11 +770,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/succeeded'
+          path: /lro/put/200/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2284,11 +848,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/succeeded/nostate'
+          path: /lro/put/200/succeeded/nostate
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2352,11 +917,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/202/retry/200'
+          path: /lro/put/202/retry/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2420,11 +986,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/201/creating/succeeded/200'
+          path: /lro/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2501,11 +1068,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/updating/succeeded/200'
+          path: /lro/put/200/updating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2569,11 +1137,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/201/created/failed/200'
+          path: /lro/put/201/created/failed/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2650,11 +1219,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/200/accepted/canceled/200'
+          path: /lro/put/200/accepted/canceled/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2718,11 +1288,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/put/noheader/202/200'
+          path: /lro/put/noheader/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2734,7 +1305,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_28
+            schema: *ref_16
             header: location
           knownMediaType: json
           mediaTypes:
@@ -2790,11 +1361,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/retry/succeeded'
+          path: /lro/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2806,13 +1378,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_29
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_30
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_31
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -2868,11 +1440,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noretry/succeeded'
+          path: /lro/putasync/noretry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2884,10 +1457,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_32
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_33
+            schema: *ref_16
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -2943,11 +1516,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/retry/failed'
+          path: /lro/putasync/retry/failed
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -2959,13 +1533,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_34
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_35
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_36
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3021,11 +1595,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noretry/canceled'
+          path: /lro/putasync/noretry/canceled
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3037,10 +1612,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_37
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_38
+            schema: *ref_16
             header: Location
           knownMediaType: json
           mediaTypes:
@@ -3096,11 +1671,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putasync/noheader/201/200'
+          path: /lro/putasync/noheader/201/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3112,7 +1688,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_39
+            schema: *ref_16
             header: Azure-AsyncOperation
           knownMediaType: json
           mediaTypes:
@@ -3149,7 +1725,7 @@ operationGroups:
       parameters:
       - *ref_26
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -3168,14 +1744,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putnonresource/202/200'
+          path: /lro/putnonresource/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3217,7 +1794,7 @@ operationGroups:
       parameters:
       - *ref_26
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -3225,7 +1802,7 @@ operationGroups:
         language: !<!Languages> 
           default:
             name: sku
-            description: Sku to put
+            description: sku to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: body
@@ -3236,14 +1813,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putnonresourceasync/202/200'
+          path: /lro/putnonresourceasync/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -3304,11 +1882,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putsubresource/202/200'
+          path: /lro/putsubresource/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -3372,11 +1951,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/putsubresourceasync/202/200'
+          path: /lro/putsubresourceasync/202/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5
@@ -3426,8 +2006,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/accepted/200/succeeded'
+          path: /lro/delete/provisioning/202/accepted/200/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3452,10 +2033,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_41
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_42
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3496,8 +2077,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/deleting/200/failed'
+          path: /lro/delete/provisioning/202/deleting/200/failed
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3522,10 +2104,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_43
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_44
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3566,8 +2148,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/provisioning/202/deleting/200/canceled'
+          path: /lro/delete/provisioning/202/deleting/200/canceled
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3592,10 +2175,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_45
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_46
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -3636,8 +2219,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/204/succeeded'
+          path: /lro/delete/204/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3682,8 +2266,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/202/retry/200'
+          path: /lro/delete/202/retry/200
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3707,10 +2292,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_47
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_48
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -3748,8 +2333,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/202/noretry/204'
+          path: /lro/delete/202/noretry/204
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -3773,10 +2359,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_49
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_50
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -3814,8 +2400,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/delete/noheader'
+          path: /lro/delete/noheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3826,7 +2413,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_51
+            schema: *ref_16
             header: Location
           statusCodes:
           - '202'
@@ -3873,8 +2460,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/noheader/202/204'
+          path: /lro/deleteasync/noheader/202/204
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3885,7 +2473,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_52
+            schema: *ref_16
             header: Location
           statusCodes:
           - '202'
@@ -3932,8 +2520,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/succeeded'
+          path: /lro/deleteasync/retry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3944,13 +2533,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_53
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_54
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_55
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -3988,8 +2577,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/noretry/succeeded'
+          path: /lro/deleteasync/noretry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4000,13 +2590,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_56
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_57
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_58
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4044,8 +2634,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/failed'
+          path: /lro/deleteasync/retry/failed
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4056,13 +2647,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_59
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_60
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_61
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4100,8 +2691,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/deleteasync/retry/canceled'
+          path: /lro/deleteasync/retry/canceled
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4112,13 +2704,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_62
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_63
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_64
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4156,11 +2748,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/post/payload/200'
+          path: /lro/post/payload/200
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4173,7 +2766,7 @@ operationGroups:
           statusCodes:
           - '200'
     - !<!SchemaResponse> 
-      schema: *ref_40
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -4233,11 +2826,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/post/202/retry/200'
+          path: /lro/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4248,10 +2842,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_65
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_66
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4304,11 +2898,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/post/202/noretry/204'
+          path: /lro/post/202/noretry/204
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4320,10 +2915,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_67
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_68
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -4365,8 +2960,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalLocationGet'
+          path: /lro/LROPostDoubleHeadersFinalLocationGet
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4417,8 +3013,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalAzureHeaderGet'
+          path: /lro/LROPostDoubleHeadersFinalAzureHeaderGet
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4469,8 +3066,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault'
+          path: /lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4535,11 +3133,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/succeeded'
+          path: /lro/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4563,13 +3162,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_69
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_70
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_71
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4622,11 +3221,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/noretry/succeeded'
+          path: /lro/postasync/noretry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4650,13 +3250,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_72
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_73
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_74
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4709,11 +3309,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/failed'
+          path: /lro/postasync/retry/failed
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4724,13 +3325,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_75
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_76
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_77
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4783,11 +3384,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/postasync/retry/canceled'
+          path: /lro/postasync/retry/canceled
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4798,13 +3400,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_78
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_79
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_80
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -4865,11 +3467,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/put/201/creating/succeeded/200'
+          path: /lro/retryerror/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4948,11 +3551,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/putasync/retry/succeeded'
+          path: /lro/retryerror/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -4964,13 +3568,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_81
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_82
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_83
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -5012,8 +3616,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/delete/provisioning/202/accepted/200/succeeded'
+          path: /lro/retryerror/delete/provisioning/202/accepted/200/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5038,10 +3643,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_84
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_85
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -5084,8 +3689,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/delete/202/retry/200'
+          path: /lro/retryerror/delete/202/retry/200
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5096,10 +3702,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_86
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_87
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5137,8 +3743,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/retryerror/deleteasync/retry/succeeded'
+          path: /lro/retryerror/deleteasync/retry/succeeded
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5149,13 +3756,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_88
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_89
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_90
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5207,11 +3814,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/post/202/retry/200'
+          path: /lro/retryerror/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5222,10 +3830,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_91
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_92
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5278,11 +3886,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/retryerror/postasync/retry/succeeded'
+          path: /lro/retryerror/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5293,13 +3902,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_93
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_94
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_95
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5360,11 +3969,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/400'
+          path: /lro/nonretryerror/put/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5441,11 +4051,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/201/creating/400'
+          path: /lro/nonretryerror/put/201/creating/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5522,11 +4133,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/put/201/creating/400/invalidjson'
+          path: /lro/nonretryerror/put/201/creating/400/invalidjson
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5603,11 +4215,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/putasync/retry/400'
+          path: /lro/nonretryerror/putasync/retry/400
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -5619,13 +4232,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_96
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_97
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_98
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -5667,8 +4280,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/delete/400'
+          path: /lro/nonretryerror/delete/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5679,10 +4293,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_99
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_100
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5720,8 +4334,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/delete/202/retry/400'
+          path: /lro/nonretryerror/delete/202/retry/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5732,10 +4347,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_101
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_102
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5773,8 +4388,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/nonretryerror/deleteasync/retry/400'
+          path: /lro/nonretryerror/deleteasync/retry/400
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5785,13 +4401,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_103
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_104
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_105
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5843,11 +4459,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/post/400'
+          path: /lro/nonretryerror/post/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5858,10 +4475,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_106
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_107
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5914,11 +4531,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/post/202/retry/400'
+          path: /lro/nonretryerror/post/202/retry/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -5929,10 +4547,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_108
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_109
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -5985,11 +4603,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/nonretryerror/postasync/retry/400'
+          path: /lro/nonretryerror/postasync/retry/400
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6000,13 +4619,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_110
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_111
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_112
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6059,11 +4678,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/put/201/noprovisioningstatepayload'
+          path: /lro/error/put/201/noprovisioningstatepayload
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6140,11 +4760,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/nostatus'
+          path: /lro/error/putasync/retry/nostatus
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6156,13 +4777,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_113
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_114
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_115
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6218,11 +4839,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/nostatuspayload'
+          path: /lro/error/putasync/retry/nostatuspayload
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6234,13 +4856,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_116
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_117
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_118
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6282,8 +4904,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/delete/204/nolocation'
+          path: /lro/error/delete/204/nolocation
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6328,8 +4951,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/nostatus'
+          path: /lro/error/deleteasync/retry/nostatus
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6340,13 +4964,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_119
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_120
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_121
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6398,11 +5022,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/post/202/nolocation'
+          path: /lro/error/post/202/nolocation
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6413,10 +5038,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_122
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_123
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6469,11 +5094,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/nopayload'
+          path: /lro/error/postasync/retry/nopayload
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6484,13 +5110,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_124
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_125
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_126
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6543,11 +5169,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/put/200/invalidjson'
+          path: /lro/error/put/200/invalidjson
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6620,11 +5247,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/invalidheader'
+          path: /lro/error/putasync/retry/invalidheader
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6636,13 +5264,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_127
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_128
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_129
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6698,11 +5326,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/putasync/retry/invalidjsonpolling'
+          path: /lro/error/putasync/retry/invalidjsonpolling
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -6714,13 +5343,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_130
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_131
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_132
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -6762,8 +5391,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/delete/202/retry/invalidheader'
+          path: /lro/error/delete/202/retry/invalidheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6774,10 +5404,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_133
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_134
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6815,8 +5445,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/invalidheader'
+          path: /lro/error/deleteasync/retry/invalidheader
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6827,13 +5458,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_135
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_136
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_137
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6871,8 +5502,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/lro/error/deleteasync/retry/invalidjsonpolling'
+          path: /lro/error/deleteasync/retry/invalidjsonpolling
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6883,13 +5515,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_138
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_139
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_140
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -6941,11 +5573,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/post/202/retry/invalidheader'
+          path: /lro/error/post/202/retry/invalidheader
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -6956,10 +5589,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_141
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_142
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -7012,11 +5645,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/invalidheader'
+          path: /lro/error/postasync/retry/invalidheader
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7027,13 +5661,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_143
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_144
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_145
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -7086,11 +5720,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/error/postasync/retry/invalidjsonpolling'
+          path: /lro/error/postasync/retry/invalidjsonpolling
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7101,13 +5736,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_146
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_147
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_148
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -7168,11 +5803,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/putasync/retry/succeeded'
+          path: /lro/customheader/putasync/retry/succeeded
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -7184,13 +5820,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_149
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_150
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_151
+            schema: *ref_28
             header: Retry-After
           knownMediaType: json
           mediaTypes:
@@ -7248,11 +5884,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/put/201/creating/succeeded/200'
+          path: /lro/customheader/put/201/creating/succeeded/200
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -7331,11 +5968,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/post/202/retry/200'
+          path: /lro/customheader/post/202/retry/200
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7346,10 +5984,10 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_152
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_153
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'
@@ -7404,11 +6042,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/lro/customheader/postasync/retry/succeeded'
+          path: /lro/customheader/postasync/retry/succeeded
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -7419,13 +6058,13 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_154
+            schema: *ref_16
             header: Azure-AsyncOperation
           - !<!HttpHeader> 
-            schema: *ref_155
+            schema: *ref_16
             header: Location
           - !<!HttpHeader> 
-            schema: *ref_156
+            schema: *ref_28
             header: Retry-After
           statusCodes:
           - '202'

--- a/modelerfour/test/outputs/model-flattening/flattened.yaml
+++ b/modelerfour/test/outputs/model-flattening/flattened.yaml
@@ -20,168 +20,159 @@ schemas: !<!Schemas>
           - *ref_0
         properties:
         - !<!Property> 
-          schema: !<!ObjectSchema> &ref_3
-            type: object
+          schema: !<!StringSchema> &ref_3
+            type: string
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            properties:
-            - !<!Property> 
-              schema: !<!StringSchema> &ref_24
-                type: string
-                apiVersions:
-                - !<!ApiVersion> 
-                  version: 1.0.0
-                language: !<!Languages> 
-                  default:
-                    name: FlattenedProduct-properties-p.name
-                    description: MISSING·SCHEMA-DESCRIPTION-STRING
-                protocol: !<!Protocols> {}
-              serializedName: p.name
-              language: !<!Languages> 
-                default:
-                  name: p.name
-                  description: MISSING·SCHEMA-DESCRIPTION-STRING
-              protocol: !<!Protocols> {}
-            - !<!Property> 
-              schema: !<!StringSchema> &ref_25
-                type: string
-                apiVersions:
-                - !<!ApiVersion> 
-                  version: 1.0.0
-                language: !<!Languages> 
-                  default:
-                    name: FlattenedProduct-properties-type
-                    description: MISSING·SCHEMA-DESCRIPTION-STRING
-                protocol: !<!Protocols> {}
-              serializedName: type
-              language: !<!Languages> 
-                default:
-                  name: type
-                  description: MISSING·SCHEMA-DESCRIPTION-STRING
-              protocol: !<!Protocols> {}
-            - !<!Property> 
-              schema: !<!SealedChoiceSchema> &ref_17
-                choices:
-                - !<!ChoiceValue> 
-                  value: Succeeded
-                  language:
-                    default:
-                      name: Succeeded
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Failed
-                  language:
-                    default:
-                      name: Failed
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: canceled
-                  language:
-                    default:
-                      name: canceled
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Accepted
-                  language:
-                    default:
-                      name: Accepted
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Creating
-                  language:
-                    default:
-                      name: Creating
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Created
-                  language:
-                    default:
-                      name: Created
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Updating
-                  language:
-                    default:
-                      name: Updating
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Updated
-                  language:
-                    default:
-                      name: Updated
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Deleting
-                  language:
-                    default:
-                      name: Deleting
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: Deleted
-                  language:
-                    default:
-                      name: Deleted
-                      description: ''
-                - !<!ChoiceValue> 
-                  value: OK
-                  language:
-                    default:
-                      name: OK
-                      description: ''
-                type: sealed-choice
-                apiVersions:
-                - !<!ApiVersion> 
-                  version: 1.0.0
-                choiceType: !<!StringSchema> &ref_6
-                  type: string
-                  language: !<!Languages> 
-                    default:
-                      name: string
-                      description: simple string
-                  protocol: !<!Protocols> {}
-                language: !<!Languages> 
-                  default:
-                    name: FlattenedProduct-properties-provisioningStateValues
-                    description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-                protocol: !<!Protocols> {}
-              readOnly: true
-              serializedName: provisioningStateValues
-              language: !<!Languages> 
-                default:
-                  name: provisioningStateValues
-                  description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-              protocol: !<!Protocols> {}
-            - !<!Property> 
-              schema: !<!StringSchema> &ref_26
-                type: string
-                apiVersions:
-                - !<!ApiVersion> 
-                  version: 1.0.0
-                language: !<!Languages> 
-                  default:
-                    name: FlattenedProduct-properties-provisioningState
-                    description: MISSING·SCHEMA-DESCRIPTION-STRING
-                protocol: !<!Protocols> {}
-              serializedName: provisioningState
-              language: !<!Languages> 
-                default:
-                  name: provisioningState
-                  description: MISSING·SCHEMA-DESCRIPTION-STRING
-              protocol: !<!Protocols> {}
-            extensions:
-              x-ms-client-flatten: true
             language: !<!Languages> 
               default:
-                name: FlattenedProduct-properties
-                description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
-                namespace: Api100
+                name: FlattenedProduct-properties-p.name
+                description: MISSING·SCHEMA-DESCRIPTION-STRING
             protocol: !<!Protocols> {}
-          serializedName: properties
+          flattenedNames:
+          - properties
+          - p.name
+          serializedName: p.name
           language: !<!Languages> 
             default:
-              name: properties
-              description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
+              name: p.name
+              description: MISSING·SCHEMA-DESCRIPTION-STRING
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: !<!StringSchema> &ref_4
+            type: string
+            apiVersions:
+            - !<!ApiVersion> 
+              version: 1.0.0
+            language: !<!Languages> 
+              default:
+                name: FlattenedProduct-properties-type
+                description: MISSING·SCHEMA-DESCRIPTION-STRING
+            protocol: !<!Protocols> {}
+          flattenedNames:
+          - properties
+          - type
+          serializedName: type
+          language: !<!Languages> 
+            default:
+              name: type
+              description: MISSING·SCHEMA-DESCRIPTION-STRING
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: !<!SealedChoiceSchema> &ref_5
+            choices:
+            - !<!ChoiceValue> 
+              value: Succeeded
+              language:
+                default:
+                  name: Succeeded
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Failed
+              language:
+                default:
+                  name: Failed
+                  description: ''
+            - !<!ChoiceValue> 
+              value: canceled
+              language:
+                default:
+                  name: canceled
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Accepted
+              language:
+                default:
+                  name: Accepted
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Creating
+              language:
+                default:
+                  name: Creating
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Created
+              language:
+                default:
+                  name: Created
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Updating
+              language:
+                default:
+                  name: Updating
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Updated
+              language:
+                default:
+                  name: Updated
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Deleting
+              language:
+                default:
+                  name: Deleting
+                  description: ''
+            - !<!ChoiceValue> 
+              value: Deleted
+              language:
+                default:
+                  name: Deleted
+                  description: ''
+            - !<!ChoiceValue> 
+              value: OK
+              language:
+                default:
+                  name: OK
+                  description: ''
+            type: sealed-choice
+            apiVersions:
+            - !<!ApiVersion> 
+              version: 1.0.0
+            choiceType: !<!StringSchema> &ref_9
+              type: string
+              language: !<!Languages> 
+                default:
+                  name: string
+                  description: simple string
+              protocol: !<!Protocols> {}
+            language: !<!Languages> 
+              default:
+                name: FlattenedProduct-properties-provisioningStateValues
+                description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+            protocol: !<!Protocols> {}
+          flattenedNames:
+          - properties
+          - provisioningStateValues
+          readOnly: true
+          serializedName: provisioningStateValues
+          language: !<!Languages> 
+            default:
+              name: provisioningStateValues
+              description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: !<!StringSchema> &ref_6
+            type: string
+            apiVersions:
+            - !<!ApiVersion> 
+              version: 1.0.0
+            language: !<!Languages> 
+              default:
+                name: FlattenedProduct-properties-provisioningState
+                description: MISSING·SCHEMA-DESCRIPTION-STRING
+            protocol: !<!Protocols> {}
+          flattenedNames:
+          - properties
+          - provisioningState
+          serializedName: provisioningState
+          language: !<!Languages> 
+            default:
+              name: provisioningState
+              description: MISSING·SCHEMA-DESCRIPTION-STRING
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -193,7 +184,7 @@ schemas: !<!Schemas>
       - *ref_1
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_18
+      schema: !<!StringSchema> &ref_20
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -211,7 +202,7 @@ schemas: !<!Schemas>
           description: Resource Id
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_19
+      schema: !<!StringSchema> &ref_21
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -229,9 +220,9 @@ schemas: !<!Schemas>
           description: Resource Type
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_11
+      schema: !<!DictionarySchema> &ref_14
         type: dictionary
-        elementType: !<!StringSchema> &ref_20
+        elementType: !<!StringSchema> &ref_22
           type: string
           apiVersions:
           - !<!ApiVersion> 
@@ -253,7 +244,7 @@ schemas: !<!Schemas>
           description: Dictionary of <components·schemas·resource·properties·tags·additionalproperties>
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_21
+      schema: !<!StringSchema> &ref_23
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -270,7 +261,7 @@ schemas: !<!Schemas>
           description: Resource Location
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_22
+      schema: !<!StringSchema> &ref_24
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -300,7 +291,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_16
+      schema: !<!NumberSchema> &ref_19
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -315,7 +306,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_23
+      schema: !<!StringSchema> &ref_25
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -346,15 +337,61 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_1
-  - *ref_3
-  - !<!ObjectSchema> &ref_4
+  - !<!ObjectSchema> 
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_27
+      schema: *ref_3
+      serializedName: p.name
+      language: !<!Languages> 
+        default:
+          name: p.name
+          description: MISSING·SCHEMA-DESCRIPTION-STRING
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_4
+      serializedName: type
+      language: !<!Languages> 
+        default:
+          name: type
+          description: MISSING·SCHEMA-DESCRIPTION-STRING
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_5
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_6
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: MISSING·SCHEMA-DESCRIPTION-STRING
+      protocol: !<!Protocols> {}
+    extensions:
+      x-ms-client-flatten: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedProduct-properties
+        description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
+        namespace: Api100
+    protocol: !<!Protocols> {}
+  - !<!ObjectSchema> &ref_7
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: !<!StringSchema> &ref_26
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -376,14 +413,14 @@ schemas: !<!Schemas>
         description: The wrapped produc.
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_13
+  - !<!ObjectSchema> &ref_16
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: *ref_4
+      schema: *ref_7
       serializedName: property
       language: !<!Languages> 
         default:
@@ -411,7 +448,7 @@ schemas: !<!Schemas>
           description: Flattened product.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_14
+      schema: !<!ArraySchema> &ref_17
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -429,7 +466,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_12
+      schema: !<!DictionarySchema> &ref_15
         type: dictionary
         elementType: *ref_1
         language: !<!Languages> 
@@ -449,33 +486,33 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_5
+  - !<!ObjectSchema> &ref_8
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     children: !<!Relations> 
       all:
-      - !<!ObjectSchema> &ref_9
+      - !<!ObjectSchema> &ref_12
         type: object
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
         parents: !<!Relations> 
           all:
-          - *ref_5
+          - *ref_8
           immediate:
-          - *ref_5
+          - *ref_8
         properties:
         - !<!Property> 
-          schema: !<!ObjectSchema> &ref_10
+          schema: !<!ObjectSchema> &ref_13
             type: object
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
             properties:
             - !<!Property> 
-              schema: !<!StringSchema> &ref_30
+              schema: !<!StringSchema> &ref_29
                 type: string
                 apiVersions:
                 - !<!ApiVersion> 
@@ -493,7 +530,7 @@ schemas: !<!Schemas>
                   description: Display name of product.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!ConstantSchema> &ref_15
+              schema: !<!ConstantSchema> &ref_18
                 type: constant
                 apiVersions:
                 - !<!ApiVersion> 
@@ -504,7 +541,7 @@ schemas: !<!Schemas>
                     default:
                       name: ''
                       description: ''
-                valueType: *ref_6
+                valueType: *ref_9
                 language: !<!Languages> 
                   default:
                     name: capacity
@@ -518,26 +555,26 @@ schemas: !<!Schemas>
                   description: 'Capacity of product. For example, 4 people.'
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!ObjectSchema> &ref_7
+              schema: !<!ObjectSchema> &ref_10
                 type: object
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
                 parents: !<!Relations> 
                   all:
-                  - !<!ObjectSchema> &ref_8
+                  - !<!ObjectSchema> &ref_11
                     type: object
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 1.0.0
                     children: !<!Relations> 
                       all:
-                      - *ref_7
+                      - *ref_10
                       immediate:
-                      - *ref_7
+                      - *ref_10
                     properties:
                     - !<!Property> 
-                      schema: !<!StringSchema> &ref_31
+                      schema: !<!StringSchema> &ref_30
                         type: string
                         apiVersions:
                         - !<!ApiVersion> 
@@ -560,10 +597,10 @@ schemas: !<!Schemas>
                         namespace: Api100
                     protocol: !<!Protocols> {}
                   immediate:
-                  - *ref_8
+                  - *ref_11
                 properties:
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_32
+                  schema: !<!StringSchema> &ref_31
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -611,10 +648,10 @@ schemas: !<!Schemas>
             namespace: Api100
         protocol: !<!Protocols> {}
       immediate:
-      - *ref_9
+      - *ref_12
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_28
+      schema: !<!StringSchema> &ref_27
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -632,7 +669,7 @@ schemas: !<!Schemas>
           description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_29
+      schema: !<!StringSchema> &ref_28
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -655,15 +692,23 @@ schemas: !<!Schemas>
         description: The product documentation.
         namespace: Api100
     protocol: !<!Protocols> {}
-  - *ref_9
-  - *ref_10
-  - *ref_8
-  - *ref_7
-  dictionaries:
-  - *ref_11
   - *ref_12
+  - *ref_13
+  - *ref_11
+  - *ref_10
+  dictionaries:
+  - *ref_14
+  - !<!DictionarySchema> &ref_37
+    type: dictionary
+    elementType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: DictionaryOfFlattenedProduct
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
+  - *ref_15
   arrays:
-  - !<!ArraySchema> &ref_34
+  - !<!ArraySchema> &ref_33
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -674,7 +719,7 @@ schemas: !<!Schemas>
         name: Array of Resource
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_35
+  - !<!ArraySchema> &ref_34
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -685,65 +730,55 @@ schemas: !<!Schemas>
         name: Array of FlattenedProduct
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_36
+  - !<!ArraySchema> &ref_35
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_4
+    elementType: *ref_7
     language: !<!Languages> 
       default:
         name: Array of WrappedProduct
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_37
+  - !<!ArraySchema> &ref_36
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: *ref_13
+    elementType: *ref_16
     language: !<!Languages> 
       default:
         name: Array of ProductWrapper
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - *ref_14
-  constants:
-  - *ref_15
-  numbers:
-  - *ref_16
-  sealedChoices:
   - *ref_17
-  strings:
-  - *ref_6
+  constants:
   - *ref_18
+  numbers:
   - *ref_19
+  sealedChoices:
+  - *ref_5
+  strings:
+  - *ref_9
   - *ref_20
   - *ref_21
   - *ref_22
   - *ref_23
   - *ref_24
   - *ref_25
+  - *ref_3
+  - *ref_4
+  - *ref_6
   - *ref_26
   - *ref_27
   - *ref_28
   - *ref_29
   - *ref_30
   - *ref_31
-  - *ref_32
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_33
-  schema: *ref_6
+- !<!Parameter> &ref_32
+  schema: *ref_9
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -753,7 +788,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: model-flattening
@@ -767,9 +802,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_33
         implementation: Method
         required: true
         extensions:
@@ -788,11 +823,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/array'
+          path: /model-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -830,18 +866,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/array'
+          path: /model-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_35
+      schema: *ref_34
       language: !<!Languages> 
         default:
           name: ''
@@ -878,9 +915,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_35
         implementation: Method
         required: true
         extensions:
@@ -899,11 +936,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/wrappedarray'
+          path: /model-flatten/wrappedarray
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -941,18 +979,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/wrappedarray'
+          path: /model-flatten/wrappedarray
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_37
+      schema: *ref_36
       language: !<!Languages> 
         default:
           name: ''
@@ -989,9 +1028,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_37
         implementation: Method
         required: true
         extensions:
@@ -1010,11 +1049,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/dictionary'
+          path: /model-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1052,18 +1092,19 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/dictionary'
+          path: /model-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_12
+      schema: *ref_37
       language: !<!Languages> 
         default:
           name: ''
@@ -1100,7 +1141,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       - !<!Parameter> 
         schema: *ref_38
         implementation: Method
@@ -1121,11 +1162,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/resourcecollection'
+          path: /model-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1163,15 +1205,16 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/resourcecollection'
+          path: /model-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_38
@@ -1211,9 +1254,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1232,14 +1275,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening'
+          path: /model-flatten/customFlattening
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1278,9 +1322,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1300,14 +1344,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening'
+          path: /model-flatten/customFlattening
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''
@@ -1346,9 +1391,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_33
+      - *ref_32
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1362,7 +1407,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1384,14 +1429,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening/parametergrouping/{name}/'
+          path: '/model-flatten/customFlattening/parametergrouping/{name}/'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_12
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/model-flattening/modeler.yaml
+++ b/modelerfour/test/outputs/model-flattening/modeler.yaml
@@ -178,6 +178,8 @@ schemas: !<!Schemas>
                 namespace: Api100
             protocol: !<!Protocols> {}
           serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
               name: properties
@@ -396,7 +398,7 @@ schemas: !<!Schemas>
         description: The wrapped produc.
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_38
+  - !<!ObjectSchema> &ref_39
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -661,6 +663,14 @@ schemas: !<!Schemas>
   - *ref_21
   dictionaries:
   - *ref_26
+  - !<!DictionarySchema> &ref_38
+    type: dictionary
+    elementType: *ref_10
+    language: !<!Languages> 
+      default:
+        name: paths·model_flatten-dictionary·put·requestbody·content·application-json·schema
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
   - *ref_27
   arrays:
   - !<!ArraySchema> &ref_33
@@ -731,16 +741,6 @@ schemas: !<!Schemas>
   - *ref_18
   - *ref_20
   - *ref_19
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·model_flatten-customflattening-parametergrouping-name·put·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_34
   schema: *ref_7
@@ -753,7 +753,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: model-flattening
@@ -788,11 +788,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/array'
+          path: /model-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -837,8 +838,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/array'
+          path: /model-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_35
@@ -899,11 +901,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/wrappedarray'
+          path: /model-flatten/wrappedarray
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -948,8 +951,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/wrappedarray'
+          path: /model-flatten/wrappedarray
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_37
@@ -991,7 +995,7 @@ operationGroups:
       parameters:
       - *ref_34
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_38
         implementation: Method
         required: true
         extensions:
@@ -1010,11 +1014,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/dictionary'
+          path: /model-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1059,11 +1064,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/dictionary'
+          path: /model-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -1102,7 +1108,7 @@ operationGroups:
       parameters:
       - *ref_34
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_39
         implementation: Method
         required: true
         extensions:
@@ -1121,11 +1127,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/resourcecollection'
+          path: /model-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1170,11 +1177,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/resourcecollection'
+          path: /model-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_38
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -1232,11 +1240,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening'
+          path: /model-flatten/customFlattening
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_24
@@ -1300,11 +1309,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening'
+          path: /model-flatten/customFlattening
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_24
@@ -1348,7 +1358,7 @@ operationGroups:
       parameters:
       - *ref_34
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_2
         implementation: Method
         required: true
         extensions:
@@ -1384,11 +1394,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening/parametergrouping/{name}/'
+          path: '/model-flatten/customFlattening/parametergrouping/{name}/'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_24

--- a/modelerfour/test/outputs/model-flattening/namer.yaml
+++ b/modelerfour/test/outputs/model-flattening/namer.yaml
@@ -178,6 +178,8 @@ schemas: !<!Schemas>
                 namespace: Api100
             protocol: !<!Protocols> {}
           serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
               name: properties
@@ -396,7 +398,7 @@ schemas: !<!Schemas>
         description: The wrapped produc.
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_38
+  - !<!ObjectSchema> &ref_39
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -661,6 +663,14 @@ schemas: !<!Schemas>
   - *ref_7
   dictionaries:
   - *ref_11
+  - !<!DictionarySchema> &ref_38
+    type: dictionary
+    elementType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: DictionaryOfFlattenedProduct
+        description: Dictionary of <FlattenedProduct>
+    protocol: !<!Protocols> {}
   - *ref_12
   arrays:
   - !<!ArraySchema> &ref_34
@@ -731,16 +741,6 @@ schemas: !<!Schemas>
   - *ref_30
   - *ref_31
   - *ref_32
-  - !<!StringSchema> &ref_39
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_33
   schema: *ref_6
@@ -753,7 +753,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: model-flattening
@@ -788,11 +788,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/array'
+          path: /model-flatten/array
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -837,8 +838,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/array'
+          path: /model-flatten/array
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_35
@@ -899,11 +901,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/wrappedarray'
+          path: /model-flatten/wrappedarray
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -948,8 +951,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/wrappedarray'
+          path: /model-flatten/wrappedarray
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_37
@@ -991,7 +995,7 @@ operationGroups:
       parameters:
       - *ref_33
       - !<!Parameter> 
-        schema: *ref_12
+        schema: *ref_38
         implementation: Method
         required: true
         extensions:
@@ -1010,11 +1014,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/dictionary'
+          path: /model-flatten/dictionary
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1059,11 +1064,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/dictionary'
+          path: /model-flatten/dictionary
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_12
+      schema: *ref_38
       language: !<!Languages> 
         default:
           name: ''
@@ -1102,7 +1108,7 @@ operationGroups:
       parameters:
       - *ref_33
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_39
         implementation: Method
         required: true
         extensions:
@@ -1121,11 +1127,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/resourcecollection'
+          path: /model-flatten/resourcecollection
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1170,11 +1177,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/model-flatten/resourcecollection'
+          path: /model-flatten/resourcecollection
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_38
+      schema: *ref_39
       language: !<!Languages> 
         default:
           name: ''
@@ -1232,11 +1240,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening'
+          path: /model-flatten/customFlattening
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_9
@@ -1300,11 +1309,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening'
+          path: /model-flatten/customFlattening
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_9
@@ -1348,7 +1358,7 @@ operationGroups:
       parameters:
       - *ref_33
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -1384,11 +1394,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/model-flatten/customFlattening/parametergrouping/{name}/'
+          path: '/model-flatten/customFlattening/parametergrouping/{name}/'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_9

--- a/modelerfour/test/outputs/paging/flattened.yaml
+++ b/modelerfour/test/outputs/paging/flattened.yaml
@@ -112,7 +112,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_0
   - *ref_1
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_17
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -290,86 +290,6 @@ schemas: !<!Schemas>
         name: integer
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_17
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_20
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_21
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_28
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_29
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   sealedChoices:
   - *ref_5
   strings:
@@ -386,137 +306,7 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_9
-  - !<!StringSchema> &ref_19
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_26
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_10
   schema: *ref_6
@@ -529,7 +319,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Long-running Operation for AutoRest
   title: paging
@@ -550,8 +340,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/single'
+          path: /paging/single
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -606,7 +397,7 @@ operationGroups:
         schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_15
             postfix: Options
         language: !<!Languages> 
           default:
@@ -619,7 +410,7 @@ operationGroups:
         schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_16
             postfix: Options
         language: !<!Languages> 
           default:
@@ -634,8 +425,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple'
+          path: /paging/multiple
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -677,7 +469,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -687,11 +479,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -700,11 +491,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -718,11 +508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/odata'
+          path: /paging/multiple/odata
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -761,7 +552,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -771,11 +562,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -784,7 +574,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -798,11 +588,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -816,8 +605,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/withpath/{offset}'
+          path: '/paging/multiple/withpath/{offset}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -864,8 +654,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/retryfirst'
+          path: /paging/multiple/retryfirst
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -912,8 +703,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/retrysecond'
+          path: /paging/multiple/retrysecond
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -960,8 +752,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/single/failure'
+          path: /paging/single/failure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1008,8 +801,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/failure'
+          path: /paging/multiple/failure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1056,8 +850,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/failureuri'
+          path: /paging/multiple/failureuri
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1099,7 +894,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1110,7 +905,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1126,11 +921,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragment/{tenant}'
+          path: '/paging/multiple/fragment/{tenant}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1170,11 +966,11 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_18
             name: custom-parameter-group
         language: !<!Languages> 
           default:
@@ -1184,11 +980,11 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_19
             name: custom-parameter-group
         language: !<!Languages> 
           default:
@@ -1203,11 +999,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragmentwithgrouping/{tenant}'
+          path: '/paging/multiple/fragmentwithgrouping/{tenant}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1247,7 +1044,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1257,11 +1054,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -1270,11 +1066,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -1288,8 +1083,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/lro'
+          path: /paging/multiple/lro
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1332,7 +1128,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1343,7 +1139,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1354,7 +1150,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1372,11 +1168,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragment/{tenant}/{nextLink}'
+          path: '/paging/multiple/fragment/{tenant}/{nextLink}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1416,12 +1213,11 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
-            name: custom-parameter-group
+          x-ms-parameter-grouping: *ref_18
         language: !<!Languages> 
           default:
             name: api_version
@@ -1430,12 +1226,11 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
-            name: custom-parameter-group
+          x-ms-parameter-grouping: *ref_19
         language: !<!Languages> 
           default:
             name: tenant
@@ -1444,7 +1239,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1462,11 +1257,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}'
+          path: '/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/paging/modeler.yaml
+++ b/modelerfour/test/outputs/paging/modeler.yaml
@@ -112,7 +112,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_2
   - *ref_3
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_17
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -290,86 +290,6 @@ schemas: !<!Schemas>
         name: paths·paging-multiple·get·parameters·2·schema
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-odata·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_17
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-odata·get·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_20
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-withpath-offset·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_21
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-withpath-offset·get·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-withpath-offset·get·parameters·3·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_28
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-lro·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_29
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-lro·post·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   sealedChoices:
   - *ref_9
   strings:
@@ -386,137 +306,7 @@ schemas: !<!Schemas>
         name: paths·paging-multiple·get·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-odata·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_4
-  - !<!StringSchema> &ref_19
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-withpath-offset·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragment-tenant·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragment-tenant·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_26
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragmentwithgrouping-tenant·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-lro·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragment-tenant-nextlink·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragment-tenant-nextlink·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragment-tenant-nextlink·get·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·paging-multiple-fragmentwithgrouping-tenant-nextlink·get·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_11
   schema: *ref_5
@@ -529,7 +319,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Long-running Operation for AutoRest
   title: paging
@@ -550,8 +340,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/single'
+          path: /paging/single
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -606,7 +397,7 @@ operationGroups:
         schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_15
             postfix: Options
         language: !<!Languages> 
           default:
@@ -619,7 +410,7 @@ operationGroups:
         schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_16
             postfix: Options
         language: !<!Languages> 
           default:
@@ -634,8 +425,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple'
+          path: /paging/multiple
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -677,7 +469,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -687,11 +479,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -700,11 +491,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -718,11 +508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/odata'
+          path: /paging/multiple/odata
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -761,7 +552,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -771,11 +562,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -784,7 +574,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -798,11 +588,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -816,8 +605,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/withpath/{offset}'
+          path: '/paging/multiple/withpath/{offset}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -864,8 +654,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/retryfirst'
+          path: /paging/multiple/retryfirst
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -912,8 +703,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/retrysecond'
+          path: /paging/multiple/retrysecond
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -960,8 +752,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/single/failure'
+          path: /paging/single/failure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -1008,8 +801,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/failure'
+          path: /paging/multiple/failure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -1056,8 +850,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/failureuri'
+          path: /paging/multiple/failureuri
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -1099,7 +894,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1110,7 +905,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1126,11 +921,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragment/{tenant}'
+          path: '/paging/multiple/fragment/{tenant}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1170,11 +966,11 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_18
             name: custom-parameter-group
         language: !<!Languages> 
           default:
@@ -1184,11 +980,11 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_19
             name: custom-parameter-group
         language: !<!Languages> 
           default:
@@ -1203,11 +999,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragmentwithgrouping/{tenant}'
+          path: '/paging/multiple/fragmentwithgrouping/{tenant}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1247,7 +1044,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1257,11 +1054,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -1270,11 +1066,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -1288,8 +1083,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/lro'
+          path: /paging/multiple/lro
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_10
@@ -1332,7 +1128,7 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1343,7 +1139,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1354,7 +1150,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1372,11 +1168,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragment/{tenant}/{nextLink}'
+          path: '/paging/multiple/fragment/{tenant}/{nextLink}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1416,12 +1213,11 @@ operationGroups:
       parameters:
       - *ref_11
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
-            name: custom-parameter-group
+          x-ms-parameter-grouping: *ref_18
         language: !<!Languages> 
           default:
             name: api_version
@@ -1430,12 +1226,11 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
-            name: custom-parameter-group
+          x-ms-parameter-grouping: *ref_19
         language: !<!Languages> 
           default:
             name: tenant
@@ -1444,7 +1239,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1462,11 +1257,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}'
+          path: '/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/paging/namer.yaml
+++ b/modelerfour/test/outputs/paging/namer.yaml
@@ -112,7 +112,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_0
   - *ref_1
-  - !<!ObjectSchema> &ref_18
+  - !<!ObjectSchema> &ref_17
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -290,86 +290,6 @@ schemas: !<!Schemas>
         name: integer
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_16
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_17
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_20
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_21
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_22
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_28
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_29
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    defaultValue: 30
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   sealedChoices:
   - *ref_5
   strings:
@@ -386,137 +306,7 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_9
-  - !<!StringSchema> &ref_19
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_26
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_27
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_30
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_35
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_10
   schema: *ref_6
@@ -529,7 +319,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Long-running Operation for AutoRest
   title: paging
@@ -550,8 +340,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/single'
+          path: /paging/single
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -606,7 +397,7 @@ operationGroups:
         schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_15
             postfix: Options
         language: !<!Languages> 
           default:
@@ -619,7 +410,7 @@ operationGroups:
         schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_16
             postfix: Options
         language: !<!Languages> 
           default:
@@ -634,8 +425,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple'
+          path: /paging/multiple
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -677,7 +469,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_15
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -687,11 +479,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_16
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -700,11 +491,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_17
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -718,11 +508,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/odata'
+          path: /paging/multiple/odata
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -761,7 +552,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -771,11 +562,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_20
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -784,7 +574,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_13
         implementation: Method
         required: true
         extensions:
@@ -798,11 +588,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -816,8 +605,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/withpath/{offset}'
+          path: '/paging/multiple/withpath/{offset}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -864,8 +654,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/retryfirst'
+          path: /paging/multiple/retryfirst
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -912,8 +703,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/retrysecond'
+          path: /paging/multiple/retrysecond
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -960,8 +752,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/single/failure'
+          path: /paging/single/failure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1008,8 +801,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/failure'
+          path: /paging/multiple/failure
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1056,8 +850,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/failureuri'
+          path: /paging/multiple/failureuri
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1099,7 +894,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1110,7 +905,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1126,11 +921,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragment/{tenant}'
+          path: '/paging/multiple/fragment/{tenant}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1170,11 +966,11 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_18
             name: custom-parameter-group
         language: !<!Languages> 
           default:
@@ -1184,11 +980,11 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
+          x-ms-parameter-grouping: &ref_19
             name: custom-parameter-group
         language: !<!Languages> 
           default:
@@ -1203,11 +999,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragmentwithgrouping/{tenant}'
+          path: '/paging/multiple/fragmentwithgrouping/{tenant}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1247,7 +1044,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1257,11 +1054,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_13
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_15
         language: !<!Languages> 
           default:
             name: maxresults
@@ -1270,11 +1066,10 @@ operationGroups:
           http: !<!HttpParameter> 
             in: header
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_14
         implementation: Method
         extensions:
-          x-ms-parameter-grouping:
-            postfix: Options
+          x-ms-parameter-grouping: *ref_16
         language: !<!Languages> 
           default:
             name: timeout
@@ -1288,8 +1083,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/lro'
+          path: /paging/multiple/lro
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_11
@@ -1332,7 +1128,7 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1343,7 +1139,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1354,7 +1150,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1372,11 +1168,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragment/{tenant}/{nextLink}'
+          path: '/paging/multiple/fragment/{tenant}/{nextLink}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1416,12 +1213,11 @@ operationGroups:
       parameters:
       - *ref_10
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
-            name: custom-parameter-group
+          x-ms-parameter-grouping: *ref_18
         language: !<!Languages> 
           default:
             name: api_version
@@ -1430,12 +1226,11 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
-          x-ms-parameter-grouping:
-            name: custom-parameter-group
+          x-ms-parameter-grouping: *ref_19
         language: !<!Languages> 
           default:
             name: tenant
@@ -1444,7 +1239,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1462,11 +1257,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}'
+          path: '/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_18
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/parameter-flattening/flattened.yaml
+++ b/modelerfour/test/outputs/parameter-flattening/flattened.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_6
+  - !<!ObjectSchema> &ref_5
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -48,17 +48,8 @@ schemas: !<!Schemas>
         name: string
         description: simple string
     protocol: !<!Protocols> {}
+  - *ref_1
   - !<!StringSchema> &ref_4
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_5
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -69,7 +60,6 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_1
 globalParameters:
 - !<!Parameter> &ref_3
   schema: *ref_2
@@ -82,7 +72,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: parameter-flattening
@@ -98,7 +88,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_4
+        schema: *ref_1
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -109,7 +99,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_5
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -120,7 +110,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_5
         implementation: Method
         required: true
         extensions:
@@ -139,11 +129,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/parameterFlattening/{resourceGroupName}/{availabilitySetName}'
+          path: '/parameterFlattening/{resourceGroupName}/{availabilitySetName}'
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/parameter-flattening/modeler.yaml
+++ b/modelerfour/test/outputs/parameter-flattening/modeler.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_5
+  - !<!ObjectSchema> &ref_4
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -17,7 +17,7 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: components·schemas·availabilitysetupdateparameters·properties·tags·additionalproperties
+              name: paths·parameterflattening-resourcegroupname-availabilitysetname·patch·parameters·0·schema
               description: MISSING·SCHEMA-DESCRIPTION-STRING
           protocol: !<!Protocols> {}
         language: !<!Languages> 
@@ -48,17 +48,8 @@ schemas: !<!Schemas>
         name: string
         description: simple string
     protocol: !<!Protocols> {}
+  - *ref_0
   - !<!StringSchema> &ref_3
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·parameterflattening-resourcegroupname-availabilitysetname·patch·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_4
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -69,9 +60,8 @@ schemas: !<!Schemas>
         name: paths·parameterflattening-resourcegroupname-availabilitysetname·patch·parameters·1·schema
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_0
 globalParameters:
-- !<!Parameter> &ref_6
+- !<!Parameter> &ref_5
   schema: *ref_2
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
@@ -82,7 +72,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: parameter-flattening
@@ -96,9 +86,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_6
+      - *ref_5
       - !<!Parameter> 
-        schema: *ref_3
+        schema: *ref_0
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -109,7 +99,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_4
+        schema: *ref_3
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -120,7 +110,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_5
+        schema: *ref_4
         implementation: Method
         required: true
         extensions:
@@ -139,11 +129,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/parameterFlattening/{resourceGroupName}/{availabilitySetName}'
+          path: '/parameterFlattening/{resourceGroupName}/{availabilitySetName}'
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/parameter-flattening/namer.yaml
+++ b/modelerfour/test/outputs/parameter-flattening/namer.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_6
+  - !<!ObjectSchema> &ref_5
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -48,17 +48,8 @@ schemas: !<!Schemas>
         name: string
         description: simple string
     protocol: !<!Protocols> {}
+  - *ref_1
   - !<!StringSchema> &ref_4
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_5
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -69,7 +60,6 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_1
 globalParameters:
 - !<!Parameter> &ref_3
   schema: *ref_2
@@ -82,7 +72,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Resource Flattening for AutoRest
   title: parameter-flattening
@@ -98,7 +88,7 @@ operationGroups:
       parameters:
       - *ref_3
       - !<!Parameter> 
-        schema: *ref_4
+        schema: *ref_1
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -109,7 +99,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_5
+        schema: *ref_4
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -120,7 +110,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_5
         implementation: Method
         required: true
         extensions:
@@ -139,11 +129,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/parameterFlattening/{resourceGroupName}/{availabilitySetName}'
+          path: '/parameterFlattening/{resourceGroupName}/{availabilitySetName}'
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 

--- a/modelerfour/test/outputs/report/flattened.yaml
+++ b/modelerfour/test/outputs/report/flattened.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: report
@@ -129,8 +129,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/report'
+          path: /report
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/report/modeler.yaml
+++ b/modelerfour/test/outputs/report/modeler.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: report
@@ -129,8 +129,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/report'
+          path: /report
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_5

--- a/modelerfour/test/outputs/report/namer.yaml
+++ b/modelerfour/test/outputs/report/namer.yaml
@@ -98,7 +98,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: report
@@ -129,8 +129,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/report'
+          path: /report
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_6

--- a/modelerfour/test/outputs/required-optional/flattened.yaml
+++ b/modelerfour/test/outputs/required-optional/flattened.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_20
+  - !<!ObjectSchema> &ref_18
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_7
+      schema: !<!StringSchema> &ref_8
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_21
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_30
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -100,14 +100,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_35
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_8
+      schema: !<!StringSchema> &ref_9
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -130,14 +130,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_36
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_9
+      schema: !<!StringSchema> &ref_10
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_10
+      schema: !<!StringSchema> &ref_11
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -205,7 +205,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_39
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -226,7 +226,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_40
+  - !<!ObjectSchema> &ref_26
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -246,7 +246,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_43
+  - !<!ObjectSchema> &ref_29
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -286,7 +286,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_44
+  - !<!ObjectSchema> &ref_30
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -326,12 +326,12 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_41
+  - !<!ArraySchema> &ref_27
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_11
+    elementType: !<!StringSchema> &ref_12
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -346,12 +346,12 @@ schemas: !<!Schemas>
         name: Array of post-content-schemaItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_42
+  - !<!ArraySchema> &ref_28
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_12
+    elementType: !<!StringSchema> &ref_7
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -368,7 +368,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
-  - !<!ArraySchema> &ref_45
+  - !<!ArraySchema> &ref_31
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -388,40 +388,9 @@ schemas: !<!Schemas>
         name: Array of post-0-itemsItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_46
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_16
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
   numbers:
   - *ref_3
-  - !<!NumberSchema> &ref_27
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_28
+  - !<!NumberSchema> &ref_20
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -434,30 +403,8 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_4
   - *ref_5
-  - !<!NumberSchema> &ref_31
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_32
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   - *ref_6
-  - !<!NumberSchema> &ref_26
+  - !<!NumberSchema> &ref_19
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -469,126 +416,25 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
   strings:
-  - !<!StringSchema> &ref_17
+  - !<!StringSchema> &ref_16
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: simple string
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_19
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_7
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_8
   - *ref_9
-  - !<!StringSchema> &ref_37
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_10
   - *ref_11
   - *ref_12
   - *ref_13
   - *ref_14
   - *ref_15
-  - *ref_16
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_18
-  schema: *ref_17
+- !<!Parameter> &ref_17
+  schema: *ref_16
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -598,7 +444,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: required-optional
@@ -612,9 +458,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -630,11 +476,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/required/path/{pathParameter}'
+          path: '/reqopt/implicit/required/path/{pathParameter}'
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -657,9 +504,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_7
         implementation: Method
         language: !<!Languages> 
           default:
@@ -674,8 +521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/optional/query'
+          path: /reqopt/implicit/optional/query
           method: put
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -688,7 +536,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -711,9 +559,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_7
         implementation: Method
         language: !<!Languages> 
           default:
@@ -728,8 +576,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/optional/header'
+          path: /reqopt/implicit/optional/header
           method: put
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -742,7 +591,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -765,9 +614,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -786,11 +635,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/implicit/optional/body'
+          path: /reqopt/implicit/optional/body
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -803,7 +653,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -828,9 +678,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -846,11 +696,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/required/path/{required-global-path}'
+          path: '/reqopt/global/required/path/{required-global-path}'
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -873,9 +724,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -891,11 +742,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/required/query'
+          path: /reqopt/global/required/query
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -918,9 +770,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_19
         implementation: Method
         language: !<!Languages> 
           default:
@@ -935,11 +787,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/optional/query'
+          path: /reqopt/global/optional/query
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -970,9 +823,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -991,14 +844,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/integer/parameter'
+          path: /reqopt/requied/integer/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1023,9 +877,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -1044,11 +898,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/integer/parameter'
+          path: /reqopt/optional/integer/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1061,7 +916,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1086,9 +941,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1107,14 +962,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/integer/property'
+          path: /reqopt/requied/integer/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1139,9 +995,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1160,11 +1016,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/integer/property'
+          path: /reqopt/optional/integer/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1177,7 +1034,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1202,9 +1059,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1220,11 +1077,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/integer/header'
+          path: /reqopt/requied/integer/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1247,9 +1105,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1264,8 +1122,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/integer/header'
+          path: /reqopt/optional/integer/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1278,7 +1137,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1301,9 +1160,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -1322,14 +1181,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/string/parameter'
+          path: /reqopt/requied/string/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1354,9 +1214,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -1375,11 +1235,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/string/parameter'
+          path: /reqopt/optional/string/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1392,7 +1253,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1417,9 +1278,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_23
         implementation: Method
         required: true
         extensions:
@@ -1438,14 +1299,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/string/property'
+          path: /reqopt/requied/string/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1470,9 +1332,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_24
         implementation: Method
         required: true
         extensions:
@@ -1491,11 +1353,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/string/property'
+          path: /reqopt/optional/string/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1508,7 +1371,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1533,9 +1396,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1551,11 +1414,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/string/header'
+          path: /reqopt/requied/string/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1578,9 +1442,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_7
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1595,8 +1459,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/string/header'
+          path: /reqopt/optional/string/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1609,7 +1474,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1632,7 +1497,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
         schema: *ref_0
         implementation: Method
@@ -1653,14 +1518,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/class/parameter'
+          path: /reqopt/requied/class/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1685,7 +1551,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
         schema: *ref_0
         implementation: Method
@@ -1706,11 +1572,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/class/parameter'
+          path: /reqopt/optional/class/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1723,7 +1590,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1748,9 +1615,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -1769,14 +1636,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/class/property'
+          path: /reqopt/requied/class/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1801,9 +1669,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -1822,11 +1690,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/class/property'
+          path: /reqopt/optional/class/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1839,7 +1708,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1864,9 +1733,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_27
         implementation: Method
         required: true
         extensions:
@@ -1885,14 +1754,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/array/parameter'
+          path: /reqopt/requied/array/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1917,9 +1787,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_28
         implementation: Method
         required: true
         extensions:
@@ -1938,11 +1808,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/array/parameter'
+          path: /reqopt/optional/array/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1955,7 +1826,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1980,9 +1851,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -2001,14 +1872,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/array/property'
+          path: /reqopt/requied/array/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -2033,9 +1905,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2054,11 +1926,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/array/property'
+          path: /reqopt/optional/array/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2071,7 +1944,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -2096,9 +1969,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_31
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2114,11 +1987,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/array/header'
+          path: /reqopt/requied/array/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -2141,9 +2015,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_28
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2158,8 +2032,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/array/header'
+          path: /reqopt/optional/array/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2172,7 +2047,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/required-optional/modeler.yaml
+++ b/modelerfour/test/outputs/required-optional/modeler.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_19
+  - !<!ObjectSchema> &ref_17
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_21
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_30
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -100,7 +100,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_35
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -130,7 +130,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_36
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -205,7 +205,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_39
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -226,7 +226,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_40
+  - !<!ObjectSchema> &ref_26
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -246,7 +246,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_43
+  - !<!ObjectSchema> &ref_29
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -286,7 +286,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_44
+  - !<!ObjectSchema> &ref_30
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -326,7 +326,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_41
+  - !<!ArraySchema> &ref_27
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -346,7 +346,7 @@ schemas: !<!Schemas>
         name: paths·reqopt-requied-array-parameter·post·requestbody·content·application-json·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_42
+  - !<!ArraySchema> &ref_28
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -358,17 +358,17 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: paths·reqopt-optional-array-parameter·post·requestbody·content·application-json·schema·items
+          name: components·parameters·required_global_path·schema
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: paths·reqopt-optional-array-parameter·post·requestbody·content·application-json·schema
+        name: paths·reqopt-optional-array-header·post·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
   - *ref_13
   - *ref_14
-  - !<!ArraySchema> &ref_45
+  - !<!ArraySchema> &ref_31
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -388,53 +388,9 @@ schemas: !<!Schemas>
         name: paths·reqopt-requied-array-header·post·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_46
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_16
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·reqopt-optional-array-header·post·parameters·0·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-optional-array-header·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
   numbers:
   - *ref_7
-  - !<!NumberSchema> &ref_27
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-requied-integer-parameter·post·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_28
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-optional-integer-parameter·post·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - *ref_8
-  - *ref_9
-  - !<!NumberSchema> &ref_31
+  - !<!NumberSchema> &ref_20
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -445,19 +401,10 @@ schemas: !<!Schemas>
         name: paths·reqopt-requied-integer-header·post·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_32
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-optional-integer-header·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
+  - *ref_8
+  - *ref_9
   - *ref_10
-  - !<!NumberSchema> &ref_26
+  - !<!NumberSchema> &ref_19
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -469,126 +416,25 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
   strings:
-  - !<!StringSchema> &ref_17
+  - !<!StringSchema> &ref_16
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: simple string
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_18
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-implicit-required-path-pathparameter·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_12
   - *ref_0
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-implicit-optional-query·put·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-implicit-optional-header·put·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-implicit-optional-body·put·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-requied-string-parameter·post·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-optional-string-parameter·post·requestbody·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
-  - !<!StringSchema> &ref_37
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-requied-string-header·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·reqopt-optional-string-header·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_3
   - *ref_11
-  - *ref_12
   - *ref_5
   - *ref_6
   - *ref_15
-  - *ref_16
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: components·parameters·required_global_path·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: components·parameters·required_global_query·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_20
-  schema: *ref_17
+- !<!Parameter> &ref_18
+  schema: *ref_16
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -598,7 +444,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: required-optional
@@ -612,9 +458,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_18
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -630,11 +476,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/required/path/{pathParameter}'
+          path: '/reqopt/implicit/required/path/{pathParameter}'
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -657,9 +504,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -674,8 +521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/optional/query'
+          path: /reqopt/implicit/optional/query
           method: put
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -688,7 +536,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -711,9 +559,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -728,8 +576,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/optional/header'
+          path: /reqopt/implicit/optional/header
           method: put
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -742,7 +591,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -765,9 +614,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -786,11 +635,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/implicit/optional/body'
+          path: /reqopt/implicit/optional/body
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -803,7 +653,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -828,9 +678,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -846,11 +696,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/required/path/{required-global-path}'
+          path: '/reqopt/global/required/path/{required-global-path}'
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -873,9 +724,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -891,11 +742,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/required/query'
+          path: /reqopt/global/required/query
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -918,9 +770,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_19
         implementation: Method
         language: !<!Languages> 
           default:
@@ -935,11 +787,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/optional/query'
+          path: /reqopt/global/optional/query
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -970,9 +823,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -991,14 +844,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/integer/parameter'
+          path: /reqopt/requied/integer/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1023,9 +877,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -1044,11 +898,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/integer/parameter'
+          path: /reqopt/optional/integer/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1061,7 +916,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1086,9 +941,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1107,14 +962,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/integer/property'
+          path: /reqopt/requied/integer/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1139,9 +995,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1160,11 +1016,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/integer/property'
+          path: /reqopt/optional/integer/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1177,7 +1034,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1202,9 +1059,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1220,11 +1077,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/integer/header'
+          path: /reqopt/requied/integer/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1247,9 +1105,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1264,8 +1122,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/integer/header'
+          path: /reqopt/optional/integer/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1278,7 +1137,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1301,9 +1160,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1322,14 +1181,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/string/parameter'
+          path: /reqopt/requied/string/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1354,9 +1214,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_12
         implementation: Method
         required: true
         extensions:
@@ -1375,11 +1235,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/string/parameter'
+          path: /reqopt/optional/string/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1392,7 +1253,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1417,9 +1278,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_23
         implementation: Method
         required: true
         extensions:
@@ -1438,14 +1299,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/string/property'
+          path: /reqopt/requied/string/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1470,9 +1332,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_24
         implementation: Method
         required: true
         extensions:
@@ -1491,11 +1353,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/string/property'
+          path: /reqopt/optional/string/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1508,7 +1371,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1533,9 +1396,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_12
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1551,11 +1414,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/string/header'
+          path: /reqopt/requied/string/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1578,9 +1442,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_12
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1595,8 +1459,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/string/header'
+          path: /reqopt/optional/string/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1609,7 +1474,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1632,7 +1497,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
         schema: *ref_4
         implementation: Method
@@ -1653,14 +1518,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/class/parameter'
+          path: /reqopt/requied/class/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1685,7 +1551,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
         schema: *ref_4
         implementation: Method
@@ -1706,11 +1572,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/class/parameter'
+          path: /reqopt/optional/class/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1723,7 +1590,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1748,9 +1615,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -1769,14 +1636,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/class/property'
+          path: /reqopt/requied/class/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1801,9 +1669,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -1822,11 +1690,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/class/property'
+          path: /reqopt/optional/class/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1839,7 +1708,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1864,9 +1733,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_27
         implementation: Method
         required: true
         extensions:
@@ -1885,14 +1754,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/array/parameter'
+          path: /reqopt/requied/array/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1917,9 +1787,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_28
         implementation: Method
         required: true
         extensions:
@@ -1938,11 +1808,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/array/parameter'
+          path: /reqopt/optional/array/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1955,7 +1826,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1980,9 +1851,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -2001,14 +1872,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/array/property'
+          path: /reqopt/requied/array/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -2033,9 +1905,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2054,11 +1926,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/array/property'
+          path: /reqopt/optional/array/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2071,7 +1944,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -2096,9 +1969,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_31
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2114,11 +1987,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/array/header'
+          path: /reqopt/requied/array/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -2141,9 +2015,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_20
+      - *ref_18
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_28
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2158,8 +2032,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/array/header'
+          path: /reqopt/optional/array/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2172,7 +2047,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_19
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/required-optional/namer.yaml
+++ b/modelerfour/test/outputs/required-optional/namer.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_20
+  - !<!ObjectSchema> &ref_18
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_7
+      schema: !<!StringSchema> &ref_8
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_21
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_30
+  - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -100,14 +100,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_35
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_8
+      schema: !<!StringSchema> &ref_9
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -130,14 +130,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_36
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_9
+      schema: !<!StringSchema> &ref_10
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_10
+      schema: !<!StringSchema> &ref_11
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -205,7 +205,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_39
+  - !<!ObjectSchema> &ref_25
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -226,7 +226,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_40
+  - !<!ObjectSchema> &ref_26
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -246,7 +246,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_43
+  - !<!ObjectSchema> &ref_29
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -286,7 +286,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_44
+  - !<!ObjectSchema> &ref_30
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -326,12 +326,12 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_41
+  - !<!ArraySchema> &ref_27
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_11
+    elementType: !<!StringSchema> &ref_12
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -346,12 +346,12 @@ schemas: !<!Schemas>
         name: Array of post-content-schemaItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_42
+  - !<!ArraySchema> &ref_28
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_12
+    elementType: !<!StringSchema> &ref_7
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -368,7 +368,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
-  - !<!ArraySchema> &ref_45
+  - !<!ArraySchema> &ref_31
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -388,40 +388,9 @@ schemas: !<!Schemas>
         name: Array of post-0-itemsItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_46
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_16
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
   numbers:
   - *ref_3
-  - !<!NumberSchema> &ref_27
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_28
+  - !<!NumberSchema> &ref_20
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -434,30 +403,8 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_4
   - *ref_5
-  - !<!NumberSchema> &ref_31
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
-  - !<!NumberSchema> &ref_32
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   - *ref_6
-  - !<!NumberSchema> &ref_26
+  - !<!NumberSchema> &ref_19
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -469,126 +416,25 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-INTEGER
     protocol: !<!Protocols> {}
   strings:
-  - !<!StringSchema> &ref_17
+  - !<!StringSchema> &ref_16
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: simple string
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_19
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_7
-  - !<!StringSchema> &ref_21
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_23
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_34
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_8
   - *ref_9
-  - !<!StringSchema> &ref_37
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_38
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_10
   - *ref_11
   - *ref_12
   - *ref_13
   - *ref_14
   - *ref_15
-  - *ref_16
-  - !<!StringSchema> &ref_24
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_18
-  schema: *ref_17
+- !<!Parameter> &ref_17
+  schema: *ref_16
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -598,7 +444,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: required-optional
@@ -612,9 +458,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_19
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -630,11 +476,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/required/path/{pathParameter}'
+          path: '/reqopt/implicit/required/path/{pathParameter}'
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -657,9 +504,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_21
+        schema: *ref_7
         implementation: Method
         language: !<!Languages> 
           default:
@@ -674,8 +521,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/optional/query'
+          path: /reqopt/implicit/optional/query
           method: put
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -688,7 +536,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -711,9 +559,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_22
+        schema: *ref_7
         implementation: Method
         language: !<!Languages> 
           default:
@@ -728,8 +576,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/implicit/optional/header'
+          path: /reqopt/implicit/optional/header
           method: put
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -742,7 +591,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -765,9 +614,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_23
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -786,11 +635,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/implicit/optional/body'
+          path: /reqopt/implicit/optional/body
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -803,7 +653,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -828,9 +678,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_24
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -846,11 +696,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/required/path/{required-global-path}'
+          path: '/reqopt/global/required/path/{required-global-path}'
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -873,9 +724,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -891,11 +742,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/required/query'
+          path: /reqopt/global/required/query
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -918,9 +770,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_19
         implementation: Method
         language: !<!Languages> 
           default:
@@ -935,11 +787,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/global/optional/query'
+          path: /reqopt/global/optional/query
           method: get
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -970,9 +823,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -991,14 +844,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/integer/parameter'
+          path: /reqopt/requied/integer/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1023,9 +877,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_20
         implementation: Method
         required: true
         extensions:
@@ -1044,11 +898,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/integer/parameter'
+          path: /reqopt/optional/integer/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1061,7 +916,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1086,9 +941,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_21
         implementation: Method
         required: true
         extensions:
@@ -1107,14 +962,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/integer/property'
+          path: /reqopt/requied/integer/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1139,9 +995,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_22
         implementation: Method
         required: true
         extensions:
@@ -1160,11 +1016,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/integer/property'
+          path: /reqopt/optional/integer/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1177,7 +1034,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1202,9 +1059,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1220,11 +1077,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/integer/header'
+          path: /reqopt/requied/integer/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1247,9 +1105,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1264,8 +1122,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/integer/header'
+          path: /reqopt/optional/integer/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1278,7 +1137,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1301,9 +1160,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -1322,14 +1181,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/string/parameter'
+          path: /reqopt/requied/string/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1354,9 +1214,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_7
         implementation: Method
         required: true
         extensions:
@@ -1375,11 +1235,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/string/parameter'
+          path: /reqopt/optional/string/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1392,7 +1253,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1417,9 +1278,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_23
         implementation: Method
         required: true
         extensions:
@@ -1438,14 +1299,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/string/property'
+          path: /reqopt/requied/string/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1470,9 +1332,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_24
         implementation: Method
         required: true
         extensions:
@@ -1491,11 +1353,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/string/property'
+          path: /reqopt/optional/string/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1508,7 +1371,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1533,9 +1396,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_7
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1551,11 +1414,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/string/header'
+          path: /reqopt/requied/string/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1578,9 +1442,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_7
         implementation: Method
         language: !<!Languages> 
           default:
@@ -1595,8 +1459,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/string/header'
+          path: /reqopt/optional/string/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1609,7 +1474,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1632,7 +1497,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
         schema: *ref_0
         implementation: Method
@@ -1653,14 +1518,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/class/parameter'
+          path: /reqopt/requied/class/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1685,7 +1551,7 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
         schema: *ref_0
         implementation: Method
@@ -1706,11 +1572,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/class/parameter'
+          path: /reqopt/optional/class/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1723,7 +1590,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1748,9 +1615,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_25
         implementation: Method
         required: true
         extensions:
@@ -1769,14 +1636,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/class/property'
+          path: /reqopt/requied/class/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1801,9 +1669,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_26
         implementation: Method
         required: true
         extensions:
@@ -1822,11 +1690,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/class/property'
+          path: /reqopt/optional/class/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1839,7 +1708,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1864,9 +1733,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_27
         implementation: Method
         required: true
         extensions:
@@ -1885,14 +1754,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/array/parameter'
+          path: /reqopt/requied/array/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1917,9 +1787,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_28
         implementation: Method
         required: true
         extensions:
@@ -1938,11 +1808,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/array/parameter'
+          path: /reqopt/optional/array/parameter
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1955,7 +1826,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -1980,9 +1851,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_29
         implementation: Method
         required: true
         extensions:
@@ -2001,14 +1872,15 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/requied/array/property'
+          path: /reqopt/requied/array/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -2033,9 +1905,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_30
         implementation: Method
         required: true
         extensions:
@@ -2054,11 +1926,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/reqopt/optional/array/property'
+          path: /reqopt/optional/array/property
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2071,7 +1944,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -2096,9 +1969,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_31
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2114,11 +1987,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/requied/array/header'
+          path: /reqopt/requied/array/header
           method: post
+          url: '{$host}'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''
@@ -2141,9 +2015,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_18
+      - *ref_17
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_28
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2158,8 +2032,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/reqopt/optional/array/header'
+          path: /reqopt/optional/array/header
           method: post
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2172,7 +2047,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_20
+      schema: *ref_18
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/storage/flattened.yaml
+++ b/modelerfour/test/outputs/storage/flattened.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_52
+  - !<!ObjectSchema> &ref_50
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_29
+      schema: !<!StringSchema> &ref_31
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -26,7 +26,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_30
+      schema: !<!StringSchema> &ref_32
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -50,14 +50,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_53
+  - !<!ObjectSchema> &ref_51
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_23
+      schema: !<!BooleanSchema> &ref_24
         type: boolean
         language: !<!Languages> 
           default:
@@ -71,7 +71,7 @@ schemas: !<!Schemas>
           description: 'Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or invalid and cannot be used.'
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ChoiceSchema> &ref_17
+      schema: !<!ChoiceSchema> &ref_18
         choices:
         - !<!ChoiceValue> 
           value: AccountNameInvalid
@@ -108,7 +108,7 @@ schemas: !<!Schemas>
           description: Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_31
+      schema: !<!StringSchema> &ref_33
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -241,7 +241,7 @@ schemas: !<!Schemas>
               version: 2015-05-01-preview
             properties:
             - !<!Property> 
-              schema: !<!ChoiceSchema> &ref_18
+              schema: !<!ChoiceSchema> &ref_19
                 choices:
                 - !<!ChoiceValue> 
                   value: Creating
@@ -293,7 +293,7 @@ schemas: !<!Schemas>
                   version: 2015-05-01-preview
                 properties:
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_37
+                  schema: !<!StringSchema> &ref_38
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -310,7 +310,7 @@ schemas: !<!Schemas>
                       description: Gets the blob endpoint.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_38
+                  schema: !<!StringSchema> &ref_39
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -327,7 +327,7 @@ schemas: !<!Schemas>
                       description: Gets the queue endpoint.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_39
+                  schema: !<!StringSchema> &ref_40
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -410,7 +410,7 @@ schemas: !<!Schemas>
                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!StringSchema> &ref_40
+              schema: !<!StringSchema> &ref_41
                 type: string
                 apiVersions:
                 - !<!ApiVersion> 
@@ -458,7 +458,7 @@ schemas: !<!Schemas>
                   description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!DateTimeSchema> &ref_25
+              schema: !<!DateTimeSchema> &ref_26
                 type: date-time
                 format: date-time
                 apiVersions:
@@ -480,7 +480,7 @@ schemas: !<!Schemas>
                     if the accountType is StandardGRS or StandardRAGRS.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!StringSchema> &ref_41
+              schema: !<!StringSchema> &ref_42
                 type: string
                 apiVersions:
                 - !<!ApiVersion> 
@@ -505,7 +505,7 @@ schemas: !<!Schemas>
                   description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!DateTimeSchema> &ref_26
+              schema: !<!DateTimeSchema> &ref_27
                 type: date-time
                 format: date-time
                 apiVersions:
@@ -530,7 +530,7 @@ schemas: !<!Schemas>
                   version: 2015-05-01-preview
                 properties:
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_42
+                  schema: !<!StringSchema> &ref_43
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -547,7 +547,7 @@ schemas: !<!Schemas>
                       description: Gets or sets the custom domain name. Name is the CNAME source.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!BooleanSchema> &ref_24
+                  schema: !<!BooleanSchema> &ref_25
                     type: boolean
                     language: !<!Languages> 
                       default:
@@ -656,7 +656,7 @@ schemas: !<!Schemas>
       - *ref_8
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_32
+      schema: !<!StringSchema> &ref_34
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -675,7 +675,7 @@ schemas: !<!Schemas>
           description: Resource Id
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_33
+      schema: !<!StringSchema> &ref_35
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -694,7 +694,7 @@ schemas: !<!Schemas>
           description: Resource name
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_34
+      schema: !<!StringSchema> &ref_36
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -713,7 +713,7 @@ schemas: !<!Schemas>
           description: Resource type
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_35
+      schema: !<!StringSchema> &ref_37
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -731,9 +731,9 @@ schemas: !<!Schemas>
           description: Resource location
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_16
+      schema: !<!DictionarySchema> &ref_17
         type: dictionary
-        elementType: !<!StringSchema> &ref_36
+        elementType: !<!StringSchema> &ref_30
           type: string
           apiVersions:
           - !<!ApiVersion> 
@@ -773,14 +773,14 @@ schemas: !<!Schemas>
   - *ref_5
   - *ref_8
   - *ref_13
-  - !<!ObjectSchema> &ref_65
+  - !<!ObjectSchema> &ref_57
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_43
+      schema: !<!StringSchema> &ref_14
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -797,21 +797,12 @@ schemas: !<!Schemas>
           description: Gets the value of key 1.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_44
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 2015-05-01-preview
-        language: !<!Languages> 
-          default:
-            name: StorageAccountKeys-key2
-            description: Gets the value of key 2.
-        protocol: !<!Protocols> {}
+      schema: *ref_14
       serializedName: key2
       language: !<!Languages> 
         default:
           name: key2
-          description: Gets the value of key 2.
+          description: Gets the value of key 1.
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -819,14 +810,14 @@ schemas: !<!Schemas>
         description: The access keys for the storage account.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_67
+  - !<!ObjectSchema> &ref_59
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_21
+      schema: !<!ArraySchema> &ref_22
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -844,7 +835,7 @@ schemas: !<!Schemas>
           description: Gets the list of storage accounts and their properties.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_45
+      schema: !<!StringSchema> &ref_44
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -866,14 +857,14 @@ schemas: !<!Schemas>
         description: The list storage accounts operation response.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_71
+  - !<!ObjectSchema> &ref_62
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ChoiceSchema> &ref_19
+      schema: !<!ChoiceSchema> &ref_20
         choices:
         - !<!ChoiceValue> 
           value: key1
@@ -909,26 +900,26 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_73
+  - !<!ObjectSchema> &ref_64
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_22
+      schema: !<!ArraySchema> &ref_23
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        elementType: !<!ObjectSchema> &ref_14
+        elementType: !<!ObjectSchema> &ref_15
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
           properties:
           - !<!Property> 
-            schema: !<!ChoiceSchema> &ref_20
+            schema: !<!ChoiceSchema> &ref_21
               choices:
               - !<!ChoiceValue> 
                 value: Count
@@ -983,7 +974,7 @@ schemas: !<!Schemas>
                 description: Gets the unit of measurement.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!NumberSchema> &ref_27
+            schema: !<!NumberSchema> &ref_28
               type: integer
               precision: 32
               language: !<!Languages> 
@@ -998,7 +989,7 @@ schemas: !<!Schemas>
                 description: Gets the current count of the allocated resources in the subscription.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!NumberSchema> &ref_28
+            schema: !<!NumberSchema> &ref_29
               type: integer
               precision: 32
               language: !<!Languages> 
@@ -1013,14 +1004,14 @@ schemas: !<!Schemas>
                 description: Gets the maximum count of the resources that can be allocated in the subscription.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_15
+            schema: !<!ObjectSchema> &ref_16
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
               properties:
               - !<!Property> 
-                schema: !<!StringSchema> &ref_46
+                schema: !<!StringSchema> &ref_45
                   type: string
                   apiVersions:
                   - !<!ApiVersion> 
@@ -1037,7 +1028,7 @@ schemas: !<!Schemas>
                     description: Gets a string describing the resource name.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!StringSchema> &ref_47
+                schema: !<!StringSchema> &ref_46
                   type: string
                   apiVersions:
                   - !<!ApiVersion> 
@@ -1088,8 +1079,8 @@ schemas: !<!Schemas>
         description: The List Usages operation response.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - *ref_14
   - *ref_15
+  - *ref_16
   - !<!ObjectSchema> 
     type: object
     apiVersions:
@@ -1097,7 +1088,7 @@ schemas: !<!Schemas>
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_48
+      schema: !<!StringSchema> &ref_47
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -1122,22 +1113,78 @@ schemas: !<!Schemas>
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
   dictionaries:
-  - *ref_16
-  choices:
   - *ref_17
-  - *ref_2
+  choices:
   - *ref_18
-  - *ref_4
+  - *ref_2
   - *ref_19
+  - *ref_4
   - *ref_20
-  arrays:
   - *ref_21
+  arrays:
   - *ref_22
-  booleans:
   - *ref_23
+  booleans:
   - *ref_24
+  - *ref_25
   constants:
-  - !<!ConstantSchema> &ref_50
+  - !<!ConstantSchema> &ref_49
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_52
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_53
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_54
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_55
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1193,7 +1240,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-05-01-preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
+  - !<!ConstantSchema> &ref_61
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1207,63 +1254,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-05-01-preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_64
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
+  - !<!ConstantSchema> &ref_63
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1278,46 +1269,15 @@ schemas: !<!Schemas>
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   dateTimes:
-  - *ref_25
   - *ref_26
-  numbers:
   - *ref_27
+  numbers:
   - *ref_28
+  - *ref_29
   strings:
   - *ref_1
-  - !<!StringSchema> &ref_51
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - *ref_29
   - *ref_30
   - *ref_31
-  - !<!StringSchema> &ref_54
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_55
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_32
   - *ref_33
   - *ref_34
@@ -1329,74 +1289,14 @@ schemas: !<!Schemas>
   - *ref_40
   - *ref_41
   - *ref_42
-  - !<!StringSchema> &ref_57
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_59
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_61
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_63
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_43
+  - *ref_14
   - *ref_44
   - *ref_45
-  - !<!StringSchema> &ref_69
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_46
   - *ref_47
-  - *ref_48
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_49
+- !<!Parameter> &ref_48
   schema: *ref_1
   clientDefaultValue: 'https://management.azure.com'
   implementation: Client
@@ -1407,7 +1307,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   title: storage
 operationGroups:
@@ -1420,9 +1320,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_49
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1433,7 +1333,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1444,7 +1344,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_50
         implementation: Method
         required: true
         extensions:
@@ -1463,15 +1363,16 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_53
+      schema: *ref_51
       language: !<!Languages> 
         default:
           name: ''
@@ -1497,9 +1398,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1510,7 +1411,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_55
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1521,7 +1422,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_52
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1532,7 +1433,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1562,12 +1463,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1608,9 +1510,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1621,7 +1523,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1632,7 +1534,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_53
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1643,7 +1545,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1659,8 +1561,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1691,9 +1594,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1704,7 +1607,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1715,7 +1618,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_54
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1726,7 +1629,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1742,8 +1645,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1770,9 +1674,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1783,7 +1687,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1794,7 +1698,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_55
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1805,7 +1709,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1835,12 +1739,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1872,9 +1777,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1885,18 +1790,18 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: accountName
-            description: The name of the storage account.
+            description: 'The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  '
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_56
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1907,7 +1812,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1923,11 +1828,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys'
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_65
+      schema: *ref_57
       language: !<!Languages> 
         default:
           name: ''
@@ -1951,9 +1857,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_58
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1964,7 +1870,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1980,11 +1886,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_59
       language: !<!Languages> 
         default:
           name: ''
@@ -2011,9 +1918,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2024,7 +1931,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_60
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2035,7 +1942,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2051,11 +1958,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_59
       language: !<!Languages> 
         default:
           name: ''
@@ -2082,9 +1990,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2095,7 +2003,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2106,7 +2014,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_61
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2117,7 +2025,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2128,7 +2036,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_62
         implementation: Method
         required: true
         extensions:
@@ -2147,15 +2055,16 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_65
+      schema: *ref_57
       language: !<!Languages> 
         default:
           name: ''
@@ -2189,9 +2098,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_63
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2202,7 +2111,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2218,11 +2127,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_64
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/storage/modeler.yaml
+++ b/modelerfour/test/outputs/storage/modeler.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_51
+  - !<!ObjectSchema> &ref_49
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -50,14 +50,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_52
+  - !<!ObjectSchema> &ref_50
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_36
+      schema: !<!BooleanSchema> &ref_35
         type: boolean
         language: !<!Languages> 
           default:
@@ -71,7 +71,7 @@ schemas: !<!Schemas>
           description: 'Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or invalid and cannot be used.'
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ChoiceSchema> &ref_38
+      schema: !<!ChoiceSchema> &ref_37
         choices:
         - !<!ChoiceValue> 
           value: AccountNameInvalid
@@ -241,7 +241,7 @@ schemas: !<!Schemas>
               version: 2015-05-01-preview
             properties:
             - !<!Property> 
-              schema: !<!ChoiceSchema> &ref_39
+              schema: !<!ChoiceSchema> &ref_38
                 choices:
                 - !<!ChoiceValue> 
                   value: Creating
@@ -458,7 +458,7 @@ schemas: !<!Schemas>
                   description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!DateTimeSchema> &ref_43
+              schema: !<!DateTimeSchema> &ref_42
                 type: date-time
                 format: date-time
                 apiVersions:
@@ -505,7 +505,7 @@ schemas: !<!Schemas>
                   description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!DateTimeSchema> &ref_44
+              schema: !<!DateTimeSchema> &ref_43
                 type: date-time
                 format: date-time
                 apiVersions:
@@ -547,7 +547,7 @@ schemas: !<!Schemas>
                       description: Gets or sets the custom domain name. Name is the CNAME source.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!BooleanSchema> &ref_37
+                  schema: !<!BooleanSchema> &ref_36
                     type: boolean
                     language: !<!Languages> 
                       default:
@@ -731,7 +731,7 @@ schemas: !<!Schemas>
           description: Resource location
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_42
+      schema: !<!DictionarySchema> &ref_41
         type: dictionary
         elementType: !<!StringSchema> &ref_8
           type: string
@@ -773,7 +773,7 @@ schemas: !<!Schemas>
   - *ref_19
   - *ref_22
   - *ref_27
-  - !<!ObjectSchema> &ref_65
+  - !<!ObjectSchema> &ref_57
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -797,21 +797,12 @@ schemas: !<!Schemas>
           description: Gets the value of key 1.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_29
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 2015-05-01-preview
-        language: !<!Languages> 
-          default:
-            name: StorageAccountKeys-key2
-            description: Gets the value of key 2.
-        protocol: !<!Protocols> {}
+      schema: *ref_28
       serializedName: key2
       language: !<!Languages> 
         default:
           name: key2
-          description: Gets the value of key 2.
+          description: Gets the value of key 1.
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -819,14 +810,14 @@ schemas: !<!Schemas>
         description: The access keys for the storage account.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_67
+  - !<!ObjectSchema> &ref_59
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_45
+      schema: !<!ArraySchema> &ref_44
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -844,7 +835,7 @@ schemas: !<!Schemas>
           description: Gets the list of storage accounts and their properties.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_30
+      schema: !<!StringSchema> &ref_29
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -866,14 +857,14 @@ schemas: !<!Schemas>
         description: The list storage accounts operation response.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_71
+  - !<!ObjectSchema> &ref_62
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ChoiceSchema> &ref_40
+      schema: !<!ChoiceSchema> &ref_39
         choices:
         - !<!ChoiceValue> 
           value: key1
@@ -909,26 +900,26 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_73
+  - !<!ObjectSchema> &ref_64
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_46
+      schema: !<!ArraySchema> &ref_45
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        elementType: !<!ObjectSchema> &ref_33
+        elementType: !<!ObjectSchema> &ref_32
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
           properties:
           - !<!Property> 
-            schema: !<!ChoiceSchema> &ref_41
+            schema: !<!ChoiceSchema> &ref_40
               choices:
               - !<!ChoiceValue> 
                 value: Count
@@ -983,7 +974,7 @@ schemas: !<!Schemas>
                 description: Gets the unit of measurement.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!NumberSchema> &ref_47
+            schema: !<!NumberSchema> &ref_46
               type: integer
               precision: 32
               language: !<!Languages> 
@@ -998,7 +989,7 @@ schemas: !<!Schemas>
                 description: Gets the current count of the allocated resources in the subscription.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!NumberSchema> &ref_48
+            schema: !<!NumberSchema> &ref_47
               type: integer
               precision: 32
               language: !<!Languages> 
@@ -1013,14 +1004,14 @@ schemas: !<!Schemas>
                 description: Gets the maximum count of the resources that can be allocated in the subscription.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_34
+            schema: !<!ObjectSchema> &ref_33
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
               properties:
               - !<!Property> 
-                schema: !<!StringSchema> &ref_31
+                schema: !<!StringSchema> &ref_30
                   type: string
                   apiVersions:
                   - !<!ApiVersion> 
@@ -1037,7 +1028,7 @@ schemas: !<!Schemas>
                     description: Gets a string describing the resource name.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!StringSchema> &ref_32
+                schema: !<!StringSchema> &ref_31
                   type: string
                   apiVersions:
                   - !<!ApiVersion> 
@@ -1088,8 +1079,8 @@ schemas: !<!Schemas>
         description: The List Usages operation response.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
+  - *ref_32
   - *ref_33
-  - *ref_34
   - !<!ObjectSchema> 
     type: object
     apiVersions:
@@ -1097,7 +1088,7 @@ schemas: !<!Schemas>
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_35
+      schema: !<!StringSchema> &ref_34
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -1122,22 +1113,78 @@ schemas: !<!Schemas>
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
   dictionaries:
-  - *ref_42
-  choices:
-  - *ref_38
-  - *ref_10
-  - *ref_39
-  - *ref_17
-  - *ref_40
   - *ref_41
-  arrays:
-  - *ref_45
-  - *ref_46
-  booleans:
-  - *ref_36
+  choices:
   - *ref_37
+  - *ref_10
+  - *ref_38
+  - *ref_17
+  - *ref_39
+  - *ref_40
+  arrays:
+  - *ref_44
+  - *ref_45
+  booleans:
+  - *ref_35
+  - *ref_36
   constants:
-  - !<!ConstantSchema> &ref_49
+  - !<!ConstantSchema> &ref_48
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_0
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_52
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_0
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_53
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_0
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_54
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_0
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_55
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1193,7 +1240,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-05-01-preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
+  - !<!ConstantSchema> &ref_61
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1207,63 +1254,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-05-01-preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_64
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
+  - !<!ConstantSchema> &ref_63
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1278,125 +1269,34 @@ schemas: !<!Schemas>
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   dateTimes:
+  - *ref_42
   - *ref_43
-  - *ref_44
   numbers:
+  - *ref_46
   - *ref_47
-  - *ref_48
   strings:
   - *ref_0
-  - !<!StringSchema> &ref_50
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: components·parameters·subscriptionidparameter·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_8
   - *ref_1
   - *ref_2
   - *ref_3
-  - !<!StringSchema> &ref_54
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: components·parameters·resourcegroupname·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_55
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·put·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_4
   - *ref_5
   - *ref_6
   - *ref_7
-  - *ref_8
   - *ref_11
   - *ref_12
   - *ref_13
   - *ref_15
   - *ref_16
   - *ref_18
-  - !<!StringSchema> &ref_57
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·delete·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_59
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_61
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname·patch·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_63
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-listkeys·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_28
   - *ref_29
   - *ref_30
-  - !<!StringSchema> &ref_69
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname-providers-microsoft-storage-storageaccounts-accountname-regeneratekey·post·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_31
-  - *ref_32
-  - *ref_35
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: components·parameters·apiversionparameter·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
+  - *ref_34
 globalParameters:
-- !<!Parameter> &ref_53
+- !<!Parameter> &ref_51
   schema: *ref_0
   clientDefaultValue: 'https://management.azure.com'
   implementation: Client
@@ -1407,7 +1307,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   title: storage
 operationGroups:
@@ -1420,9 +1320,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_48
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1433,7 +1333,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1444,7 +1344,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_49
         implementation: Method
         required: true
         extensions:
@@ -1463,15 +1363,16 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_52
+      schema: *ref_50
       language: !<!Languages> 
         default:
           name: ''
@@ -1497,9 +1398,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1510,7 +1411,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_55
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1521,7 +1422,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_52
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1532,7 +1433,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1562,12 +1463,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_21
@@ -1608,9 +1510,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1621,7 +1523,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1632,7 +1534,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_53
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1643,7 +1545,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1659,8 +1561,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1691,9 +1594,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1704,7 +1607,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1715,7 +1618,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_54
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1726,7 +1629,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1742,8 +1645,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_21
@@ -1770,9 +1674,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1783,7 +1687,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1794,7 +1698,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_55
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1805,7 +1709,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1835,12 +1739,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_21
@@ -1872,9 +1777,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1885,18 +1790,18 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: accountName
-            description: The name of the storage account.
+            description: 'The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  '
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_56
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1907,7 +1812,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1923,11 +1828,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys'
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_65
+      schema: *ref_57
       language: !<!Languages> 
         default:
           name: ''
@@ -1951,9 +1857,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_58
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1964,7 +1870,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1980,11 +1886,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_59
       language: !<!Languages> 
         default:
           name: ''
@@ -2011,9 +1918,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2024,7 +1931,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_60
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2035,7 +1942,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2051,11 +1958,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_59
       language: !<!Languages> 
         default:
           name: ''
@@ -2082,9 +1990,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2095,7 +2003,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2106,7 +2014,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_61
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2117,7 +2025,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2128,7 +2036,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_62
         implementation: Method
         required: true
         extensions:
@@ -2147,15 +2055,16 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_65
+      schema: *ref_57
       language: !<!Languages> 
         default:
           name: ''
@@ -2189,9 +2098,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_53
+      - *ref_51
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_63
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2202,7 +2111,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_8
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2218,11 +2127,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_64
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/storage/namer.yaml
+++ b/modelerfour/test/outputs/storage/namer.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_52
+  - !<!ObjectSchema> &ref_50
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_29
+      schema: !<!StringSchema> &ref_31
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -26,7 +26,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_30
+      schema: !<!StringSchema> &ref_32
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -50,14 +50,14 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_53
+  - !<!ObjectSchema> &ref_51
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!BooleanSchema> &ref_23
+      schema: !<!BooleanSchema> &ref_24
         type: boolean
         language: !<!Languages> 
           default:
@@ -71,7 +71,7 @@ schemas: !<!Schemas>
           description: 'Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or invalid and cannot be used.'
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ChoiceSchema> &ref_17
+      schema: !<!ChoiceSchema> &ref_18
         choices:
         - !<!ChoiceValue> 
           value: AccountNameInvalid
@@ -108,7 +108,7 @@ schemas: !<!Schemas>
           description: Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_31
+      schema: !<!StringSchema> &ref_33
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -241,7 +241,7 @@ schemas: !<!Schemas>
               version: 2015-05-01-preview
             properties:
             - !<!Property> 
-              schema: !<!ChoiceSchema> &ref_18
+              schema: !<!ChoiceSchema> &ref_19
                 choices:
                 - !<!ChoiceValue> 
                   value: Creating
@@ -293,7 +293,7 @@ schemas: !<!Schemas>
                   version: 2015-05-01-preview
                 properties:
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_37
+                  schema: !<!StringSchema> &ref_38
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -310,7 +310,7 @@ schemas: !<!Schemas>
                       description: Gets the blob endpoint.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_38
+                  schema: !<!StringSchema> &ref_39
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -327,7 +327,7 @@ schemas: !<!Schemas>
                       description: Gets the queue endpoint.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_39
+                  schema: !<!StringSchema> &ref_40
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -410,7 +410,7 @@ schemas: !<!Schemas>
                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!StringSchema> &ref_40
+              schema: !<!StringSchema> &ref_41
                 type: string
                 apiVersions:
                 - !<!ApiVersion> 
@@ -458,7 +458,7 @@ schemas: !<!Schemas>
                   description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!DateTimeSchema> &ref_25
+              schema: !<!DateTimeSchema> &ref_26
                 type: date-time
                 format: date-time
                 apiVersions:
@@ -480,7 +480,7 @@ schemas: !<!Schemas>
                     if the accountType is StandardGRS or StandardRAGRS.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!StringSchema> &ref_41
+              schema: !<!StringSchema> &ref_42
                 type: string
                 apiVersions:
                 - !<!ApiVersion> 
@@ -505,7 +505,7 @@ schemas: !<!Schemas>
                   description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
               protocol: !<!Protocols> {}
             - !<!Property> 
-              schema: !<!DateTimeSchema> &ref_26
+              schema: !<!DateTimeSchema> &ref_27
                 type: date-time
                 format: date-time
                 apiVersions:
@@ -530,7 +530,7 @@ schemas: !<!Schemas>
                   version: 2015-05-01-preview
                 properties:
                 - !<!Property> 
-                  schema: !<!StringSchema> &ref_42
+                  schema: !<!StringSchema> &ref_43
                     type: string
                     apiVersions:
                     - !<!ApiVersion> 
@@ -547,7 +547,7 @@ schemas: !<!Schemas>
                       description: Gets or sets the custom domain name. Name is the CNAME source.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!BooleanSchema> &ref_24
+                  schema: !<!BooleanSchema> &ref_25
                     type: boolean
                     language: !<!Languages> 
                       default:
@@ -656,7 +656,7 @@ schemas: !<!Schemas>
       - *ref_8
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_32
+      schema: !<!StringSchema> &ref_34
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -675,7 +675,7 @@ schemas: !<!Schemas>
           description: Resource Id
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_33
+      schema: !<!StringSchema> &ref_35
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -694,7 +694,7 @@ schemas: !<!Schemas>
           description: Resource name
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_34
+      schema: !<!StringSchema> &ref_36
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -713,7 +713,7 @@ schemas: !<!Schemas>
           description: Resource type
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_35
+      schema: !<!StringSchema> &ref_37
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -731,9 +731,9 @@ schemas: !<!Schemas>
           description: Resource location
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!DictionarySchema> &ref_16
+      schema: !<!DictionarySchema> &ref_17
         type: dictionary
-        elementType: !<!StringSchema> &ref_36
+        elementType: !<!StringSchema> &ref_30
           type: string
           apiVersions:
           - !<!ApiVersion> 
@@ -773,14 +773,14 @@ schemas: !<!Schemas>
   - *ref_5
   - *ref_8
   - *ref_13
-  - !<!ObjectSchema> &ref_65
+  - !<!ObjectSchema> &ref_57
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_43
+      schema: !<!StringSchema> &ref_14
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -797,21 +797,12 @@ schemas: !<!Schemas>
           description: Gets the value of key 1.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_44
-        type: string
-        apiVersions:
-        - !<!ApiVersion> 
-          version: 2015-05-01-preview
-        language: !<!Languages> 
-          default:
-            name: StorageAccountKeys-key2
-            description: Gets the value of key 2.
-        protocol: !<!Protocols> {}
+      schema: *ref_14
       serializedName: key2
       language: !<!Languages> 
         default:
           name: key2
-          description: Gets the value of key 2.
+          description: Gets the value of key 1.
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -819,14 +810,14 @@ schemas: !<!Schemas>
         description: The access keys for the storage account.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_67
+  - !<!ObjectSchema> &ref_59
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_21
+      schema: !<!ArraySchema> &ref_22
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -844,7 +835,7 @@ schemas: !<!Schemas>
           description: Gets the list of storage accounts and their properties.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_45
+      schema: !<!StringSchema> &ref_44
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -866,14 +857,14 @@ schemas: !<!Schemas>
         description: The list storage accounts operation response.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_71
+  - !<!ObjectSchema> &ref_62
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ChoiceSchema> &ref_19
+      schema: !<!ChoiceSchema> &ref_20
         choices:
         - !<!ChoiceValue> 
           value: key1
@@ -909,26 +900,26 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_73
+  - !<!ObjectSchema> &ref_64
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_22
+      schema: !<!ArraySchema> &ref_23
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        elementType: !<!ObjectSchema> &ref_14
+        elementType: !<!ObjectSchema> &ref_15
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
           properties:
           - !<!Property> 
-            schema: !<!ChoiceSchema> &ref_20
+            schema: !<!ChoiceSchema> &ref_21
               choices:
               - !<!ChoiceValue> 
                 value: Count
@@ -983,7 +974,7 @@ schemas: !<!Schemas>
                 description: Gets the unit of measurement.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!NumberSchema> &ref_27
+            schema: !<!NumberSchema> &ref_28
               type: integer
               precision: 32
               language: !<!Languages> 
@@ -998,7 +989,7 @@ schemas: !<!Schemas>
                 description: Gets the current count of the allocated resources in the subscription.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!NumberSchema> &ref_28
+            schema: !<!NumberSchema> &ref_29
               type: integer
               precision: 32
               language: !<!Languages> 
@@ -1013,14 +1004,14 @@ schemas: !<!Schemas>
                 description: Gets the maximum count of the resources that can be allocated in the subscription.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_15
+            schema: !<!ObjectSchema> &ref_16
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
               properties:
               - !<!Property> 
-                schema: !<!StringSchema> &ref_46
+                schema: !<!StringSchema> &ref_45
                   type: string
                   apiVersions:
                   - !<!ApiVersion> 
@@ -1037,7 +1028,7 @@ schemas: !<!Schemas>
                     description: Gets a string describing the resource name.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!StringSchema> &ref_47
+                schema: !<!StringSchema> &ref_46
                   type: string
                   apiVersions:
                   - !<!ApiVersion> 
@@ -1088,8 +1079,8 @@ schemas: !<!Schemas>
         description: The List Usages operation response.
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
-  - *ref_14
   - *ref_15
+  - *ref_16
   - !<!ObjectSchema> 
     type: object
     apiVersions:
@@ -1097,7 +1088,7 @@ schemas: !<!Schemas>
       version: 2015-05-01-preview
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_48
+      schema: !<!StringSchema> &ref_47
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -1122,22 +1113,78 @@ schemas: !<!Schemas>
         namespace: Api20150501Preview
     protocol: !<!Protocols> {}
   dictionaries:
-  - *ref_16
-  choices:
   - *ref_17
-  - *ref_2
+  choices:
   - *ref_18
-  - *ref_4
+  - *ref_2
   - *ref_19
+  - *ref_4
   - *ref_20
-  arrays:
   - *ref_21
+  arrays:
   - *ref_22
-  booleans:
   - *ref_23
+  booleans:
   - *ref_24
+  - *ref_25
   constants:
-  - !<!ConstantSchema> &ref_50
+  - !<!ConstantSchema> &ref_49
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_52
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_53
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_54
+    type: constant
+    value: !<!ConstantValue> 
+      value: 2015-05-01-preview
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_1
+    language: !<!Languages> 
+      default:
+        name: ApiVersion-2015-05-01-preview
+        description: Api Version (2015-05-01-preview)
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_55
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1193,7 +1240,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-05-01-preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
+  - !<!ConstantSchema> &ref_61
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1207,63 +1254,7 @@ schemas: !<!Schemas>
         name: ApiVersion-2015-05-01-preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_64
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
-    type: constant
-    value: !<!ConstantValue> 
-      value: 2015-05-01-preview
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_1
-    language: !<!Languages> 
-      default:
-        name: ApiVersion-2015-05-01-preview
-        description: Api Version (2015-05-01-preview)
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
+  - !<!ConstantSchema> &ref_63
     type: constant
     value: !<!ConstantValue> 
       value: 2015-05-01-preview
@@ -1278,46 +1269,15 @@ schemas: !<!Schemas>
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   dateTimes:
-  - *ref_25
   - *ref_26
-  numbers:
   - *ref_27
+  numbers:
   - *ref_28
+  - *ref_29
   strings:
   - *ref_1
-  - !<!StringSchema> &ref_51
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - *ref_29
   - *ref_30
   - *ref_31
-  - !<!StringSchema> &ref_54
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_55
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_32
   - *ref_33
   - *ref_34
@@ -1329,74 +1289,14 @@ schemas: !<!Schemas>
   - *ref_40
   - *ref_41
   - *ref_42
-  - !<!StringSchema> &ref_57
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_59
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_61
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_63
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_43
+  - *ref_14
   - *ref_44
   - *ref_45
-  - !<!StringSchema> &ref_69
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_46
   - *ref_47
-  - *ref_48
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2015-05-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_49
+- !<!Parameter> &ref_48
   schema: *ref_1
   clientDefaultValue: 'https://management.azure.com'
   implementation: Client
@@ -1407,7 +1307,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   title: storage
 operationGroups:
@@ -1420,9 +1320,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_49
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1433,7 +1333,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1444,7 +1344,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_50
         implementation: Method
         required: true
         extensions:
@@ -1463,15 +1363,16 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_53
+      schema: *ref_51
       language: !<!Languages> 
         default:
           name: ''
@@ -1497,9 +1398,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1510,7 +1411,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_55
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1521,7 +1422,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_52
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1532,7 +1433,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1562,12 +1463,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1608,9 +1510,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1621,7 +1523,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1632,7 +1534,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_53
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1643,7 +1545,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1659,8 +1561,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: delete
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1691,9 +1594,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1704,7 +1607,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1715,7 +1618,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_54
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1726,7 +1629,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1742,8 +1645,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1770,9 +1674,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1783,7 +1687,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1794,7 +1698,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_55
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1805,7 +1709,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1835,12 +1739,13 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
           method: patch
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_7
@@ -1872,9 +1777,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1885,18 +1790,18 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: accountName
-            description: The name of the storage account.
+            description: 'The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  '
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_56
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1907,7 +1812,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1923,11 +1828,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys'
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_65
+      schema: *ref_57
       language: !<!Languages> 
         default:
           name: ''
@@ -1951,9 +1857,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_58
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -1964,7 +1870,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1980,11 +1886,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_59
       language: !<!Languages> 
         default:
           name: ''
@@ -2011,9 +1918,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2024,7 +1931,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_60
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2035,7 +1942,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2051,11 +1958,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_67
+      schema: *ref_59
       language: !<!Languages> 
         default:
           name: ''
@@ -2082,9 +1990,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2095,7 +2003,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2106,7 +2014,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_61
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2117,7 +2025,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2128,7 +2036,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_62
         implementation: Method
         required: true
         extensions:
@@ -2147,15 +2055,16 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey'
+          path: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
           - text/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_65
+      schema: *ref_57
       language: !<!Languages> 
         default:
           name: ''
@@ -2189,9 +2098,9 @@ operationGroups:
       version: 2015-05-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_49
+      - *ref_48
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_63
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -2202,7 +2111,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2218,11 +2127,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'
+          path: '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_73
+      schema: *ref_64
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/subscriptionId-apiVersion/flattened.yaml
+++ b/modelerfour/test/outputs/subscriptionId-apiVersion/flattened.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_9
+  - !<!ObjectSchema> &ref_8
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -47,7 +47,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_10
+  - !<!ObjectSchema> &ref_9
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -92,7 +92,7 @@ schemas: !<!Schemas>
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_8
+  - !<!ConstantSchema> &ref_7
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -126,29 +126,9 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_7
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_2
   - *ref_3
   - *ref_4
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_5
   schema: *ref_1
@@ -161,7 +141,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Some cool documentation.
   title: subscriptionId-apiVersion
@@ -188,7 +168,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -199,7 +179,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_7
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -215,11 +195,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -233,7 +214,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_9
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/subscriptionId-apiVersion/modeler.yaml
+++ b/modelerfour/test/outputs/subscriptionId-apiVersion/modeler.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_8
+  - !<!ObjectSchema> &ref_7
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -47,7 +47,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_9
+  - !<!ObjectSchema> &ref_8
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -92,7 +92,7 @@ schemas: !<!Schemas>
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_7
+  - !<!ConstantSchema> &ref_6
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -126,31 +126,11 @@ schemas: !<!Schemas>
         name: components·parameters·subscriptionidparameter·schema
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_6
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: paths·subscriptions-subscriptionid-resourcegroups-resourcegroupname·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
   - *ref_3
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: components·parameters·apiversionparameter·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_10
+- !<!Parameter> &ref_9
   schema: *ref_0
   clientDefaultValue: 'https://management.azure.com'
   implementation: Client
@@ -161,7 +141,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Some cool documentation.
   title: subscriptionId-apiVersion
@@ -175,7 +155,7 @@ operationGroups:
       version: 2014-04-01-preview
     request: !<!Request> 
       parameters:
-      - *ref_10
+      - *ref_9
       - !<!Parameter> 
         schema: *ref_5
         implementation: Method
@@ -188,7 +168,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_5
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -199,7 +179,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -215,11 +195,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -233,7 +214,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/subscriptionId-apiVersion/namer.yaml
+++ b/modelerfour/test/outputs/subscriptionId-apiVersion/namer.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_9
+  - !<!ObjectSchema> &ref_8
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -47,7 +47,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_10
+  - !<!ObjectSchema> &ref_9
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -92,7 +92,7 @@ schemas: !<!Schemas>
         namespace: Api20140401Preview
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_8
+  - !<!ConstantSchema> &ref_7
     type: constant
     value: !<!ConstantValue> 
       value: 2014-04-01-preview
@@ -126,29 +126,9 @@ schemas: !<!Schemas>
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_7
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_2
   - *ref_3
   - *ref_4
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 2014-04-01-preview
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
 globalParameters:
 - !<!Parameter> &ref_5
   schema: *ref_1
@@ -161,7 +141,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Some cool documentation.
   title: subscriptionId-apiVersion
@@ -188,7 +168,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -199,7 +179,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_8
+        schema: *ref_7
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -215,11 +195,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
+          path: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_9
+      schema: *ref_8
       language: !<!Languages> 
         default:
           name: ''
@@ -233,7 +214,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_10
+      schema: *ref_9
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/url-multi-collectionFormat/flattened.yaml
+++ b/modelerfour/test/outputs/url-multi-collectionFormat/flattened.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_8
+  - !<!ObjectSchema> &ref_7
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_7
+  - !<!ArraySchema> &ref_6
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -66,7 +66,7 @@ schemas: !<!Schemas>
         name: Array of get-0-itemsItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_9
+  - !<!ArraySchema> &ref_8
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -86,30 +86,10 @@ schemas: !<!Schemas>
         name: Array of string
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_10
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_4
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
   numbers:
   - *ref_0
   strings:
-  - !<!StringSchema> &ref_5
+  - !<!StringSchema> &ref_4
     type: string
     language: !<!Languages> 
       default:
@@ -119,10 +99,9 @@ schemas: !<!Schemas>
   - *ref_1
   - *ref_2
   - *ref_3
-  - *ref_4
 globalParameters:
-- !<!Parameter> &ref_6
-  schema: *ref_5
+- !<!Parameter> &ref_5
+  schema: *ref_4
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -132,7 +111,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: url-multi-collectionFormat
@@ -146,9 +125,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_6
+      - *ref_5
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Method
         language: !<!Languages> 
           default:
@@ -163,8 +142,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/null'
+          path: /queries/array/multi/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -177,7 +157,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -200,9 +180,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_6
+      - *ref_5
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -217,8 +197,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/empty'
+          path: /queries/array/multi/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -231,7 +212,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -254,14 +235,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_6
+      - *ref_5
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the mult-array format'
+            description: 'an empty array [] of string using the multi-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -271,8 +252,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/valid'
+          path: /queries/array/multi/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -285,7 +267,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/url-multi-collectionFormat/modeler.yaml
+++ b/modelerfour/test/outputs/url-multi-collectionFormat/modeler.yaml
@@ -1,14 +1,14 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_7
+  - !<!ObjectSchema> &ref_6
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!NumberSchema> &ref_4
+      schema: !<!NumberSchema> &ref_3
         type: integer
         precision: 32
         language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-INTEGER
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_3
+      schema: !<!StringSchema> &ref_2
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_6
+  - !<!ArraySchema> &ref_5
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -66,7 +66,7 @@ schemas: !<!Schemas>
         name: paths·queries-array-multi-string-null·get·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_9
+  - !<!ArraySchema> &ref_8
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -86,30 +86,10 @@ schemas: !<!Schemas>
         name: paths·queries-array-multi-string-empty·get·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_10
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_2
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·queries-array-multi-string-valid·get·parameters·0·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·queries-array-multi-string-valid·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
   numbers:
-  - *ref_4
+  - *ref_3
   strings:
-  - !<!StringSchema> &ref_5
+  - !<!StringSchema> &ref_4
     type: string
     language: !<!Languages> 
       default:
@@ -117,12 +97,11 @@ schemas: !<!Schemas>
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_0
-  - *ref_3
-  - *ref_1
   - *ref_2
+  - *ref_1
 globalParameters:
-- !<!Parameter> &ref_8
-  schema: *ref_5
+- !<!Parameter> &ref_7
+  schema: *ref_4
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -132,7 +111,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: url-multi-collectionFormat
@@ -146,9 +125,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_8
+      - *ref_7
       - !<!Parameter> 
-        schema: *ref_6
+        schema: *ref_5
         implementation: Method
         language: !<!Languages> 
           default:
@@ -163,8 +142,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/null'
+          path: /queries/array/multi/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -177,7 +157,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -200,9 +180,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_8
+      - *ref_7
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -217,8 +197,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/empty'
+          path: /queries/array/multi/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -231,7 +212,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''
@@ -254,14 +235,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_8
+      - *ref_7
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the mult-array format'
+            description: 'an empty array [] of string using the multi-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -271,8 +252,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/valid'
+          path: /queries/array/multi/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -285,7 +267,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_7
+      schema: *ref_6
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/url-multi-collectionFormat/namer.yaml
+++ b/modelerfour/test/outputs/url-multi-collectionFormat/namer.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_8
+  - !<!ObjectSchema> &ref_7
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_7
+  - !<!ArraySchema> &ref_6
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -66,7 +66,7 @@ schemas: !<!Schemas>
         name: Array of get-0-itemsItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_9
+  - !<!ArraySchema> &ref_8
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -86,30 +86,10 @@ schemas: !<!Schemas>
         name: Array of string
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_10
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_4
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
   numbers:
   - *ref_0
   strings:
-  - !<!StringSchema> &ref_5
+  - !<!StringSchema> &ref_4
     type: string
     language: !<!Languages> 
       default:
@@ -119,10 +99,9 @@ schemas: !<!Schemas>
   - *ref_1
   - *ref_2
   - *ref_3
-  - *ref_4
 globalParameters:
-- !<!Parameter> &ref_6
-  schema: *ref_5
+- !<!Parameter> &ref_5
+  schema: *ref_4
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
   required: true
@@ -132,7 +111,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: url-multi-collectionFormat
@@ -146,9 +125,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_6
+      - *ref_5
       - !<!Parameter> 
-        schema: *ref_7
+        schema: *ref_6
         implementation: Method
         language: !<!Languages> 
           default:
@@ -163,8 +142,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/null'
+          path: /queries/array/multi/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -177,7 +157,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -200,9 +180,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_6
+      - *ref_5
       - !<!Parameter> 
-        schema: *ref_9
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
@@ -217,8 +197,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/empty'
+          path: /queries/array/multi/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -231,7 +212,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''
@@ -254,14 +235,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_6
+      - *ref_5
       - !<!Parameter> 
-        schema: *ref_10
+        schema: *ref_8
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the mult-array format'
+            description: 'an empty array [] of string using the multi-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -271,8 +252,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/multi/string/valid'
+          path: /queries/array/multi/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -285,7 +267,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_8
+      schema: *ref_7
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/url/flattened.yaml
+++ b/modelerfour/test/outputs/url/flattened.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_43
+  - !<!ChoiceSchema> &ref_37
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -83,12 +83,12 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_51
+  - !<!ArraySchema> &ref_45
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_20
+    elementType: !<!StringSchema> &ref_21
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -103,112 +103,12 @@ schemas: !<!Schemas>
         name: Array of get-0-itemsItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_75
+  - !<!ArraySchema> &ref_68
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_21
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_76
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_22
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_77
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_23
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_78
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_24
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_79
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_25
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_80
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_26
+    elementType: !<!StringSchema> &ref_20
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -231,7 +131,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_55
+  - !<!BooleanSchema> &ref_49
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -242,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_44
+  - !<!ByteArraySchema> &ref_38
     type: byte-array
     format: byte
     apiVersions:
@@ -253,7 +153,7 @@ schemas: !<!Schemas>
         name: byte-array
         description: MISSING·SCHEMA-DESCRIPTION-BYTEARRAY
     protocol: !<!Protocols> {}
-  - !<!ByteArraySchema> &ref_50
+  - !<!ByteArraySchema> &ref_44
     type: byte-array
     format: base64url
     apiVersions:
@@ -265,7 +165,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-BYTEARRAY
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_23
     type: constant
     value: !<!ConstantValue> 
       value: true
@@ -279,7 +179,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
+  - !<!ConstantSchema> &ref_25
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -292,7 +192,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
+  - !<!ConstantSchema> &ref_26
     type: constant
     value: !<!ConstantValue> 
       value: 1000000
@@ -313,7 +213,7 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
+  - !<!ConstantSchema> &ref_27
     type: constant
     value: !<!ConstantValue> 
       value: -1000000
@@ -334,7 +234,7 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_28
     type: constant
     value: !<!ConstantValue> 
       value: 10000000000
@@ -355,7 +255,7 @@ schemas: !<!Schemas>
         name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_29
     type: constant
     value: !<!ConstantValue> 
       value: -10000000000
@@ -376,7 +276,7 @@ schemas: !<!Schemas>
         name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_30
     type: constant
     value: !<!ConstantValue> 
       value: 103400000000000000000
@@ -397,7 +297,7 @@ schemas: !<!Schemas>
         name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
+  - !<!ConstantSchema> &ref_31
     type: constant
     value: !<!ConstantValue> 
       value: -1.034e-20
@@ -418,7 +318,7 @@ schemas: !<!Schemas>
         name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
+  - !<!ConstantSchema> &ref_32
     type: constant
     value: !<!ConstantValue> 
       value: 9999999.999
@@ -439,7 +339,7 @@ schemas: !<!Schemas>
         name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_33
     type: constant
     value: !<!ConstantValue> 
       value: -9999999.999
@@ -460,7 +360,7 @@ schemas: !<!Schemas>
         name: Constant9
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
+  - !<!ConstantSchema> &ref_34
     type: constant
     value: !<!ConstantValue> 
       value: 啊齄丂狛狜隣郎隣兀﨩
@@ -474,7 +374,7 @@ schemas: !<!Schemas>
         name: Constant10
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
+  - !<!ConstantSchema> &ref_35
     type: constant
     value: !<!ConstantValue> 
       value: 'begin!*''();:@ &=+$,/?#[]end'
@@ -488,7 +388,7 @@ schemas: !<!Schemas>
         name: Constant11
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_41
+  - !<!ConstantSchema> &ref_36
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -501,7 +401,7 @@ schemas: !<!Schemas>
         name: Constant12
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
+  - !<!ConstantSchema> &ref_39
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -514,7 +414,7 @@ schemas: !<!Schemas>
         name: Constant13
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
+  - !<!ConstantSchema> &ref_40
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01'
@@ -528,7 +428,7 @@ schemas: !<!Schemas>
         name: Constant14
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_48
+  - !<!ConstantSchema> &ref_42
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01T01:01:01Z'
@@ -542,7 +442,7 @@ schemas: !<!Schemas>
         name: Constant15
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_47
     type: constant
     value: !<!ConstantValue> 
       value: true
@@ -556,7 +456,7 @@ schemas: !<!Schemas>
         name: Constant16
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_54
+  - !<!ConstantSchema> &ref_48
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -569,7 +469,7 @@ schemas: !<!Schemas>
         name: Constant17
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_56
+  - !<!ConstantSchema> &ref_50
     type: constant
     value: !<!ConstantValue> 
       value: 1000000
@@ -590,7 +490,7 @@ schemas: !<!Schemas>
         name: Constant18
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_57
+  - !<!ConstantSchema> &ref_51
     type: constant
     value: !<!ConstantValue> 
       value: -1000000
@@ -611,7 +511,7 @@ schemas: !<!Schemas>
         name: Constant19
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_59
+  - !<!ConstantSchema> &ref_53
     type: constant
     value: !<!ConstantValue> 
       value: 10000000000
@@ -632,7 +532,7 @@ schemas: !<!Schemas>
         name: Constant20
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_60
+  - !<!ConstantSchema> &ref_54
     type: constant
     value: !<!ConstantValue> 
       value: -10000000000
@@ -653,7 +553,7 @@ schemas: !<!Schemas>
         name: Constant21
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
+  - !<!ConstantSchema> &ref_56
     type: constant
     value: !<!ConstantValue> 
       value: 103400000000000000000
@@ -674,7 +574,7 @@ schemas: !<!Schemas>
         name: Constant22
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_63
+  - !<!ConstantSchema> &ref_57
     type: constant
     value: !<!ConstantValue> 
       value: -1.034e-20
@@ -695,7 +595,7 @@ schemas: !<!Schemas>
         name: Constant23
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_65
+  - !<!ConstantSchema> &ref_59
     type: constant
     value: !<!ConstantValue> 
       value: 9999999.999
@@ -716,7 +616,7 @@ schemas: !<!Schemas>
         name: Constant24
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
+  - !<!ConstantSchema> &ref_60
     type: constant
     value: !<!ConstantValue> 
       value: -9999999.999
@@ -737,7 +637,7 @@ schemas: !<!Schemas>
         name: Constant25
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
+  - !<!ConstantSchema> &ref_62
     type: constant
     value: !<!ConstantValue> 
       value: 啊齄丂狛狜隣郎隣兀﨩
@@ -751,7 +651,7 @@ schemas: !<!Schemas>
         name: Constant26
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_69
+  - !<!ConstantSchema> &ref_63
     type: constant
     value: !<!ConstantValue> 
       value: 'begin!*''();:@ &=+$,/?#[]end'
@@ -765,7 +665,7 @@ schemas: !<!Schemas>
         name: Constant27
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
+  - !<!ConstantSchema> &ref_64
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -778,7 +678,7 @@ schemas: !<!Schemas>
         name: Constant28
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
+  - !<!ConstantSchema> &ref_65
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -791,7 +691,7 @@ schemas: !<!Schemas>
         name: Constant29
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
+  - !<!ConstantSchema> &ref_66
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01'
@@ -805,7 +705,7 @@ schemas: !<!Schemas>
         name: Constant30
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_74
+  - !<!ConstantSchema> &ref_67
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01T01:01:01Z'
@@ -820,7 +720,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   dateTimes:
-  - !<!DateTimeSchema> &ref_49
+  - !<!DateTimeSchema> &ref_43
     type: date-time
     format: date-time
     apiVersions:
@@ -832,7 +732,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-DATETIME
     protocol: !<!Protocols> {}
   dates:
-  - !<!DateSchema> &ref_47
+  - !<!DateSchema> &ref_41
     type: date
     apiVersions:
     - !<!ApiVersion> 
@@ -854,7 +754,7 @@ schemas: !<!Schemas>
   - *ref_10
   - *ref_11
   - *ref_12
-  - !<!NumberSchema> &ref_58
+  - !<!NumberSchema> &ref_52
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -867,7 +767,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_13
   - *ref_14
-  - !<!NumberSchema> &ref_61
+  - !<!NumberSchema> &ref_55
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -880,7 +780,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_15
   - *ref_16
-  - !<!NumberSchema> &ref_64
+  - !<!NumberSchema> &ref_58
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -893,7 +793,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_17
   - *ref_18
-  - !<!NumberSchema> &ref_67
+  - !<!NumberSchema> &ref_61
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -907,191 +807,66 @@ schemas: !<!Schemas>
   strings:
   - *ref_1
   - *ref_19
-  - !<!StringSchema> &ref_42
+  - *ref_20
+  - *ref_21
+  - !<!StringSchema> &ref_69
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_20
+  - !<!StringSchema> &ref_70
+    type: string
+    language: !<!Languages> 
+      default:
+        name: string
+        description: MISSING·SCHEMA-DESCRIPTION-STRING
+    protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_71
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_21
-  - *ref_22
-  - *ref_23
-  - *ref_24
-  - *ref_25
-  - *ref_26
-  - !<!StringSchema> &ref_81
+  - !<!StringSchema> &ref_72
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_82
+  - !<!StringSchema> &ref_73
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_83
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_84
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_85
+  - !<!StringSchema> &ref_74
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_86
+  - !<!StringSchema> &ref_75
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_87
+  - !<!StringSchema> &ref_76
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_88
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_89
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_90
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_91
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_92
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_93
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_94
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_95
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_96
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
   unixtimes:
-  - !<!UnixTimeSchema> &ref_52
+  - !<!UnixTimeSchema> &ref_46
     type: unixtime
     apiVersions:
     - !<!ApiVersion> 
@@ -1102,7 +877,7 @@ schemas: !<!Schemas>
         description: 'date in seconds since 1970-01-01T00:00:00Z.'
     protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_27
+- !<!Parameter> &ref_22
   schema: *ref_1
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
@@ -1113,7 +888,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: url
@@ -1127,9 +902,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_23
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1145,8 +920,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/bool/true/{boolPath}'
+          path: '/paths/bool/true/{boolPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1159,7 +935,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1182,9 +958,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_25
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1200,8 +976,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/bool/false/{boolPath}'
+          path: '/paths/bool/false/{boolPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1214,7 +991,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1237,9 +1014,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1255,8 +1032,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/1000000/{intPath}'
+          path: '/paths/int/1000000/{intPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1269,7 +1047,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1292,9 +1070,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_27
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1310,8 +1088,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/-1000000/{intPath}'
+          path: '/paths/int/-1000000/{intPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1324,7 +1103,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1347,9 +1126,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_28
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1365,8 +1144,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/long/10000000000/{longPath}'
+          path: '/paths/long/10000000000/{longPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1379,7 +1159,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1402,9 +1182,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_29
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1420,8 +1200,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/long/-10000000000/{longPath}'
+          path: '/paths/long/-10000000000/{longPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1434,7 +1215,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1457,9 +1238,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1475,8 +1256,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/float/1.034E+20/{floatPath}'
+          path: '/paths/float/1.034E+20/{floatPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1489,7 +1271,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1512,9 +1294,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_31
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1530,8 +1312,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/float/-1.034E-20/{floatPath}'
+          path: '/paths/float/-1.034E-20/{floatPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1544,7 +1327,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1567,9 +1350,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_32
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1585,8 +1368,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/double/9999999.999/{doublePath}'
+          path: '/paths/double/9999999.999/{doublePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1599,7 +1383,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1622,9 +1406,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_33
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1640,8 +1424,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/double/-9999999.999/{doublePath}'
+          path: '/paths/double/-9999999.999/{doublePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1654,7 +1439,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1677,9 +1462,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_34
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1695,8 +1480,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/unicode/{stringPath}'
+          path: '/paths/string/unicode/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1709,7 +1495,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1732,9 +1518,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_35
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1750,8 +1536,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}'
+          path: '/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1764,7 +1551,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1787,9 +1574,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_36
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1805,8 +1592,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/empty/{stringPath}'
+          path: '/paths/string/empty/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1819,7 +1607,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1842,9 +1630,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1860,8 +1648,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/null/{stringPath}'
+          path: '/paths/string/null/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1874,7 +1663,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1897,9 +1686,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1915,8 +1704,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/enum/green%20color/{enumPath}'
+          path: '/paths/enum/green%20color/{enumPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1929,7 +1719,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1952,15 +1742,15 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: enumPath
-            description: send null should throw
+            description: send the value green
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1970,8 +1760,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/null/{enumPath}'
+          path: '/paths/string/null/{enumPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1984,7 +1775,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2007,9 +1798,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2025,8 +1816,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/multibyte/{bytePath}'
+          path: '/paths/byte/multibyte/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2039,7 +1831,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2062,9 +1854,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_39
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2080,8 +1872,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/empty/{bytePath}'
+          path: '/paths/byte/empty/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2094,7 +1887,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2117,15 +1910,15 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: bytePath
-            description: null as byte array (should throw)
+            description: '''啊齄丂狛狜隣郎隣兀﨩'' multibyte value as utf-8 encoded byte array'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -2135,8 +1928,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/null/{bytePath}'
+          path: '/paths/byte/null/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2149,7 +1943,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2172,9 +1966,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_40
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2190,8 +1984,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/date/2012-01-01/{datePath}'
+          path: '/paths/date/2012-01-01/{datePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2204,7 +1999,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2227,9 +2022,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_41
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2245,8 +2040,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/date/null/{datePath}'
+          path: '/paths/date/null/{datePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2259,7 +2055,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2282,9 +2078,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_42
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2300,8 +2096,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}'
+          path: '/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2314,7 +2111,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2337,9 +2134,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_43
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2355,8 +2152,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/datetime/null/{dateTimePath}'
+          path: '/paths/datetime/null/{dateTimePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2369,7 +2167,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2392,9 +2190,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_44
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2410,8 +2208,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/bG9yZW0/{base64UrlPath}'
+          path: '/paths/string/bG9yZW0/{base64UrlPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2424,7 +2223,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2447,9 +2246,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_45
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2465,8 +2264,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}'
+          path: '/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2479,7 +2279,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2502,9 +2302,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_46
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2520,8 +2320,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/1460505600/{unixTimeUrlPath}'
+          path: '/paths/int/1460505600/{unixTimeUrlPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2534,7 +2335,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2565,9 +2366,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_53
+        schema: *ref_47
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2583,8 +2384,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/true'
+          path: /queries/bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2597,7 +2399,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2620,9 +2422,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_48
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2638,8 +2440,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/false'
+          path: /queries/bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2652,7 +2455,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2675,9 +2478,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_55
+        schema: *ref_49
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2692,8 +2495,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/null'
+          path: /queries/bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2706,7 +2510,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2729,9 +2533,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_50
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2747,8 +2551,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/1000000'
+          path: /queries/int/1000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2761,7 +2566,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2784,9 +2589,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_51
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2802,8 +2607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/-1000000'
+          path: /queries/int/-1000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2816,7 +2622,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2839,9 +2645,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_52
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2856,8 +2662,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/null'
+          path: /queries/int/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2870,7 +2677,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2893,9 +2700,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_53
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2911,8 +2718,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/10000000000'
+          path: /queries/long/10000000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2925,7 +2733,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2948,9 +2756,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_54
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2966,8 +2774,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/-10000000000'
+          path: /queries/long/-10000000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2980,7 +2789,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3003,9 +2812,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_55
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3020,8 +2829,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/null'
+          path: /queries/long/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3034,7 +2844,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3057,9 +2867,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_56
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3075,8 +2885,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/1.034E+20'
+          path: /queries/float/1.034E+20
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3089,7 +2900,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3112,9 +2923,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_57
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3130,8 +2941,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/-1.034E-20'
+          path: /queries/float/-1.034E-20
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3144,7 +2956,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3167,9 +2979,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_58
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3184,8 +2996,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/null'
+          path: /queries/float/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3198,7 +3011,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3221,9 +3034,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_59
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3239,8 +3052,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/9999999.999'
+          path: /queries/double/9999999.999
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3253,7 +3067,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3276,9 +3090,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_60
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3294,8 +3108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/-9999999.999'
+          path: /queries/double/-9999999.999
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3308,7 +3123,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3331,9 +3146,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_61
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3348,8 +3163,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/null'
+          path: /queries/double/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3362,7 +3178,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3385,9 +3201,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_62
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3403,8 +3219,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/unicode/'
+          path: /queries/string/unicode/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3417,7 +3234,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3440,9 +3257,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_63
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3458,8 +3275,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend'
+          path: /queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3472,7 +3290,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3495,9 +3313,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_64
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3513,8 +3331,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/empty'
+          path: /queries/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3527,7 +3346,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3550,9 +3369,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3567,8 +3386,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/null'
+          path: /queries/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3581,7 +3401,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3604,9 +3424,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3621,8 +3441,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/enum/green%20color'
+          path: /queries/enum/green%20color
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3635,7 +3456,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3658,14 +3479,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         language: !<!Languages> 
           default:
             name: enumQuery
-            description: null string value
+            description: '''green color'' enum value'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -3675,8 +3496,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/enum/null'
+          path: /queries/enum/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3689,7 +3511,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3712,9 +3534,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3729,8 +3551,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/multibyte'
+          path: /queries/byte/multibyte
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3743,7 +3566,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3766,9 +3589,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_65
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3784,8 +3607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/empty'
+          path: /queries/byte/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3798,7 +3622,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3821,14 +3645,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         language: !<!Languages> 
           default:
             name: byteQuery
-            description: null as byte array (no query parameters in uri)
+            description: '''啊齄丂狛狜隣郎隣兀﨩'' multibyte value as utf-8 encoded byte array'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -3838,8 +3662,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/null'
+          path: /queries/byte/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3852,7 +3677,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3875,9 +3700,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_66
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3893,8 +3718,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/date/2012-01-01'
+          path: /queries/date/2012-01-01
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3907,7 +3733,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3930,9 +3756,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_41
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3947,8 +3773,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/date/null'
+          path: /queries/date/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3961,7 +3788,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3984,9 +3811,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_67
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4002,8 +3829,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/datetime/2012-01-01T01%3A01%3A01Z'
+          path: /queries/datetime/2012-01-01T01%3A01%3A01Z
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4016,7 +3844,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4039,9 +3867,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_43
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4056,8 +3884,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/datetime/null'
+          path: /queries/datetime/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4070,7 +3899,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4093,9 +3922,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4110,8 +3939,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/valid'
+          path: /queries/array/csv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4124,7 +3954,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4147,14 +3977,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: a null array of string using the csv-array format
+            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the csv-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4164,8 +3994,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/null'
+          path: /queries/array/csv/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4178,7 +4009,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4201,14 +4032,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: 'an empty array [] of string using the csv-array format'
+            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the csv-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4218,8 +4049,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/empty'
+          path: /queries/array/csv/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4232,7 +4064,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4255,9 +4087,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_78
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4272,8 +4104,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/ssv/string/valid'
+          path: /queries/array/ssv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4286,7 +4119,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4309,9 +4142,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_79
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4326,8 +4159,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/tsv/string/valid'
+          path: /queries/array/tsv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4340,7 +4174,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4363,9 +4197,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_80
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4380,8 +4214,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/pipes/string/valid'
+          path: /queries/array/pipes/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4394,7 +4229,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4425,9 +4260,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_81
+        schema: *ref_69
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4438,7 +4273,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_82
+        schema: *ref_70
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4448,7 +4283,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_83
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4459,7 +4294,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_84
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4474,8 +4309,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4488,7 +4324,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4513,9 +4349,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_85
+        schema: *ref_71
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4526,7 +4362,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_86
+        schema: *ref_72
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4536,7 +4372,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_87
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4547,7 +4383,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_88
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4562,8 +4398,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4576,7 +4413,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4599,9 +4436,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_89
+        schema: *ref_73
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4612,7 +4449,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_90
+        schema: *ref_74
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4622,7 +4459,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4633,12 +4470,12 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_92
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
             name: localStringQuery
-            description: should contain null value
+            description: should contain value 'localStringQuery'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4648,8 +4485,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4662,7 +4500,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4685,9 +4523,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_93
+        schema: *ref_75
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4698,7 +4536,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_94
+        schema: *ref_76
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4708,7 +4546,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_95
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4719,12 +4557,12 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_96
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
             name: localStringQuery
-            description: should contain value null
+            description: should contain value 'localStringQuery'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4734,8 +4572,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4748,7 +4587,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/url/modeler.yaml
+++ b/modelerfour/test/outputs/url/modeler.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_28
+  - !<!ObjectSchema> &ref_23
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_43
+  - !<!ChoiceSchema> &ref_37
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -83,7 +83,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_51
+  - !<!ArraySchema> &ref_45
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -103,7 +103,7 @@ schemas: !<!Schemas>
         name: paths·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_75
+  - !<!ArraySchema> &ref_68
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -115,112 +115,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: paths·queries-array-csv-string-valid·get·parameters·0·schema·items
+          name: paths·paths-string-null-stringpath·get·parameters·0·schema
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
         name: paths·queries-array-csv-string-valid·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_76
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_22
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·queries-array-csv-string-null·get·parameters·0·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·queries-array-csv-string-null·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_77
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_23
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·queries-array-csv-string-empty·get·parameters·0·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·queries-array-csv-string-empty·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_78
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_24
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·queries-array-ssv-string-valid·get·parameters·0·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·queries-array-ssv-string-valid·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_79
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_25
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·queries-array-tsv-string-valid·get·parameters·0·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·queries-array-tsv-string-valid·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_80
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_26
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: paths·queries-array-pipes-string-valid·get·parameters·0·schema·items
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: paths·queries-array-pipes-string-valid·get·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
   booleans:
@@ -231,7 +131,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_55
+  - !<!BooleanSchema> &ref_49
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -242,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_44
+  - !<!ByteArraySchema> &ref_38
     type: byte-array
     format: byte
     apiVersions:
@@ -253,7 +153,7 @@ schemas: !<!Schemas>
         name: paths·paths-byte-multibyte-bytepath·get·parameters·0·schema
         description: MISSING·SCHEMA-DESCRIPTION-BYTEARRAY
     protocol: !<!Protocols> {}
-  - !<!ByteArraySchema> &ref_50
+  - !<!ByteArraySchema> &ref_44
     type: byte-array
     format: base64url
     apiVersions:
@@ -265,7 +165,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-BYTEARRAY
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_22
     type: constant
     value: !<!ConstantValue> 
       value: true
@@ -279,7 +179,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
+  - !<!ConstantSchema> &ref_25
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -292,7 +192,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
+  - !<!ConstantSchema> &ref_26
     type: constant
     value: !<!ConstantValue> 
       value: 1000000
@@ -313,7 +213,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
+  - !<!ConstantSchema> &ref_27
     type: constant
     value: !<!ConstantValue> 
       value: -1000000
@@ -334,7 +234,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_28
     type: constant
     value: !<!ConstantValue> 
       value: 10000000000
@@ -355,7 +255,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_29
     type: constant
     value: !<!ConstantValue> 
       value: -10000000000
@@ -376,7 +276,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_30
     type: constant
     value: !<!ConstantValue> 
       value: 103400000000000000000
@@ -397,7 +297,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
+  - !<!ConstantSchema> &ref_31
     type: constant
     value: !<!ConstantValue> 
       value: -1.034e-20
@@ -418,7 +318,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
+  - !<!ConstantSchema> &ref_32
     type: constant
     value: !<!ConstantValue> 
       value: 9999999.999
@@ -439,7 +339,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_33
     type: constant
     value: !<!ConstantValue> 
       value: -9999999.999
@@ -460,7 +360,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
+  - !<!ConstantSchema> &ref_34
     type: constant
     value: !<!ConstantValue> 
       value: 啊齄丂狛狜隣郎隣兀﨩
@@ -474,7 +374,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
+  - !<!ConstantSchema> &ref_35
     type: constant
     value: !<!ConstantValue> 
       value: 'begin!*''();:@ &=+$,/?#[]end'
@@ -488,7 +388,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_41
+  - !<!ConstantSchema> &ref_36
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -501,7 +401,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
+  - !<!ConstantSchema> &ref_39
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -514,7 +414,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
+  - !<!ConstantSchema> &ref_40
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01'
@@ -528,7 +428,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_48
+  - !<!ConstantSchema> &ref_42
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01T01:01:01Z'
@@ -542,7 +442,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_47
     type: constant
     value: !<!ConstantValue> 
       value: true
@@ -556,7 +456,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_54
+  - !<!ConstantSchema> &ref_48
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -569,7 +469,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_56
+  - !<!ConstantSchema> &ref_50
     type: constant
     value: !<!ConstantValue> 
       value: 1000000
@@ -590,7 +490,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_57
+  - !<!ConstantSchema> &ref_51
     type: constant
     value: !<!ConstantValue> 
       value: -1000000
@@ -611,7 +511,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_59
+  - !<!ConstantSchema> &ref_53
     type: constant
     value: !<!ConstantValue> 
       value: 10000000000
@@ -632,7 +532,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_60
+  - !<!ConstantSchema> &ref_54
     type: constant
     value: !<!ConstantValue> 
       value: -10000000000
@@ -653,7 +553,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
+  - !<!ConstantSchema> &ref_56
     type: constant
     value: !<!ConstantValue> 
       value: 103400000000000000000
@@ -674,7 +574,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_63
+  - !<!ConstantSchema> &ref_57
     type: constant
     value: !<!ConstantValue> 
       value: -1.034e-20
@@ -695,7 +595,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_65
+  - !<!ConstantSchema> &ref_59
     type: constant
     value: !<!ConstantValue> 
       value: 9999999.999
@@ -716,7 +616,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
+  - !<!ConstantSchema> &ref_60
     type: constant
     value: !<!ConstantValue> 
       value: -9999999.999
@@ -737,7 +637,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
+  - !<!ConstantSchema> &ref_62
     type: constant
     value: !<!ConstantValue> 
       value: 啊齄丂狛狜隣郎隣兀﨩
@@ -751,7 +651,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_69
+  - !<!ConstantSchema> &ref_63
     type: constant
     value: !<!ConstantValue> 
       value: 'begin!*''();:@ &=+$,/?#[]end'
@@ -765,7 +665,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
+  - !<!ConstantSchema> &ref_64
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -778,7 +678,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
+  - !<!ConstantSchema> &ref_65
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -791,7 +691,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
+  - !<!ConstantSchema> &ref_66
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01'
@@ -805,7 +705,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_74
+  - !<!ConstantSchema> &ref_67
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01T01:01:01Z'
@@ -820,7 +720,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   dateTimes:
-  - !<!DateTimeSchema> &ref_49
+  - !<!DateTimeSchema> &ref_43
     type: date-time
     format: date-time
     apiVersions:
@@ -832,7 +732,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-DATETIME
     protocol: !<!Protocols> {}
   dates:
-  - !<!DateSchema> &ref_47
+  - !<!DateSchema> &ref_41
     type: date
     apiVersions:
     - !<!ApiVersion> 
@@ -854,7 +754,7 @@ schemas: !<!Schemas>
   - *ref_11
   - *ref_12
   - *ref_13
-  - !<!NumberSchema> &ref_58
+  - !<!NumberSchema> &ref_52
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -867,7 +767,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_14
   - *ref_15
-  - !<!NumberSchema> &ref_61
+  - !<!NumberSchema> &ref_55
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -880,7 +780,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_16
   - *ref_17
-  - !<!NumberSchema> &ref_64
+  - !<!NumberSchema> &ref_58
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -893,7 +793,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_18
   - *ref_19
-  - !<!NumberSchema> &ref_67
+  - !<!NumberSchema> &ref_61
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -907,191 +807,66 @@ schemas: !<!Schemas>
   strings:
   - *ref_1
   - *ref_2
-  - !<!StringSchema> &ref_42
+  - *ref_21
+  - *ref_20
+  - !<!StringSchema> &ref_69
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     language: !<!Languages> 
       default:
-        name: paths·paths-string-null-stringpath·get·parameters·0·schema
+        name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_20
+  - !<!StringSchema> &ref_70
+    type: string
+    language: !<!Languages> 
+      default:
+        name: ''
+        description: MISSING·SCHEMA-DESCRIPTION-STRING
+    protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_71
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     language: !<!Languages> 
       default:
-        name: paths·queries-string-null·get·parameters·0·schema
+        name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_21
-  - *ref_22
-  - *ref_23
-  - *ref_24
-  - *ref_25
-  - *ref_26
-  - !<!StringSchema> &ref_81
+  - !<!StringSchema> &ref_72
     type: string
     language: !<!Languages> 
       default:
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_82
+  - !<!StringSchema> &ref_73
     type: string
     language: !<!Languages> 
       default:
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_83
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_84
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-pathitemstringquery-localstringquery·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_85
+  - !<!StringSchema> &ref_74
     type: string
     language: !<!Languages> 
       default:
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_86
+  - !<!StringSchema> &ref_75
     type: string
     language: !<!Languages> 
       default:
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_87
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_88
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-localstringquery·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_89
+  - !<!StringSchema> &ref_76
     type: string
     language: !<!Languages> 
       default:
         name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_90
-    type: string
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_91
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_92
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-null-pathitemstringquery-null·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_93
-    type: string
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_94
-    type: string
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_95
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_96
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·pathitem-nullable-globalstringpath-globalstringpath-pathitemstringpath-pathitemstringpath-localstringpath-localstringpath-globalstringquery-null-null·get·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: components·parameters·globalstringpath·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: components·parameters·globalstringquery·schema
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
   unixtimes:
-  - !<!UnixTimeSchema> &ref_52
+  - !<!UnixTimeSchema> &ref_46
     type: unixtime
     apiVersions:
     - !<!ApiVersion> 
@@ -1102,7 +877,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-UNIXTIME
     protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_29
+- !<!Parameter> &ref_24
   schema: *ref_1
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
@@ -1113,7 +888,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: url
@@ -1127,9 +902,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_22
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1145,8 +920,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/bool/true/{boolPath}'
+          path: '/paths/bool/true/{boolPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1159,7 +935,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1182,9 +958,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_25
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1200,8 +976,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/bool/false/{boolPath}'
+          path: '/paths/bool/false/{boolPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1214,7 +991,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1237,9 +1014,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1255,8 +1032,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/1000000/{intPath}'
+          path: '/paths/int/1000000/{intPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1269,7 +1047,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1292,9 +1070,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_27
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1310,8 +1088,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/-1000000/{intPath}'
+          path: '/paths/int/-1000000/{intPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1324,7 +1103,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1347,9 +1126,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_28
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1365,8 +1144,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/long/10000000000/{longPath}'
+          path: '/paths/long/10000000000/{longPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1379,7 +1159,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1402,9 +1182,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_29
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1420,8 +1200,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/long/-10000000000/{longPath}'
+          path: '/paths/long/-10000000000/{longPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1434,7 +1215,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1457,9 +1238,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1475,8 +1256,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/float/1.034E+20/{floatPath}'
+          path: '/paths/float/1.034E+20/{floatPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1489,7 +1271,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1512,9 +1294,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_31
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1530,8 +1312,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/float/-1.034E-20/{floatPath}'
+          path: '/paths/float/-1.034E-20/{floatPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1544,7 +1327,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1567,9 +1350,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_32
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1585,8 +1368,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/double/9999999.999/{doublePath}'
+          path: '/paths/double/9999999.999/{doublePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1599,7 +1383,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1622,9 +1406,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_33
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1640,8 +1424,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/double/-9999999.999/{doublePath}'
+          path: '/paths/double/-9999999.999/{doublePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1654,7 +1439,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1677,9 +1462,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_34
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1695,8 +1480,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/unicode/{stringPath}'
+          path: '/paths/string/unicode/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1709,7 +1495,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1732,9 +1518,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_35
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1750,8 +1536,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}'
+          path: '/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1764,7 +1551,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1787,9 +1574,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_36
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1805,8 +1592,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/empty/{stringPath}'
+          path: '/paths/string/empty/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1819,7 +1607,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1842,9 +1630,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_21
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1860,8 +1648,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/null/{stringPath}'
+          path: '/paths/string/null/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1874,7 +1663,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1897,9 +1686,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1915,8 +1704,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/enum/green%20color/{enumPath}'
+          path: '/paths/enum/green%20color/{enumPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1929,7 +1719,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -1952,15 +1742,15 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: enumPath
-            description: send null should throw
+            description: send the value green
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1970,8 +1760,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/null/{enumPath}'
+          path: '/paths/string/null/{enumPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1984,7 +1775,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2007,9 +1798,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2025,8 +1816,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/multibyte/{bytePath}'
+          path: '/paths/byte/multibyte/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2039,7 +1831,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2062,9 +1854,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_39
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2080,8 +1872,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/empty/{bytePath}'
+          path: '/paths/byte/empty/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2094,7 +1887,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2117,15 +1910,15 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: bytePath
-            description: null as byte array (should throw)
+            description: '''啊齄丂狛狜隣郎隣兀﨩'' multibyte value as utf-8 encoded byte array'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -2135,8 +1928,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/null/{bytePath}'
+          path: '/paths/byte/null/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2149,7 +1943,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2172,9 +1966,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_40
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2190,8 +1984,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/date/2012-01-01/{datePath}'
+          path: '/paths/date/2012-01-01/{datePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2204,7 +1999,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2227,9 +2022,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_41
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2245,8 +2040,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/date/null/{datePath}'
+          path: '/paths/date/null/{datePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2259,7 +2055,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2282,9 +2078,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_42
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2300,8 +2096,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}'
+          path: '/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2314,7 +2111,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2337,9 +2134,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_43
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2355,8 +2152,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/datetime/null/{dateTimePath}'
+          path: '/paths/datetime/null/{dateTimePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2369,7 +2167,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2392,9 +2190,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_44
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2410,8 +2208,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/bG9yZW0/{base64UrlPath}'
+          path: '/paths/string/bG9yZW0/{base64UrlPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2424,7 +2223,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2447,9 +2246,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_45
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2465,8 +2264,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}'
+          path: '/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2479,7 +2279,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2502,9 +2302,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_46
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2520,8 +2320,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/1460505600/{unixTimeUrlPath}'
+          path: '/paths/int/1460505600/{unixTimeUrlPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2534,7 +2335,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2565,9 +2366,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_53
+        schema: *ref_47
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2583,8 +2384,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/true'
+          path: /queries/bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2597,7 +2399,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2620,9 +2422,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_48
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2638,8 +2440,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/false'
+          path: /queries/bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2652,7 +2455,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2675,9 +2478,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_55
+        schema: *ref_49
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2692,8 +2495,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/null'
+          path: /queries/bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2706,7 +2510,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2729,9 +2533,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_50
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2747,8 +2551,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/1000000'
+          path: /queries/int/1000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2761,7 +2566,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2784,9 +2589,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_51
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2802,8 +2607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/-1000000'
+          path: /queries/int/-1000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2816,7 +2622,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2839,9 +2645,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_52
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2856,8 +2662,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/null'
+          path: /queries/int/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2870,7 +2677,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2893,9 +2700,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_53
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2911,8 +2718,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/10000000000'
+          path: /queries/long/10000000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2925,7 +2733,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -2948,9 +2756,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_54
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2966,8 +2774,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/-10000000000'
+          path: /queries/long/-10000000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2980,7 +2789,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3003,9 +2812,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_55
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3020,8 +2829,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/null'
+          path: /queries/long/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3034,7 +2844,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3057,9 +2867,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_56
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3075,8 +2885,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/1.034E+20'
+          path: /queries/float/1.034E+20
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3089,7 +2900,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3112,9 +2923,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_57
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3130,8 +2941,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/-1.034E-20'
+          path: /queries/float/-1.034E-20
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3144,7 +2956,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3167,9 +2979,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_58
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3184,8 +2996,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/null'
+          path: /queries/float/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3198,7 +3011,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3221,9 +3034,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_59
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3239,8 +3052,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/9999999.999'
+          path: /queries/double/9999999.999
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3253,7 +3067,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3276,9 +3090,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_60
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3294,8 +3108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/-9999999.999'
+          path: /queries/double/-9999999.999
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3308,7 +3123,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3331,9 +3146,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_61
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3348,8 +3163,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/null'
+          path: /queries/double/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3362,7 +3178,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3385,9 +3201,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_62
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3403,8 +3219,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/unicode/'
+          path: /queries/string/unicode/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3417,7 +3234,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3440,9 +3257,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_63
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3458,8 +3275,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend'
+          path: /queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3472,7 +3290,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3495,9 +3313,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_64
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3513,8 +3331,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/empty'
+          path: /queries/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3527,7 +3346,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3550,9 +3369,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_21
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3567,8 +3386,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/null'
+          path: /queries/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3581,7 +3401,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3604,9 +3424,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3621,8 +3441,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/enum/green%20color'
+          path: /queries/enum/green%20color
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3635,7 +3456,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3658,14 +3479,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         language: !<!Languages> 
           default:
             name: enumQuery
-            description: null string value
+            description: '''green color'' enum value'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -3675,8 +3496,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/enum/null'
+          path: /queries/enum/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3689,7 +3511,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3712,9 +3534,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3729,8 +3551,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/multibyte'
+          path: /queries/byte/multibyte
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3743,7 +3566,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3766,9 +3589,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_65
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3784,8 +3607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/empty'
+          path: /queries/byte/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3798,7 +3622,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3821,14 +3645,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         language: !<!Languages> 
           default:
             name: byteQuery
-            description: null as byte array (no query parameters in uri)
+            description: '''啊齄丂狛狜隣郎隣兀﨩'' multibyte value as utf-8 encoded byte array'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -3838,8 +3662,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/null'
+          path: /queries/byte/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3852,7 +3677,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3875,9 +3700,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_66
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3893,8 +3718,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/date/2012-01-01'
+          path: /queries/date/2012-01-01
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3907,7 +3733,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3930,9 +3756,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_41
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3947,8 +3773,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/date/null'
+          path: /queries/date/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3961,7 +3788,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -3984,9 +3811,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_67
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4002,8 +3829,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/datetime/2012-01-01T01%3A01%3A01Z'
+          path: /queries/datetime/2012-01-01T01%3A01%3A01Z
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4016,7 +3844,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4039,9 +3867,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_43
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4056,8 +3884,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/datetime/null'
+          path: /queries/datetime/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4070,7 +3899,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4093,9 +3922,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4110,8 +3939,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/valid'
+          path: /queries/array/csv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4124,7 +3954,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4147,14 +3977,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: a null array of string using the csv-array format
+            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the csv-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4164,8 +3994,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/null'
+          path: /queries/array/csv/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4178,7 +4009,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4201,14 +4032,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: 'an empty array [] of string using the csv-array format'
+            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the csv-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4218,8 +4049,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/empty'
+          path: /queries/array/csv/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4232,7 +4064,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4255,9 +4087,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_78
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4272,8 +4104,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/ssv/string/valid'
+          path: /queries/array/ssv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4286,7 +4119,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4309,9 +4142,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_79
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4326,8 +4159,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/tsv/string/valid'
+          path: /queries/array/tsv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4340,7 +4174,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4363,9 +4197,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_80
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4380,8 +4214,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/pipes/string/valid'
+          path: /queries/array/pipes/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4394,7 +4229,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4425,9 +4260,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_81
+        schema: *ref_69
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4438,7 +4273,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_82
+        schema: *ref_70
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4448,7 +4283,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_83
+        schema: *ref_21
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4459,7 +4294,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_84
+        schema: *ref_21
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4474,8 +4309,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4488,7 +4324,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4513,9 +4349,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_85
+        schema: *ref_71
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4526,7 +4362,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_86
+        schema: *ref_72
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4536,7 +4372,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_87
+        schema: *ref_21
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4547,7 +4383,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_88
+        schema: *ref_21
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4562,8 +4398,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4576,7 +4413,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4599,9 +4436,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_89
+        schema: *ref_73
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4612,7 +4449,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_90
+        schema: *ref_74
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4622,7 +4459,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_21
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4633,12 +4470,12 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_92
+        schema: *ref_21
         implementation: Method
         language: !<!Languages> 
           default:
             name: localStringQuery
-            description: should contain null value
+            description: should contain value 'localStringQuery'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4648,8 +4485,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4662,7 +4500,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''
@@ -4685,9 +4523,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_29
+      - *ref_24
       - !<!Parameter> 
-        schema: *ref_93
+        schema: *ref_75
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4698,7 +4536,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_94
+        schema: *ref_76
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4708,7 +4546,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_95
+        schema: *ref_21
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4719,12 +4557,12 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_96
+        schema: *ref_21
         implementation: Method
         language: !<!Languages> 
           default:
             name: localStringQuery
-            description: should contain value null
+            description: should contain value 'localStringQuery'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4734,8 +4572,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4748,7 +4587,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_28
+      schema: *ref_23
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/url/namer.yaml
+++ b/modelerfour/test/outputs/url/namer.yaml
@@ -1,7 +1,7 @@
 !<!CodeModel> 
 schemas: !<!Schemas> 
   objects:
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_24
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_43
+  - !<!ChoiceSchema> &ref_37
     choices:
     - !<!ChoiceValue> 
       value: red color
@@ -83,12 +83,12 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   arrays:
-  - !<!ArraySchema> &ref_51
+  - !<!ArraySchema> &ref_45
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_20
+    elementType: !<!StringSchema> &ref_21
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -103,112 +103,12 @@ schemas: !<!Schemas>
         name: Array of get-0-itemsItem
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_75
+  - !<!ArraySchema> &ref_68
     type: array
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    elementType: !<!StringSchema> &ref_21
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_76
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_22
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_77
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_23
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_78
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_24
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_79
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_25
-      type: string
-      apiVersions:
-      - !<!ApiVersion> 
-        version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: string
-          description: MISSING·SCHEMA-DESCRIPTION-STRING
-      protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Array of string
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_80
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: !<!StringSchema> &ref_26
+    elementType: !<!StringSchema> &ref_20
       type: string
       apiVersions:
       - !<!ApiVersion> 
@@ -231,7 +131,7 @@ schemas: !<!Schemas>
         name: bool
         description: simple boolean
     protocol: !<!Protocols> {}
-  - !<!BooleanSchema> &ref_55
+  - !<!BooleanSchema> &ref_49
     type: boolean
     apiVersions:
     - !<!ApiVersion> 
@@ -242,7 +142,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-BOOLEAN
     protocol: !<!Protocols> {}
   byteArrays:
-  - !<!ByteArraySchema> &ref_44
+  - !<!ByteArraySchema> &ref_38
     type: byte-array
     format: byte
     apiVersions:
@@ -253,7 +153,7 @@ schemas: !<!Schemas>
         name: byte-array
         description: MISSING·SCHEMA-DESCRIPTION-BYTEARRAY
     protocol: !<!Protocols> {}
-  - !<!ByteArraySchema> &ref_50
+  - !<!ByteArraySchema> &ref_44
     type: byte-array
     format: base64url
     apiVersions:
@@ -265,7 +165,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-BYTEARRAY
     protocol: !<!Protocols> {}
   constants:
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_23
     type: constant
     value: !<!ConstantValue> 
       value: true
@@ -279,7 +179,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_30
+  - !<!ConstantSchema> &ref_25
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -292,7 +192,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_31
+  - !<!ConstantSchema> &ref_26
     type: constant
     value: !<!ConstantValue> 
       value: 1000000
@@ -313,7 +213,7 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_32
+  - !<!ConstantSchema> &ref_27
     type: constant
     value: !<!ConstantValue> 
       value: -1000000
@@ -334,7 +234,7 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_33
+  - !<!ConstantSchema> &ref_28
     type: constant
     value: !<!ConstantValue> 
       value: 10000000000
@@ -355,7 +255,7 @@ schemas: !<!Schemas>
         name: Constant4
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_34
+  - !<!ConstantSchema> &ref_29
     type: constant
     value: !<!ConstantValue> 
       value: -10000000000
@@ -376,7 +276,7 @@ schemas: !<!Schemas>
         name: Constant5
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_35
+  - !<!ConstantSchema> &ref_30
     type: constant
     value: !<!ConstantValue> 
       value: 103400000000000000000
@@ -397,7 +297,7 @@ schemas: !<!Schemas>
         name: Constant6
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_36
+  - !<!ConstantSchema> &ref_31
     type: constant
     value: !<!ConstantValue> 
       value: -1.034e-20
@@ -418,7 +318,7 @@ schemas: !<!Schemas>
         name: Constant7
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_37
+  - !<!ConstantSchema> &ref_32
     type: constant
     value: !<!ConstantValue> 
       value: 9999999.999
@@ -439,7 +339,7 @@ schemas: !<!Schemas>
         name: Constant8
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_38
+  - !<!ConstantSchema> &ref_33
     type: constant
     value: !<!ConstantValue> 
       value: -9999999.999
@@ -460,7 +360,7 @@ schemas: !<!Schemas>
         name: Constant9
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_39
+  - !<!ConstantSchema> &ref_34
     type: constant
     value: !<!ConstantValue> 
       value: 啊齄丂狛狜隣郎隣兀﨩
@@ -474,7 +374,7 @@ schemas: !<!Schemas>
         name: Constant10
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_40
+  - !<!ConstantSchema> &ref_35
     type: constant
     value: !<!ConstantValue> 
       value: 'begin!*''();:@ &=+$,/?#[]end'
@@ -488,7 +388,7 @@ schemas: !<!Schemas>
         name: Constant11
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_41
+  - !<!ConstantSchema> &ref_36
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -501,7 +401,7 @@ schemas: !<!Schemas>
         name: Constant12
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_45
+  - !<!ConstantSchema> &ref_39
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -514,7 +414,7 @@ schemas: !<!Schemas>
         name: Constant13
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_46
+  - !<!ConstantSchema> &ref_40
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01'
@@ -528,7 +428,7 @@ schemas: !<!Schemas>
         name: Constant14
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_48
+  - !<!ConstantSchema> &ref_42
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01T01:01:01Z'
@@ -542,7 +442,7 @@ schemas: !<!Schemas>
         name: Constant15
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_53
+  - !<!ConstantSchema> &ref_47
     type: constant
     value: !<!ConstantValue> 
       value: true
@@ -556,7 +456,7 @@ schemas: !<!Schemas>
         name: Constant16
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_54
+  - !<!ConstantSchema> &ref_48
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -569,7 +469,7 @@ schemas: !<!Schemas>
         name: Constant17
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_56
+  - !<!ConstantSchema> &ref_50
     type: constant
     value: !<!ConstantValue> 
       value: 1000000
@@ -590,7 +490,7 @@ schemas: !<!Schemas>
         name: Constant18
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_57
+  - !<!ConstantSchema> &ref_51
     type: constant
     value: !<!ConstantValue> 
       value: -1000000
@@ -611,7 +511,7 @@ schemas: !<!Schemas>
         name: Constant19
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_59
+  - !<!ConstantSchema> &ref_53
     type: constant
     value: !<!ConstantValue> 
       value: 10000000000
@@ -632,7 +532,7 @@ schemas: !<!Schemas>
         name: Constant20
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_60
+  - !<!ConstantSchema> &ref_54
     type: constant
     value: !<!ConstantValue> 
       value: -10000000000
@@ -653,7 +553,7 @@ schemas: !<!Schemas>
         name: Constant21
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_62
+  - !<!ConstantSchema> &ref_56
     type: constant
     value: !<!ConstantValue> 
       value: 103400000000000000000
@@ -674,7 +574,7 @@ schemas: !<!Schemas>
         name: Constant22
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_63
+  - !<!ConstantSchema> &ref_57
     type: constant
     value: !<!ConstantValue> 
       value: -1.034e-20
@@ -695,7 +595,7 @@ schemas: !<!Schemas>
         name: Constant23
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_65
+  - !<!ConstantSchema> &ref_59
     type: constant
     value: !<!ConstantValue> 
       value: 9999999.999
@@ -716,7 +616,7 @@ schemas: !<!Schemas>
         name: Constant24
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_66
+  - !<!ConstantSchema> &ref_60
     type: constant
     value: !<!ConstantValue> 
       value: -9999999.999
@@ -737,7 +637,7 @@ schemas: !<!Schemas>
         name: Constant25
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_68
+  - !<!ConstantSchema> &ref_62
     type: constant
     value: !<!ConstantValue> 
       value: 啊齄丂狛狜隣郎隣兀﨩
@@ -751,7 +651,7 @@ schemas: !<!Schemas>
         name: Constant26
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_69
+  - !<!ConstantSchema> &ref_63
     type: constant
     value: !<!ConstantValue> 
       value: 'begin!*''();:@ &=+$,/?#[]end'
@@ -765,7 +665,7 @@ schemas: !<!Schemas>
         name: Constant27
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_70
+  - !<!ConstantSchema> &ref_64
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -778,7 +678,7 @@ schemas: !<!Schemas>
         name: Constant28
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_72
+  - !<!ConstantSchema> &ref_65
     type: constant
     value: !<!ConstantValue> 
       language:
@@ -791,7 +691,7 @@ schemas: !<!Schemas>
         name: Constant29
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_73
+  - !<!ConstantSchema> &ref_66
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01'
@@ -805,7 +705,7 @@ schemas: !<!Schemas>
         name: Constant30
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_74
+  - !<!ConstantSchema> &ref_67
     type: constant
     value: !<!ConstantValue> 
       value: '2012-01-01T01:01:01Z'
@@ -820,7 +720,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   dateTimes:
-  - !<!DateTimeSchema> &ref_49
+  - !<!DateTimeSchema> &ref_43
     type: date-time
     format: date-time
     apiVersions:
@@ -832,7 +732,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-DATETIME
     protocol: !<!Protocols> {}
   dates:
-  - !<!DateSchema> &ref_47
+  - !<!DateSchema> &ref_41
     type: date
     apiVersions:
     - !<!ApiVersion> 
@@ -854,7 +754,7 @@ schemas: !<!Schemas>
   - *ref_10
   - *ref_11
   - *ref_12
-  - !<!NumberSchema> &ref_58
+  - !<!NumberSchema> &ref_52
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -867,7 +767,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_13
   - *ref_14
-  - !<!NumberSchema> &ref_61
+  - !<!NumberSchema> &ref_55
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -880,7 +780,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_15
   - *ref_16
-  - !<!NumberSchema> &ref_64
+  - !<!NumberSchema> &ref_58
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -893,7 +793,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_17
   - *ref_18
-  - !<!NumberSchema> &ref_67
+  - !<!NumberSchema> &ref_61
     type: number
     apiVersions:
     - !<!ApiVersion> 
@@ -907,191 +807,66 @@ schemas: !<!Schemas>
   strings:
   - *ref_1
   - *ref_19
-  - !<!StringSchema> &ref_42
+  - *ref_20
+  - *ref_21
+  - !<!StringSchema> &ref_69
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_20
+  - !<!StringSchema> &ref_70
+    type: string
+    language: !<!Languages> 
+      default:
+        name: string
+        description: MISSING·SCHEMA-DESCRIPTION-STRING
+    protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_71
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - *ref_21
-  - *ref_22
-  - *ref_23
-  - *ref_24
-  - *ref_25
-  - *ref_26
-  - !<!StringSchema> &ref_81
+  - !<!StringSchema> &ref_72
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_82
+  - !<!StringSchema> &ref_73
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_83
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_84
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_85
+  - !<!StringSchema> &ref_74
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_86
+  - !<!StringSchema> &ref_75
     type: string
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_87
+  - !<!StringSchema> &ref_76
     type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_88
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_89
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_90
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_91
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_92
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_93
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_94
-    type: string
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_95
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_96
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
-  - !<!StringSchema> 
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
     language: !<!Languages> 
       default:
         name: string
         description: MISSING·SCHEMA-DESCRIPTION-STRING
     protocol: !<!Protocols> {}
   unixtimes:
-  - !<!UnixTimeSchema> &ref_52
+  - !<!UnixTimeSchema> &ref_46
     type: unixtime
     apiVersions:
     - !<!ApiVersion> 
@@ -1102,7 +877,7 @@ schemas: !<!Schemas>
         description: 'date in seconds since 1970-01-01T00:00:00Z.'
     protocol: !<!Protocols> {}
 globalParameters:
-- !<!Parameter> &ref_27
+- !<!Parameter> &ref_22
   schema: *ref_1
   clientDefaultValue: 'http://localhost:3000'
   implementation: Client
@@ -1113,7 +888,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest
   title: url
@@ -1127,9 +902,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_23
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1145,8 +920,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/bool/true/{boolPath}'
+          path: '/paths/bool/true/{boolPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1159,7 +935,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1182,9 +958,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_30
+        schema: *ref_25
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1200,8 +976,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/bool/false/{boolPath}'
+          path: '/paths/bool/false/{boolPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1214,7 +991,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1237,9 +1014,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_31
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1255,8 +1032,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/1000000/{intPath}'
+          path: '/paths/int/1000000/{intPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1269,7 +1047,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1292,9 +1070,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_32
+        schema: *ref_27
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1310,8 +1088,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/-1000000/{intPath}'
+          path: '/paths/int/-1000000/{intPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1324,7 +1103,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1347,9 +1126,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_33
+        schema: *ref_28
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1365,8 +1144,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/long/10000000000/{longPath}'
+          path: '/paths/long/10000000000/{longPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1379,7 +1159,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1402,9 +1182,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_34
+        schema: *ref_29
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1420,8 +1200,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/long/-10000000000/{longPath}'
+          path: '/paths/long/-10000000000/{longPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1434,7 +1215,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1457,9 +1238,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_35
+        schema: *ref_30
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1475,8 +1256,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/float/1.034E+20/{floatPath}'
+          path: '/paths/float/1.034E+20/{floatPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1489,7 +1271,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1512,9 +1294,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_36
+        schema: *ref_31
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1530,8 +1312,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/float/-1.034E-20/{floatPath}'
+          path: '/paths/float/-1.034E-20/{floatPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1544,7 +1327,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1567,9 +1350,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_37
+        schema: *ref_32
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1585,8 +1368,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/double/9999999.999/{doublePath}'
+          path: '/paths/double/9999999.999/{doublePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1599,7 +1383,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1622,9 +1406,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_38
+        schema: *ref_33
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1640,8 +1424,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/double/-9999999.999/{doublePath}'
+          path: '/paths/double/-9999999.999/{doublePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1654,7 +1439,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1677,9 +1462,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_39
+        schema: *ref_34
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1695,8 +1480,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/unicode/{stringPath}'
+          path: '/paths/string/unicode/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1709,7 +1495,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1732,9 +1518,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_40
+        schema: *ref_35
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1750,8 +1536,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}'
+          path: '/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1764,7 +1551,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1787,9 +1574,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_41
+        schema: *ref_36
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1805,8 +1592,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/empty/{stringPath}'
+          path: '/paths/string/empty/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1819,7 +1607,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1842,9 +1630,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_42
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1860,8 +1648,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/null/{stringPath}'
+          path: '/paths/string/null/{stringPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1874,7 +1663,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1897,9 +1686,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1915,8 +1704,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/enum/green%20color/{enumPath}'
+          path: '/paths/enum/green%20color/{enumPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1929,7 +1719,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -1952,15 +1742,15 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: enumPath
-            description: send null should throw
+            description: send the value green
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -1970,8 +1760,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/null/{enumPath}'
+          path: '/paths/string/null/{enumPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -1984,7 +1775,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2007,9 +1798,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2025,8 +1816,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/multibyte/{bytePath}'
+          path: '/paths/byte/multibyte/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2039,7 +1831,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2062,9 +1854,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_45
+        schema: *ref_39
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2080,8 +1872,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/empty/{bytePath}'
+          path: '/paths/byte/empty/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2094,7 +1887,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2117,15 +1910,15 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         required: true
         language: !<!Languages> 
           default:
             name: bytePath
-            description: null as byte array (should throw)
+            description: '''啊齄丂狛狜隣郎隣兀﨩'' multibyte value as utf-8 encoded byte array'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: path
@@ -2135,8 +1928,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/byte/null/{bytePath}'
+          path: '/paths/byte/null/{bytePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2149,7 +1943,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2172,9 +1966,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_46
+        schema: *ref_40
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2190,8 +1984,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/date/2012-01-01/{datePath}'
+          path: '/paths/date/2012-01-01/{datePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2204,7 +1999,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2227,9 +2022,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_41
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2245,8 +2040,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/date/null/{datePath}'
+          path: '/paths/date/null/{datePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2259,7 +2055,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2282,9 +2078,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_48
+        schema: *ref_42
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2300,8 +2096,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}'
+          path: '/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2314,7 +2111,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2337,9 +2134,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_43
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2355,8 +2152,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/datetime/null/{dateTimePath}'
+          path: '/paths/datetime/null/{dateTimePath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2369,7 +2167,7 @@ operationGroups:
           - '400'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2392,9 +2190,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_50
+        schema: *ref_44
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2410,8 +2208,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/string/bG9yZW0/{base64UrlPath}'
+          path: '/paths/string/bG9yZW0/{base64UrlPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2424,7 +2223,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2447,9 +2246,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_51
+        schema: *ref_45
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2465,8 +2264,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}'
+          path: '/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2479,7 +2279,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2502,9 +2302,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_52
+        schema: *ref_46
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2520,8 +2320,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/paths/int/1460505600/{unixTimeUrlPath}'
+          path: '/paths/int/1460505600/{unixTimeUrlPath}'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2534,7 +2335,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2565,9 +2366,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_53
+        schema: *ref_47
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2583,8 +2384,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/true'
+          path: /queries/bool/true
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2597,7 +2399,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2620,9 +2422,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_54
+        schema: *ref_48
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2638,8 +2440,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/false'
+          path: /queries/bool/false
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2652,7 +2455,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2675,9 +2478,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_55
+        schema: *ref_49
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2692,8 +2495,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/bool/null'
+          path: /queries/bool/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2706,7 +2510,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2729,9 +2533,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_56
+        schema: *ref_50
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2747,8 +2551,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/1000000'
+          path: /queries/int/1000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2761,7 +2566,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2784,9 +2589,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_57
+        schema: *ref_51
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2802,8 +2607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/-1000000'
+          path: /queries/int/-1000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2816,7 +2622,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2839,9 +2645,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_58
+        schema: *ref_52
         implementation: Method
         language: !<!Languages> 
           default:
@@ -2856,8 +2662,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/int/null'
+          path: /queries/int/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2870,7 +2677,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2893,9 +2700,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_59
+        schema: *ref_53
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2911,8 +2718,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/10000000000'
+          path: /queries/long/10000000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2925,7 +2733,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -2948,9 +2756,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_60
+        schema: *ref_54
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2966,8 +2774,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/-10000000000'
+          path: /queries/long/-10000000000
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2980,7 +2789,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3003,9 +2812,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_61
+        schema: *ref_55
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3020,8 +2829,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/long/null'
+          path: /queries/long/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3034,7 +2844,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3057,9 +2867,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_62
+        schema: *ref_56
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3075,8 +2885,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/1.034E+20'
+          path: /queries/float/1.034E+20
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3089,7 +2900,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3112,9 +2923,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_63
+        schema: *ref_57
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3130,8 +2941,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/-1.034E-20'
+          path: /queries/float/-1.034E-20
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3144,7 +2956,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3167,9 +2979,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_64
+        schema: *ref_58
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3184,8 +2996,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/float/null'
+          path: /queries/float/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3198,7 +3011,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3221,9 +3034,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_65
+        schema: *ref_59
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3239,8 +3052,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/9999999.999'
+          path: /queries/double/9999999.999
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3253,7 +3067,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3276,9 +3090,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_66
+        schema: *ref_60
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3294,8 +3108,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/-9999999.999'
+          path: /queries/double/-9999999.999
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3308,7 +3123,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3331,9 +3146,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_67
+        schema: *ref_61
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3348,8 +3163,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/double/null'
+          path: /queries/double/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3362,7 +3178,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3385,9 +3201,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_68
+        schema: *ref_62
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3403,8 +3219,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/unicode/'
+          path: /queries/string/unicode/
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3417,7 +3234,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3440,9 +3257,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_69
+        schema: *ref_63
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3458,8 +3275,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend'
+          path: /queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3472,7 +3290,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3495,9 +3313,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_70
+        schema: *ref_64
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3513,8 +3331,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/empty'
+          path: /queries/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3527,7 +3346,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3550,9 +3369,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_71
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3567,8 +3386,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/string/null'
+          path: /queries/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3581,7 +3401,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3604,9 +3424,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3621,8 +3441,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/enum/green%20color'
+          path: /queries/enum/green%20color
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3635,7 +3456,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3658,14 +3479,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_43
+        schema: *ref_37
         implementation: Method
         language: !<!Languages> 
           default:
             name: enumQuery
-            description: null string value
+            description: '''green color'' enum value'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -3675,8 +3496,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/enum/null'
+          path: /queries/enum/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3689,7 +3511,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3712,9 +3534,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3729,8 +3551,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/multibyte'
+          path: /queries/byte/multibyte
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3743,7 +3566,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3766,9 +3589,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_72
+        schema: *ref_65
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3784,8 +3607,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/empty'
+          path: /queries/byte/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3798,7 +3622,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3821,14 +3645,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_44
+        schema: *ref_38
         implementation: Method
         language: !<!Languages> 
           default:
             name: byteQuery
-            description: null as byte array (no query parameters in uri)
+            description: '''啊齄丂狛狜隣郎隣兀﨩'' multibyte value as utf-8 encoded byte array'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -3838,8 +3662,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/byte/null'
+          path: /queries/byte/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3852,7 +3677,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3875,9 +3700,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_73
+        schema: *ref_66
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3893,8 +3718,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/date/2012-01-01'
+          path: /queries/date/2012-01-01
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3907,7 +3733,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3930,9 +3756,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_47
+        schema: *ref_41
         implementation: Method
         language: !<!Languages> 
           default:
@@ -3947,8 +3773,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/date/null'
+          path: /queries/date/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3961,7 +3788,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -3984,9 +3811,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_74
+        schema: *ref_67
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4002,8 +3829,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/datetime/2012-01-01T01%3A01%3A01Z'
+          path: /queries/datetime/2012-01-01T01%3A01%3A01Z
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4016,7 +3844,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4039,9 +3867,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_49
+        schema: *ref_43
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4056,8 +3884,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/datetime/null'
+          path: /queries/datetime/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4070,7 +3899,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4093,9 +3922,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_75
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4110,8 +3939,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/valid'
+          path: /queries/array/csv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4124,7 +3954,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4147,14 +3977,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_76
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: a null array of string using the csv-array format
+            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the csv-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4164,8 +3994,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/null'
+          path: /queries/array/csv/string/null
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4178,7 +4009,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4201,14 +4032,14 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_77
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
             name: arrayQuery
-            description: 'an empty array [] of string using the csv-array format'
+            description: 'an array of string [''ArrayQuery1'', ''begin!*''();:@ &=+$,/?#[]end'' , null, ''''] using the csv-array format'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4218,8 +4049,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/csv/string/empty'
+          path: /queries/array/csv/string/empty
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4232,7 +4064,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4255,9 +4087,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_78
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4272,8 +4104,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/ssv/string/valid'
+          path: /queries/array/ssv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4286,7 +4119,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4309,9 +4142,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_79
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4326,8 +4159,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/tsv/string/valid'
+          path: /queries/array/tsv/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4340,7 +4174,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4363,9 +4197,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_80
+        schema: *ref_68
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4380,8 +4214,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/queries/array/pipes/string/valid'
+          path: /queries/array/pipes/string/valid
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4394,7 +4229,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4425,9 +4260,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_81
+        schema: *ref_69
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4438,7 +4273,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_82
+        schema: *ref_70
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4448,7 +4283,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_83
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4459,7 +4294,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_84
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4474,8 +4309,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4488,7 +4324,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4513,9 +4349,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_85
+        schema: *ref_71
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4526,7 +4362,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_86
+        schema: *ref_72
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4536,7 +4372,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_87
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4547,7 +4383,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_88
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4562,8 +4398,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4576,7 +4413,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4599,9 +4436,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_89
+        schema: *ref_73
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4612,7 +4449,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_90
+        schema: *ref_74
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4622,7 +4459,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_91
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4633,12 +4470,12 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_92
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
             name: localStringQuery
-            description: should contain null value
+            description: should contain value 'localStringQuery'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4648,8 +4485,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4662,7 +4500,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''
@@ -4685,9 +4523,9 @@ operationGroups:
       version: 1.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_22
       - !<!Parameter> 
-        schema: *ref_93
+        schema: *ref_75
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4698,7 +4536,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_94
+        schema: *ref_76
         implementation: Method
         language: !<!Languages> 
           default:
@@ -4708,7 +4546,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_95
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4719,12 +4557,12 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_96
+        schema: *ref_20
         implementation: Method
         language: !<!Languages> 
           default:
             name: localStringQuery
-            description: should contain value null
+            description: should contain value 'localStringQuery'
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
             in: query
@@ -4734,8 +4572,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null'
+          path: '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4748,7 +4587,7 @@ operationGroups:
           - '200'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_24
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/validation/flattened.yaml
+++ b/modelerfour/test/outputs/validation/flattened.yaml
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
   - *ref_7
   - *ref_8
   - *ref_9
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_25
     type: constant
     value: !<!ConstantValue> 
       value: 1.0.0
@@ -397,7 +397,7 @@ schemas: !<!Schemas>
         name: ApiVersion-1.0.0
         description: Api Version (1.0.0)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_26
     type: constant
     value: !<!ConstantValue> 
       value: constant
@@ -409,20 +409,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: Constant0
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
-    type: constant
-    value: !<!ConstantValue> 
-      value: constant
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   numbers:
@@ -444,20 +430,6 @@ schemas: !<!Schemas>
   - *ref_11
   - *ref_12
   - *ref_13
-  - !<!NumberSchema> &ref_26
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    maximum: 1000
-    minimum: 100
-    multipleOf: 10
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   strings:
   - *ref_0
   - !<!StringSchema> &ref_19
@@ -487,19 +459,6 @@ schemas: !<!Schemas>
   - *ref_15
   - *ref_16
   - *ref_17
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    maxLength: 10
-    minLength: 3
-    pattern: '[a-zA-Z0-9]+'
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - !<!StringSchema> 
     type: string
     apiVersions:
@@ -523,7 +482,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest. No server backend exists for these tests.
   title: validation
@@ -588,8 +547,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
+          path: '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_23
@@ -642,7 +602,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -653,7 +613,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_21
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -664,7 +624,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_25
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -694,11 +654,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
+          path: '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_23
@@ -742,7 +703,7 @@ operationGroups:
       parameters:
       - *ref_18
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -758,8 +719,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/validation/constantsInPath/{constantParam}/value'
+          path: '/validation/constantsInPath/{constantParam}/value'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -783,7 +745,7 @@ operationGroups:
       parameters:
       - *ref_18
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -813,11 +775,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/validation/constantsInPath/{constantParam}/value'
+          path: '/validation/constantsInPath/{constantParam}/value'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_23

--- a/modelerfour/test/outputs/validation/modeler.yaml
+++ b/modelerfour/test/outputs/validation/modeler.yaml
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
   - *ref_9
   - *ref_10
   - *ref_11
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_25
     type: constant
     value: !<!ConstantValue> 
       value: 1.0.0
@@ -397,21 +397,7 @@ schemas: !<!Schemas>
         name: ApiVersion-1.0.0
         description: Api Version (1.0.0)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
-    type: constant
-    value: !<!ConstantValue> 
-      value: constant
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
+  - !<!ConstantSchema> &ref_26
     type: constant
     value: !<!ConstantValue> 
       value: constant
@@ -444,20 +430,6 @@ schemas: !<!Schemas>
   - *ref_6
   - *ref_1
   - *ref_14
-  - !<!NumberSchema> &ref_26
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    maximum: 1000
-    minimum: 100
-    multipleOf: 10
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·2·schema
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   strings:
   - *ref_0
   - !<!StringSchema> &ref_18
@@ -487,19 +459,6 @@ schemas: !<!Schemas>
   - *ref_4
   - *ref_15
   - *ref_16
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    maxLength: 10
-    minLength: 3
-    pattern: '[a-zA-Z0-9]+'
-    language: !<!Languages> 
-      default:
-        name: paths·fakepath-subscriptionid-resourcegroupname-id-api_version-apiversion·put·parameters·1·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - !<!StringSchema> 
     type: string
     apiVersions:
@@ -523,7 +482,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest. No server backend exists for these tests.
   title: validation
@@ -588,8 +547,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
+          path: '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_22
@@ -642,7 +602,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_19
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -653,7 +613,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -664,7 +624,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_25
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -694,11 +654,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
+          path: '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_22
@@ -742,7 +703,7 @@ operationGroups:
       parameters:
       - *ref_24
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -758,8 +719,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/validation/constantsInPath/{constantParam}/value'
+          path: '/validation/constantsInPath/{constantParam}/value'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -783,7 +745,7 @@ operationGroups:
       parameters:
       - *ref_24
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -813,11 +775,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/validation/constantsInPath/{constantParam}/value'
+          path: '/validation/constantsInPath/{constantParam}/value'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_22

--- a/modelerfour/test/outputs/validation/namer.yaml
+++ b/modelerfour/test/outputs/validation/namer.yaml
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
   - *ref_7
   - *ref_8
   - *ref_9
-  - !<!ConstantSchema> &ref_27
+  - !<!ConstantSchema> &ref_25
     type: constant
     value: !<!ConstantValue> 
       value: 1.0.0
@@ -397,7 +397,7 @@ schemas: !<!Schemas>
         name: ApiVersion-1.0.0
         description: Api Version (1.0.0)
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_28
+  - !<!ConstantSchema> &ref_26
     type: constant
     value: !<!ConstantValue> 
       value: constant
@@ -409,20 +409,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: Constant0
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_29
-    type: constant
-    value: !<!ConstantValue> 
-      value: constant
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_0
-    language: !<!Languages> 
-      default:
-        name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   numbers:
@@ -444,20 +430,6 @@ schemas: !<!Schemas>
   - *ref_11
   - *ref_12
   - *ref_13
-  - !<!NumberSchema> &ref_26
-    type: integer
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    maximum: 1000
-    minimum: 100
-    multipleOf: 10
-    precision: 32
-    language: !<!Languages> 
-      default:
-        name: integer
-        description: MISSING·SCHEMA-DESCRIPTION-INTEGER
-    protocol: !<!Protocols> {}
   strings:
   - *ref_0
   - !<!StringSchema> &ref_19
@@ -487,19 +459,6 @@ schemas: !<!Schemas>
   - *ref_15
   - *ref_16
   - *ref_17
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    maxLength: 10
-    minLength: 3
-    pattern: '[a-zA-Z0-9]+'
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - !<!StringSchema> 
     type: string
     apiVersions:
@@ -523,7 +482,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest. No server backend exists for these tests.
   title: validation
@@ -588,8 +547,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
+          path: '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_23
@@ -642,7 +602,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_25
+        schema: *ref_20
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -653,7 +613,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_26
+        schema: *ref_21
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -664,7 +624,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: path
       - !<!Parameter> 
-        schema: *ref_27
+        schema: *ref_25
         implementation: Client
         required: true
         language: !<!Languages> 
@@ -694,11 +654,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
+          path: '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_23
@@ -742,7 +703,7 @@ operationGroups:
       parameters:
       - *ref_18
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -758,8 +719,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/validation/constantsInPath/{constantParam}/value'
+          path: '/validation/constantsInPath/{constantParam}/value'
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -783,7 +745,7 @@ operationGroups:
       parameters:
       - *ref_18
       - !<!Parameter> 
-        schema: *ref_29
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -813,11 +775,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/validation/constantsInPath/{constantParam}/value'
+          path: '/validation/constantsInPath/{constantParam}/value'
           method: post
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_23

--- a/modelerfour/test/outputs/xkcd/flattened.yaml
+++ b/modelerfour/test/outputs/xkcd/flattened.yaml
@@ -241,7 +241,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: 'Webcomic of romance, sarcasm, math, and language.'
   externalDocs:
@@ -278,8 +278,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/info.0.json'
+          path: /info.0.json
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -324,8 +325,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/{comicId}/info.0.json'
+          path: '/{comicId}/info.0.json'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_13

--- a/modelerfour/test/outputs/xkcd/modeler.yaml
+++ b/modelerfour/test/outputs/xkcd/modeler.yaml
@@ -241,7 +241,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: 'Webcomic of romance, sarcasm, math, and language.'
   externalDocs:
@@ -278,8 +278,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/info.0.json'
+          path: /info.0.json
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_12
@@ -324,8 +325,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/{comicId}/info.0.json'
+          path: '/{comicId}/info.0.json'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_12

--- a/modelerfour/test/outputs/xkcd/namer.yaml
+++ b/modelerfour/test/outputs/xkcd/namer.yaml
@@ -241,7 +241,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: 'Webcomic of romance, sarcasm, math, and language.'
   externalDocs:
@@ -278,8 +278,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/info.0.json'
+          path: /info.0.json
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_13
@@ -324,8 +325,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/{comicId}/info.0.json'
+          path: '/{comicId}/info.0.json'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_13

--- a/modelerfour/test/outputs/xml-service/flattened.yaml
+++ b/modelerfour/test/outputs/xml-service/flattened.yaml
@@ -458,7 +458,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_74
+      schema: !<!StringSchema> &ref_75
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -480,7 +480,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_75
+      schema: !<!StringSchema> &ref_76
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -535,14 +535,14 @@ schemas: !<!Schemas>
         description: A banana.
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_127
+  - !<!ObjectSchema> &ref_122
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_76
+      schema: !<!StringSchema> &ref_77
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -564,7 +564,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_77
+      schema: !<!StringSchema> &ref_78
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -582,7 +582,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_78
+      schema: !<!StringSchema> &ref_79
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -628,7 +628,7 @@ schemas: !<!Schemas>
             version: 1.0.0
           properties:
           - !<!Property> 
-            schema: !<!StringSchema> &ref_79
+            schema: !<!StringSchema> &ref_80
               type: string
               apiVersions:
               - !<!ApiVersion> 
@@ -672,7 +672,7 @@ schemas: !<!Schemas>
                     description: MISSING·SCHEMA-DESCRIPTION-DATETIME
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!StringSchema> &ref_80
+                schema: !<!StringSchema> &ref_81
                   type: string
                   apiVersions:
                   - !<!ApiVersion> 
@@ -857,7 +857,7 @@ schemas: !<!Schemas>
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_14
               type: dictionary
-              elementType: !<!StringSchema> &ref_81
+              elementType: !<!StringSchema> &ref_74
                 type: string
                 apiVersions:
                 - !<!ApiVersion> 
@@ -866,18 +866,19 @@ schemas: !<!Schemas>
                   default:
                     name: string
                     description: MISSING·SCHEMA-DESCRIPTION-STRING
+                    header: Custom-Header
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
                   name: Dictionary of string
-                  description: Dictionary of <components·schemas·metadata·additionalproperties>
+                  description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
               protocol: !<!Protocols> {}
             required: false
             serializedName: Metadata
             language: !<!Languages> 
               default:
                 name: Metadata
-                description: Dictionary of <components·schemas·metadata·additionalproperties>
+                description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -932,7 +933,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_4
   - *ref_5
-  - !<!ObjectSchema> &ref_130
+  - !<!ObjectSchema> &ref_125
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -1436,7 +1437,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_10
-  - !<!ObjectSchema> &ref_140
+  - !<!ObjectSchema> &ref_129
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2287,7 +2288,7 @@ schemas: !<!Schemas>
                 language: !<!Languages> 
                   default:
                     name: Metadata
-                    description: Dictionary of <components·schemas·metadata·additionalproperties>
+                    description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
                 protocol: !<!Protocols> {}
               serialization:
                 xml:
@@ -2357,7 +2358,7 @@ schemas: !<!Schemas>
   - *ref_16
   - *ref_17
   - *ref_18
-  - !<!ObjectSchema> &ref_141
+  - !<!ObjectSchema> &ref_130
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2384,7 +2385,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_142
+  - !<!ObjectSchema> &ref_131
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2424,87 +2425,23 @@ schemas: !<!Schemas>
   - *ref_22
   - *ref_23
   - *ref_24
+  - !<!ArraySchema> &ref_119
+    type: array
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    elementType: *ref_25
+    serialization:
+      xml:
+        name: bananas
+        attribute: false
+        wrapped: false
+    language: !<!Languages> 
+      default:
+        name: Array of Banana
+        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
+    protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_120
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: false
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_121
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: true
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_122
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: false
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_123
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: true
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_124
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: false
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_125
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -2522,7 +2459,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_26
   - *ref_27
-  - !<!ArraySchema> &ref_135
+  - !<!ArraySchema> &ref_128
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -2552,7 +2489,7 @@ schemas: !<!Schemas>
   - *ref_39
   - *ref_40
   constants:
-  - !<!ConstantSchema> &ref_126
+  - !<!ConstantSchema> &ref_121
     type: constant
     value: !<!ConstantValue> 
       value: list
@@ -2566,7 +2503,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_128
+  - !<!ConstantSchema> &ref_123
     type: constant
     value: !<!ConstantValue> 
       value: properties
@@ -2580,7 +2517,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_129
+  - !<!ConstantSchema> &ref_124
     type: constant
     value: !<!ConstantValue> 
       value: service
@@ -2594,10 +2531,10 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_131
+  - !<!ConstantSchema> &ref_126
     type: constant
     value: !<!ConstantValue> 
-      value: properties
+      value: acl
       language:
         default:
           name: ''
@@ -2608,10 +2545,10 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_132
+  - !<!ConstantSchema> &ref_127
     type: constant
     value: !<!ConstantValue> 
-      value: service
+      value: container
       language:
         default:
           name: ''
@@ -2620,90 +2557,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: Constant4
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_133
-    type: constant
-    value: !<!ConstantValue> 
-      value: acl
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant5
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_134
-    type: constant
-    value: !<!ConstantValue> 
-      value: container
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant6
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_136
-    type: constant
-    value: !<!ConstantValue> 
-      value: acl
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant7
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_137
-    type: constant
-    value: !<!ConstantValue> 
-      value: container
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant8
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_138
-    type: constant
-    value: !<!ConstantValue> 
-      value: list
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant9
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_139
-    type: constant
-    value: !<!ConstantValue> 
-      value: container
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant10
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   dateTimes:
@@ -2744,17 +2597,6 @@ schemas: !<!Schemas>
   - *ref_71
   - *ref_72
   - *ref_73
-  - !<!StringSchema> &ref_119
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Custom-Header
-    protocol: !<!Protocols> {}
   - *ref_74
   - *ref_75
   - *ref_76
@@ -2806,7 +2648,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: xml-service
@@ -2827,8 +2669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/complex-type-ref-no-meta'
+          path: /xml/complex-type-ref-no-meta
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_114
@@ -2875,11 +2718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/complex-type-ref-no-meta'
+          path: /xml/complex-type-ref-no-meta
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2910,8 +2754,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/complex-type-ref-with-meta'
+          path: /xml/complex-type-ref-with-meta
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_115
@@ -2958,11 +2803,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/complex-type-ref-with-meta'
+          path: /xml/complex-type-ref-with-meta
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2993,8 +2839,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/simple'
+          path: /xml/simple
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_116
@@ -3055,11 +2902,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/simple'
+          path: /xml/simple
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3104,8 +2952,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/wrapped-lists'
+          path: /xml/wrapped-lists
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_118
@@ -3152,11 +3001,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/wrapped-lists'
+          path: /xml/wrapped-lists
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3201,8 +3051,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/headers'
+          path: /xml/headers
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3213,7 +3064,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_119
+            schema: *ref_74
             header: Custom-Header
           statusCodes:
           - '200'
@@ -3235,8 +3086,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-list'
+          path: /xml/empty-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_116
@@ -3283,11 +3135,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-list'
+          path: /xml/empty-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3318,8 +3171,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-wrapped-lists'
+          path: /xml/empty-wrapped-lists
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_118
@@ -3366,11 +3220,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-wrapped-lists'
+          path: /xml/empty-wrapped-lists
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3401,11 +3256,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/root-list'
+          path: /xml/root-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_120
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3430,7 +3286,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_121
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3449,11 +3305,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/root-list'
+          path: /xml/root-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3484,11 +3341,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/root-list-single-item'
+          path: /xml/root-list-single-item
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_122
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3513,7 +3371,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_123
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3532,11 +3390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/root-list-single-item'
+          path: /xml/root-list-single-item
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3567,11 +3426,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-root-list'
+          path: /xml/empty-root-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_124
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3596,7 +3456,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_125
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3615,11 +3475,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-root-list'
+          path: /xml/empty-root-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3650,8 +3511,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-child-element'
+          path: /xml/empty-child-element
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_25
@@ -3698,11 +3560,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-child-element'
+          path: /xml/empty-child-element
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3728,7 +3591,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_126
+        schema: *ref_121
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3744,11 +3607,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_127
+      schema: *ref_122
       language: !<!Languages> 
         default:
           name: ''
@@ -3773,7 +3637,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_128
+        schema: *ref_123
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3784,7 +3648,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_129
+        schema: *ref_124
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3800,11 +3664,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_130
+      schema: *ref_125
       language: !<!Languages> 
         default:
           name: ''
@@ -3829,7 +3694,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_131
+        schema: *ref_123
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3840,7 +3705,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_132
+        schema: *ref_124
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3851,7 +3716,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_130
+        schema: *ref_125
         implementation: Method
         required: true
         extensions:
@@ -3870,11 +3735,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3900,7 +3766,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_133
+        schema: *ref_126
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3911,7 +3777,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_134
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3927,11 +3793,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_135
+      schema: *ref_128
       language: !<!Languages> 
         default:
           name: ''
@@ -3956,7 +3823,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_136
+        schema: *ref_126
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3967,7 +3834,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_137
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3978,7 +3845,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_135
+        schema: *ref_128
         implementation: Method
         required: true
         extensions:
@@ -3997,11 +3864,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4027,7 +3895,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_138
+        schema: *ref_121
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4038,7 +3906,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_139
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4054,11 +3922,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_140
+      schema: *ref_129
       language: !<!Languages> 
         default:
           name: ''
@@ -4083,7 +3952,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_141
+        schema: *ref_130
         implementation: Method
         required: true
         extensions:
@@ -4102,11 +3971,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/jsoninput'
+          path: /xml/jsoninput
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4137,11 +4007,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/jsonoutput'
+          path: /xml/jsonoutput
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_142
+      schema: *ref_131
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/xml-service/modeler.yaml
+++ b/modelerfour/test/outputs/xml-service/modeler.yaml
@@ -535,7 +535,7 @@ schemas: !<!Schemas>
         description: A banana.
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_127
+  - !<!ObjectSchema> &ref_122
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -864,20 +864,21 @@ schemas: !<!Schemas>
                   version: 1.0.0
                 language: !<!Languages> 
                   default:
-                    name: components·schemas·metadata·additionalproperties
+                    name: paths·xml-headers·get·responses·200·headers·custom_header·schema
                     description: MISSING·SCHEMA-DESCRIPTION-STRING
+                    header: Custom-Header
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
                   name: Metadata
-                  description: Dictionary of <components·schemas·metadata·additionalproperties>
+                  description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
               protocol: !<!Protocols> {}
             required: false
             serializedName: Metadata
             language: !<!Languages> 
               default:
                 name: Metadata
-                description: Dictionary of <components·schemas·metadata·additionalproperties>
+                description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -932,7 +933,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_26
   - *ref_27
-  - !<!ObjectSchema> &ref_130
+  - !<!ObjectSchema> &ref_125
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -1436,7 +1437,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_41
-  - !<!ObjectSchema> &ref_140
+  - !<!ObjectSchema> &ref_129
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2287,7 +2288,7 @@ schemas: !<!Schemas>
                 language: !<!Languages> 
                   default:
                     name: Metadata
-                    description: Dictionary of <components·schemas·metadata·additionalproperties>
+                    description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
                 protocol: !<!Protocols> {}
               serialization:
                 xml:
@@ -2357,7 +2358,7 @@ schemas: !<!Schemas>
   - *ref_68
   - *ref_69
   - *ref_70
-  - !<!ObjectSchema> &ref_141
+  - !<!ObjectSchema> &ref_130
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2384,7 +2385,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_142
+  - !<!ObjectSchema> &ref_131
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2424,7 +2425,7 @@ schemas: !<!Schemas>
   - *ref_72
   - *ref_73
   - *ref_74
-  - !<!ArraySchema> &ref_120
+  - !<!ArraySchema> &ref_119
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -2440,7 +2441,7 @@ schemas: !<!Schemas>
         name: paths·xml-root_list·get·responses·200·content·application-xml·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_121
+  - !<!ArraySchema> &ref_120
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -2456,73 +2457,9 @@ schemas: !<!Schemas>
         name: paths·xml-root_list·put·requestbody·content·application-xml·schema
         description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
     protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_122
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_75
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: false
-    language: !<!Languages> 
-      default:
-        name: paths·xml-root_list_single_item·get·responses·200·content·application-xml·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_123
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_75
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: true
-    language: !<!Languages> 
-      default:
-        name: paths·xml-root_list_single_item·put·requestbody·content·application-xml·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_124
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_75
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: false
-    language: !<!Languages> 
-      default:
-        name: paths·xml-empty_root_list·get·responses·200·content·application-xml·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_125
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_75
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: true
-    language: !<!Languages> 
-      default:
-        name: paths·xml-empty_root_list·put·requestbody·content·application-xml·schema
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
   - *ref_76
   - *ref_77
-  - !<!ArraySchema> &ref_135
+  - !<!ArraySchema> &ref_128
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -2552,79 +2489,51 @@ schemas: !<!Schemas>
   - *ref_111
   - *ref_112
   constants:
+  - !<!ConstantSchema> &ref_121
+    type: constant
+    value: !<!ConstantValue> 
+      value: list
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_23
+    language: !<!Languages> 
+      default:
+        name: ''
+        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_123
+    type: constant
+    value: !<!ConstantValue> 
+      value: properties
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_23
+    language: !<!Languages> 
+      default:
+        name: ''
+        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+    protocol: !<!Protocols> {}
+  - !<!ConstantSchema> &ref_124
+    type: constant
+    value: !<!ConstantValue> 
+      value: service
+      language:
+        default:
+          name: ''
+          description: ''
+    valueType: *ref_23
+    language: !<!Languages> 
+      default:
+        name: ''
+        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
+    protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_126
     type: constant
     value: !<!ConstantValue> 
-      value: list
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_128
-    type: constant
-    value: !<!ConstantValue> 
-      value: properties
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_129
-    type: constant
-    value: !<!ConstantValue> 
-      value: service
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_131
-    type: constant
-    value: !<!ConstantValue> 
-      value: properties
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_132
-    type: constant
-    value: !<!ConstantValue> 
-      value: service
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_133
-    type: constant
-    value: !<!ConstantValue> 
       value: acl
       language:
         default:
@@ -2636,63 +2545,7 @@ schemas: !<!Schemas>
         name: ''
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_134
-    type: constant
-    value: !<!ConstantValue> 
-      value: container
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_136
-    type: constant
-    value: !<!ConstantValue> 
-      value: acl
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_137
-    type: constant
-    value: !<!ConstantValue> 
-      value: container
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_138
-    type: constant
-    value: !<!ConstantValue> 
-      value: list
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_23
-    language: !<!Languages> 
-      default:
-        name: ''
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_139
+  - !<!ConstantSchema> &ref_127
     type: constant
     value: !<!ConstantValue> 
       value: container
@@ -2744,17 +2597,7 @@ schemas: !<!Schemas>
   - *ref_13
   - *ref_14
   - *ref_15
-  - !<!StringSchema> &ref_119
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·xml-headers·get·responses·200·headers·custom_header·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Custom-Header
-    protocol: !<!Protocols> {}
+  - *ref_24
   - *ref_16
   - *ref_17
   - *ref_18
@@ -2762,7 +2605,6 @@ schemas: !<!Schemas>
   - *ref_20
   - *ref_21
   - *ref_22
-  - *ref_24
   - *ref_25
   - *ref_28
   - *ref_29
@@ -2806,7 +2648,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: xml-service
@@ -2827,8 +2669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/complex-type-ref-no-meta'
+          path: /xml/complex-type-ref-no-meta
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_113
@@ -2875,11 +2718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/complex-type-ref-no-meta'
+          path: /xml/complex-type-ref-no-meta
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2910,8 +2754,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/complex-type-ref-with-meta'
+          path: /xml/complex-type-ref-with-meta
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_115
@@ -2958,11 +2803,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/complex-type-ref-with-meta'
+          path: /xml/complex-type-ref-with-meta
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2993,8 +2839,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/simple'
+          path: /xml/simple
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_116
@@ -3055,11 +2902,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/simple'
+          path: /xml/simple
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3104,8 +2952,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/wrapped-lists'
+          path: /xml/wrapped-lists
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_118
@@ -3152,11 +3001,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/wrapped-lists'
+          path: /xml/wrapped-lists
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3201,8 +3051,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/headers'
+          path: /xml/headers
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3213,7 +3064,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_119
+            schema: *ref_24
             header: Custom-Header
           statusCodes:
           - '200'
@@ -3235,8 +3086,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-list'
+          path: /xml/empty-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_116
@@ -3283,11 +3135,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-list'
+          path: /xml/empty-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3318,8 +3171,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-wrapped-lists'
+          path: /xml/empty-wrapped-lists
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_118
@@ -3366,11 +3220,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-wrapped-lists'
+          path: /xml/empty-wrapped-lists
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3401,11 +3256,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/root-list'
+          path: /xml/root-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_120
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3430,7 +3286,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_121
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3449,11 +3305,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/root-list'
+          path: /xml/root-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3484,11 +3341,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/root-list-single-item'
+          path: /xml/root-list-single-item
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_122
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3513,7 +3371,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_123
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3532,11 +3390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/root-list-single-item'
+          path: /xml/root-list-single-item
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3567,11 +3426,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-root-list'
+          path: /xml/empty-root-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_124
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3596,7 +3456,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_125
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3615,11 +3475,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-root-list'
+          path: /xml/empty-root-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3650,8 +3511,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-child-element'
+          path: /xml/empty-child-element
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_75
@@ -3698,11 +3560,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-child-element'
+          path: /xml/empty-child-element
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3728,7 +3591,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_126
+        schema: *ref_121
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3744,11 +3607,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_127
+      schema: *ref_122
       language: !<!Languages> 
         default:
           name: ''
@@ -3773,7 +3637,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_128
+        schema: *ref_123
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3784,7 +3648,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_129
+        schema: *ref_124
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3800,11 +3664,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_130
+      schema: *ref_125
       language: !<!Languages> 
         default:
           name: ''
@@ -3829,7 +3694,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_131
+        schema: *ref_123
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3840,7 +3705,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_132
+        schema: *ref_124
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3851,7 +3716,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_130
+        schema: *ref_125
         implementation: Method
         required: true
         extensions:
@@ -3870,11 +3735,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3900,7 +3766,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_133
+        schema: *ref_126
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3911,7 +3777,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_134
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3927,11 +3793,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_135
+      schema: *ref_128
       language: !<!Languages> 
         default:
           name: ''
@@ -3956,7 +3823,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_136
+        schema: *ref_126
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3967,7 +3834,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_137
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3978,7 +3845,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_135
+        schema: *ref_128
         implementation: Method
         required: true
         extensions:
@@ -3997,11 +3864,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4027,7 +3895,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_138
+        schema: *ref_121
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4038,7 +3906,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_139
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4054,11 +3922,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_140
+      schema: *ref_129
       language: !<!Languages> 
         default:
           name: ''
@@ -4083,7 +3952,7 @@ operationGroups:
       parameters:
       - *ref_114
       - !<!Parameter> 
-        schema: *ref_141
+        schema: *ref_130
         implementation: Method
         required: true
         extensions:
@@ -4102,11 +3971,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/jsoninput'
+          path: /xml/jsoninput
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4137,11 +4007,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/jsonoutput'
+          path: /xml/jsonoutput
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_142
+      schema: *ref_131
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/xml-service/namer.yaml
+++ b/modelerfour/test/outputs/xml-service/namer.yaml
@@ -458,7 +458,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_74
+      schema: !<!StringSchema> &ref_75
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -480,7 +480,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_75
+      schema: !<!StringSchema> &ref_76
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -535,14 +535,14 @@ schemas: !<!Schemas>
         description: A banana.
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_127
+  - !<!ObjectSchema> &ref_122
     type: object
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
     properties:
     - !<!Property> 
-      schema: !<!StringSchema> &ref_76
+      schema: !<!StringSchema> &ref_77
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -564,7 +564,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_77
+      schema: !<!StringSchema> &ref_78
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -582,7 +582,7 @@ schemas: !<!Schemas>
           description: MISSING·SCHEMA-DESCRIPTION-STRING
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!StringSchema> &ref_78
+      schema: !<!StringSchema> &ref_79
         type: string
         apiVersions:
         - !<!ApiVersion> 
@@ -628,7 +628,7 @@ schemas: !<!Schemas>
             version: 1.0.0
           properties:
           - !<!Property> 
-            schema: !<!StringSchema> &ref_79
+            schema: !<!StringSchema> &ref_80
               type: string
               apiVersions:
               - !<!ApiVersion> 
@@ -672,7 +672,7 @@ schemas: !<!Schemas>
                     description: MISSING·SCHEMA-DESCRIPTION-DATETIME
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!StringSchema> &ref_80
+                schema: !<!StringSchema> &ref_81
                   type: string
                   apiVersions:
                   - !<!ApiVersion> 
@@ -857,7 +857,7 @@ schemas: !<!Schemas>
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_14
               type: dictionary
-              elementType: !<!StringSchema> &ref_81
+              elementType: !<!StringSchema> &ref_74
                 type: string
                 apiVersions:
                 - !<!ApiVersion> 
@@ -866,18 +866,19 @@ schemas: !<!Schemas>
                   default:
                     name: string
                     description: MISSING·SCHEMA-DESCRIPTION-STRING
+                    header: Custom-Header
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
                   name: Dictionary of string
-                  description: Dictionary of <components·schemas·metadata·additionalproperties>
+                  description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
               protocol: !<!Protocols> {}
             required: false
             serializedName: Metadata
             language: !<!Languages> 
               default:
                 name: Metadata
-                description: Dictionary of <components·schemas·metadata·additionalproperties>
+                description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -932,7 +933,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_4
   - *ref_5
-  - !<!ObjectSchema> &ref_130
+  - !<!ObjectSchema> &ref_125
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -1436,7 +1437,7 @@ schemas: !<!Schemas>
         namespace: Api100
     protocol: !<!Protocols> {}
   - *ref_10
-  - !<!ObjectSchema> &ref_140
+  - !<!ObjectSchema> &ref_129
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2287,7 +2288,7 @@ schemas: !<!Schemas>
                 language: !<!Languages> 
                   default:
                     name: Metadata
-                    description: Dictionary of <components·schemas·metadata·additionalproperties>
+                    description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
                 protocol: !<!Protocols> {}
               serialization:
                 xml:
@@ -2357,7 +2358,7 @@ schemas: !<!Schemas>
   - *ref_16
   - *ref_17
   - *ref_18
-  - !<!ObjectSchema> &ref_141
+  - !<!ObjectSchema> &ref_130
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2384,7 +2385,7 @@ schemas: !<!Schemas>
         description: MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA
         namespace: Api100
     protocol: !<!Protocols> {}
-  - !<!ObjectSchema> &ref_142
+  - !<!ObjectSchema> &ref_131
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -2424,87 +2425,23 @@ schemas: !<!Schemas>
   - *ref_22
   - *ref_23
   - *ref_24
+  - !<!ArraySchema> &ref_119
+    type: array
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    elementType: *ref_25
+    serialization:
+      xml:
+        name: bananas
+        attribute: false
+        wrapped: false
+    language: !<!Languages> 
+      default:
+        name: Array of Banana
+        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
+    protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_120
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: false
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_121
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: true
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_122
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: false
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_123
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: true
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_124
-    type: array
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    elementType: *ref_25
-    serialization:
-      xml:
-        name: bananas
-        attribute: false
-        wrapped: false
-    language: !<!Languages> 
-      default:
-        name: Array of Banana
-        description: MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA
-    protocol: !<!Protocols> {}
-  - !<!ArraySchema> &ref_125
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -2522,7 +2459,7 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_26
   - *ref_27
-  - !<!ArraySchema> &ref_135
+  - !<!ArraySchema> &ref_128
     type: array
     apiVersions:
     - !<!ApiVersion> 
@@ -2552,7 +2489,7 @@ schemas: !<!Schemas>
   - *ref_39
   - *ref_40
   constants:
-  - !<!ConstantSchema> &ref_126
+  - !<!ConstantSchema> &ref_121
     type: constant
     value: !<!ConstantValue> 
       value: list
@@ -2566,7 +2503,7 @@ schemas: !<!Schemas>
         name: Constant0
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_128
+  - !<!ConstantSchema> &ref_123
     type: constant
     value: !<!ConstantValue> 
       value: properties
@@ -2580,7 +2517,7 @@ schemas: !<!Schemas>
         name: Constant1
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_129
+  - !<!ConstantSchema> &ref_124
     type: constant
     value: !<!ConstantValue> 
       value: service
@@ -2594,10 +2531,10 @@ schemas: !<!Schemas>
         name: Constant2
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_131
+  - !<!ConstantSchema> &ref_126
     type: constant
     value: !<!ConstantValue> 
-      value: properties
+      value: acl
       language:
         default:
           name: ''
@@ -2608,10 +2545,10 @@ schemas: !<!Schemas>
         name: Constant3
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_132
+  - !<!ConstantSchema> &ref_127
     type: constant
     value: !<!ConstantValue> 
-      value: service
+      value: container
       language:
         default:
           name: ''
@@ -2620,90 +2557,6 @@ schemas: !<!Schemas>
     language: !<!Languages> 
       default:
         name: Constant4
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_133
-    type: constant
-    value: !<!ConstantValue> 
-      value: acl
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant5
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_134
-    type: constant
-    value: !<!ConstantValue> 
-      value: container
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant6
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_136
-    type: constant
-    value: !<!ConstantValue> 
-      value: acl
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant7
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_137
-    type: constant
-    value: !<!ConstantValue> 
-      value: container
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant8
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_138
-    type: constant
-    value: !<!ConstantValue> 
-      value: list
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant9
-        description: MISSING·SCHEMA-DESCRIPTION-CHOICE
-    protocol: !<!Protocols> {}
-  - !<!ConstantSchema> &ref_139
-    type: constant
-    value: !<!ConstantValue> 
-      value: container
-      language:
-        default:
-          name: ''
-          description: ''
-    valueType: *ref_3
-    language: !<!Languages> 
-      default:
-        name: Constant10
         description: MISSING·SCHEMA-DESCRIPTION-CHOICE
     protocol: !<!Protocols> {}
   dateTimes:
@@ -2744,17 +2597,6 @@ schemas: !<!Schemas>
   - *ref_71
   - *ref_72
   - *ref_73
-  - !<!StringSchema> &ref_119
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 1.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-        header: Custom-Header
-    protocol: !<!Protocols> {}
   - *ref_74
   - *ref_75
   - *ref_76
@@ -2806,7 +2648,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: Test Infrastructure for AutoRest Swagger BAT
   title: xml-service
@@ -2827,8 +2669,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/complex-type-ref-no-meta'
+          path: /xml/complex-type-ref-no-meta
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_114
@@ -2875,11 +2718,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/complex-type-ref-no-meta'
+          path: /xml/complex-type-ref-no-meta
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2910,8 +2754,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/complex-type-ref-with-meta'
+          path: /xml/complex-type-ref-with-meta
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_115
@@ -2958,11 +2803,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/complex-type-ref-with-meta'
+          path: /xml/complex-type-ref-with-meta
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -2993,8 +2839,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/simple'
+          path: /xml/simple
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_116
@@ -3055,11 +2902,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/simple'
+          path: /xml/simple
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3104,8 +2952,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/wrapped-lists'
+          path: /xml/wrapped-lists
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_118
@@ -3152,11 +3001,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/wrapped-lists'
+          path: /xml/wrapped-lists
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3201,8 +3051,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/headers'
+          path: /xml/headers
           method: get
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3213,7 +3064,7 @@ operationGroups:
         http: !<!HttpResponse> 
           headers:
           - !<!HttpHeader> 
-            schema: *ref_119
+            schema: *ref_74
             header: Custom-Header
           statusCodes:
           - '200'
@@ -3235,8 +3086,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-list'
+          path: /xml/empty-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_116
@@ -3283,11 +3135,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-list'
+          path: /xml/empty-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3318,8 +3171,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-wrapped-lists'
+          path: /xml/empty-wrapped-lists
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_118
@@ -3366,11 +3220,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-wrapped-lists'
+          path: /xml/empty-wrapped-lists
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3401,11 +3256,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/root-list'
+          path: /xml/root-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_120
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3430,7 +3286,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_121
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3449,11 +3305,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/root-list'
+          path: /xml/root-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3484,11 +3341,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/root-list-single-item'
+          path: /xml/root-list-single-item
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_122
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3513,7 +3371,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_123
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3532,11 +3390,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/root-list-single-item'
+          path: /xml/root-list-single-item
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3567,11 +3426,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-root-list'
+          path: /xml/empty-root-list
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_124
+      schema: *ref_119
       language: !<!Languages> 
         default:
           name: ''
@@ -3596,7 +3456,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_125
+        schema: *ref_120
         implementation: Method
         required: true
         extensions:
@@ -3615,11 +3475,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-root-list'
+          path: /xml/empty-root-list
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3650,8 +3511,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/empty-child-element'
+          path: /xml/empty-child-element
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_25
@@ -3698,11 +3560,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/empty-child-element'
+          path: /xml/empty-child-element
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3728,7 +3591,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_126
+        schema: *ref_121
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3744,11 +3607,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_127
+      schema: *ref_122
       language: !<!Languages> 
         default:
           name: ''
@@ -3773,7 +3637,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_128
+        schema: *ref_123
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3784,7 +3648,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_129
+        schema: *ref_124
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3800,11 +3664,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_130
+      schema: *ref_125
       language: !<!Languages> 
         default:
           name: ''
@@ -3829,7 +3694,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_131
+        schema: *ref_123
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3840,7 +3705,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_132
+        schema: *ref_124
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3851,7 +3716,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_130
+        schema: *ref_125
         implementation: Method
         required: true
         extensions:
@@ -3870,11 +3735,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/'
+          path: /xml/
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -3900,7 +3766,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_133
+        schema: *ref_126
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3911,7 +3777,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_134
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3927,11 +3793,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_135
+      schema: *ref_128
       language: !<!Languages> 
         default:
           name: ''
@@ -3956,7 +3823,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_136
+        schema: *ref_126
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3967,7 +3834,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_137
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -3978,7 +3845,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_135
+        schema: *ref_128
         implementation: Method
         required: true
         extensions:
@@ -3997,11 +3864,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: put
           knownMediaType: xml
           mediaTypes:
           - application/xml
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4027,7 +3895,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_138
+        schema: *ref_121
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4038,7 +3906,7 @@ operationGroups:
           http: !<!HttpParameter> 
             in: query
       - !<!Parameter> 
-        schema: *ref_139
+        schema: *ref_127
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -4054,11 +3922,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/mycontainer'
+          path: /xml/mycontainer
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_140
+      schema: *ref_129
       language: !<!Languages> 
         default:
           name: ''
@@ -4083,7 +3952,7 @@ operationGroups:
       parameters:
       - *ref_113
       - !<!Parameter> 
-        schema: *ref_141
+        schema: *ref_130
         implementation: Method
         required: true
         extensions:
@@ -4102,11 +3971,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpWithBodyRequest> 
-          path: '{$host}/xml/jsoninput'
+          path: /xml/jsoninput
           method: put
           knownMediaType: json
           mediaTypes:
           - application/json
+          url: '{$host}'
     responses:
     - !<!Response> 
       language: !<!Languages> 
@@ -4137,11 +4007,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/xml/jsonoutput'
+          path: /xml/jsonoutput
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_142
+      schema: *ref_131
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/xms-error-responses/flattened.yaml
+++ b/modelerfour/test/outputs/xms-error-responses/flattened.yaml
@@ -248,7 +248,7 @@ schemas: !<!Schemas>
         namespace: Api000
     protocol: !<!Protocols> {}
   - *ref_2
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_27
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -424,7 +424,7 @@ schemas: !<!Schemas>
   - *ref_7
   - *ref_9
   numbers:
-  - !<!NumberSchema> &ref_27
+  - !<!NumberSchema> &ref_26
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -455,29 +455,9 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_11
   - *ref_12
-  - !<!StringSchema> &ref_26
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 0.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_13
   - *ref_14
   - *ref_15
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 0.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_16
   - *ref_17
   - *ref_18
@@ -497,7 +477,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: XMS Error Response Extensions
   title: xms-error-responses
@@ -529,8 +509,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/errorStatusCodes/Pets/{petId}/GetPet'
+          path: '/errorStatusCodes/Pets/{petId}/GetPet'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -556,7 +537,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_25
       extensions:
         x-ms-error-response: true
       language: !<!Languages> 
@@ -586,7 +567,7 @@ operationGroups:
           statusCodes:
           - '404'
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_26
       extensions:
         x-ms-error-response: true
       language: !<!Languages> 
@@ -622,7 +603,7 @@ operationGroups:
       parameters:
       - *ref_24
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_25
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -638,11 +619,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/errorStatusCodes/Pets/doSomething/{whatAction}'
+          path: '/errorStatusCodes/Pets/doSomething/{whatAction}'
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/xms-error-responses/modeler.yaml
+++ b/modelerfour/test/outputs/xms-error-responses/modeler.yaml
@@ -248,7 +248,7 @@ schemas: !<!Schemas>
         namespace: Api000
     protocol: !<!Protocols> {}
   - *ref_9
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_27
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -424,7 +424,7 @@ schemas: !<!Schemas>
   - *ref_21
   - *ref_22
   numbers:
-  - !<!NumberSchema> &ref_26
+  - !<!NumberSchema> &ref_25
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -455,29 +455,9 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_0
   - *ref_1
-  - !<!StringSchema> &ref_25
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 0.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·errorstatuscodes-pets-petid-getpet·get·responses·400·content·application-json·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_4
   - *ref_5
   - *ref_6
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 0.0.0
-    language: !<!Languages> 
-      default:
-        name: paths·errorstatuscodes-pets-dosomething-whataction·post·parameters·0·schema
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_14
   - *ref_15
   - *ref_16
@@ -486,7 +466,7 @@ schemas: !<!Schemas>
   - *ref_18
   - *ref_20
 globalParameters:
-- !<!Parameter> &ref_27
+- !<!Parameter> &ref_26
   schema: *ref_23
   clientDefaultValue: 'http://localhost'
   implementation: Client
@@ -497,7 +477,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: XMS Error Response Extensions
   title: xms-error-responses
@@ -511,7 +491,7 @@ operationGroups:
       version: 0.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_26
       - !<!Parameter> 
         schema: *ref_24
         implementation: Method
@@ -529,8 +509,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/errorStatusCodes/Pets/{petId}/GetPet'
+          path: '/errorStatusCodes/Pets/{petId}/GetPet'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_3
@@ -556,7 +537,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_25
+      schema: *ref_24
       extensions:
         x-ms-error-response: true
       language: !<!Languages> 
@@ -586,7 +567,7 @@ operationGroups:
           statusCodes:
           - '404'
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_25
       extensions:
         x-ms-error-response: true
       language: !<!Languages> 
@@ -620,9 +601,9 @@ operationGroups:
       version: 0.0.0
     request: !<!Request> 
       parameters:
-      - *ref_27
+      - *ref_26
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_24
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -638,11 +619,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/errorStatusCodes/Pets/doSomething/{whatAction}'
+          path: '/errorStatusCodes/Pets/doSomething/{whatAction}'
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/outputs/xms-error-responses/namer.yaml
+++ b/modelerfour/test/outputs/xms-error-responses/namer.yaml
@@ -248,7 +248,7 @@ schemas: !<!Schemas>
         namespace: Api000
     protocol: !<!Protocols> {}
   - *ref_2
-  - !<!ObjectSchema> &ref_29
+  - !<!ObjectSchema> &ref_27
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -424,7 +424,7 @@ schemas: !<!Schemas>
   - *ref_7
   - *ref_9
   numbers:
-  - !<!NumberSchema> &ref_27
+  - !<!NumberSchema> &ref_26
     type: integer
     apiVersions:
     - !<!ApiVersion> 
@@ -455,29 +455,9 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_11
   - *ref_12
-  - !<!StringSchema> &ref_26
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 0.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_13
   - *ref_14
   - *ref_15
-  - !<!StringSchema> &ref_28
-    type: string
-    apiVersions:
-    - !<!ApiVersion> 
-      version: 0.0.0
-    language: !<!Languages> 
-      default:
-        name: string
-        description: MISSING·SCHEMA-DESCRIPTION-STRING
-    protocol: !<!Protocols> {}
   - *ref_16
   - *ref_17
   - *ref_18
@@ -497,7 +477,7 @@ globalParameters:
       description: server parameter
   protocol: !<!Protocols> 
     http: !<!HttpParameter> 
-      in: path
+      in: uri
 info: !<!Info> 
   description: XMS Error Response Extensions
   title: xms-error-responses
@@ -529,8 +509,9 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/errorStatusCodes/Pets/{petId}/GetPet'
+          path: '/errorStatusCodes/Pets/{petId}/GetPet'
           method: get
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
       schema: *ref_1
@@ -556,7 +537,7 @@ operationGroups:
           - '202'
     exceptions:
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_25
       extensions:
         x-ms-error-response: true
       language: !<!Languages> 
@@ -586,7 +567,7 @@ operationGroups:
           statusCodes:
           - '404'
     - !<!SchemaResponse> 
-      schema: *ref_27
+      schema: *ref_26
       extensions:
         x-ms-error-response: true
       language: !<!Languages> 
@@ -622,7 +603,7 @@ operationGroups:
       parameters:
       - *ref_24
       - !<!Parameter> 
-        schema: *ref_28
+        schema: *ref_25
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -638,11 +619,12 @@ operationGroups:
           description: ''
       protocol: !<!Protocols> 
         http: !<!HttpRequest> 
-          path: '{$host}/errorStatusCodes/Pets/doSomething/{whatAction}'
+          path: '/errorStatusCodes/Pets/doSomething/{whatAction}'
           method: post
+          url: '{$host}'
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_29
+      schema: *ref_27
       language: !<!Languages> 
         default:
           name: ''


### PR DESCRIPTION
- version bump, change your configuration to specify version `~4.1.0` or greater
  
  ``` yaml 
  use-extension:
  "@autorest/modelerfour" : "~4.1.0" 
  ```
  - each Http operation (via `.protocol.http`) will now have a separate `path` and `uri` properties. 
  <br>Both are still templates, and will have parameters. 
  <br>The parameters for the `uri` property will have `in` set to `ParameterLocation.Uri`
  <br>The parameters for the `path` property will continue to have `in` set to `ParameterLocation.Path`

  
  - autorest-core recently added an option to aggressively deduplicate inline models (ie, ones without a name)
  and modeler-four based generator will have that enabled by default. (ie `deduplicate-inline-models: true`)
  <br>This may increase deduplication time on extremely large openapi models.

  - this package contains the initial code for the flattener plugin, however it is not yet enabled.

  - updated `@azure-tools/codemodel` package to `3.0.241`:
  <br>`uri` (required) was added to `HttpRequest`
  <br>`flattenedNames` (optional) was added to `Property` (in anticipation of supporting flattening)

