### PR TITLE
Add TypeScript generator regression tests to PR validation

### DIFF
--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -89,4 +89,3 @@ steps:
                      # --spec-path:paging.json \
                      # --spec-path:required-optional.json \
   displayName: Regression Test - @autorest/typescript
-  continueOnError: true # Don't make this a hard fail just yet

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -80,8 +80,8 @@ steps:
                      --spec-path:xms-error-responses.json \
                      --spec-root-path:./modelerfour/node_modules/@microsoft.azure/autorest.testserver/__files/ \
                      --output-path:./generated/typescript/ \
-                     --compare-old --package-name:test-package --version:3.0.6192 --use:@autorest/modelerfour@4.4.158 --use:$AUTOREST_TYPESCRIPT \
-                     --compare-new --package-name:test-package --version:3.0.6192 --use:./modelerfour --use:$AUTOREST_TYPESCRIPT
+                     --compare-old --v3 --package-name:test-package --version=3.0.6200 --use:@autorest/modelerfour@4.4.158 --use:$AUTOREST_TYPESCRIPT \
+                     --compare-new --v3 --package-name:test-package --version:3.0.6200 --use:./modelerfour --use:$AUTOREST_TYPESCRIPT
 
                      # Disabled due to issues with TypeScript generator and OData properties
                      # --spec-path:additionalProperties.json \

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -71,7 +71,7 @@ steps:
                      --spec-path:xms-error-responses.json \
                      --spec-root-path:./modelerfour/node_modules/@microsoft.azure/autorest.testserver/__files/ \
                      --output-path:./generated/typescript/ \
-                     --compare-old --v3 --package-name:test-package --version=3.0.6200 --use:@autorest/modelerfour@4.4.158 --use:$AUTOREST_TYPESCRIPT \
+                     --compare-old --v3 --package-name:test-package --version=3.0.6200 --use:@autorest/modelerfour@4.5.175 --use:$AUTOREST_TYPESCRIPT \
                      --compare-new --v3 --package-name:test-package --version:3.0.6200 --use:./modelerfour --use:$AUTOREST_TYPESCRIPT
 
                      # Disabled due to errors in the TypeScript generator

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -80,7 +80,7 @@ steps:
                      --spec-path:xms-error-responses.json \
                      --spec-root-path:./modelerfour/node_modules/@microsoft.azure/autorest.testserver/__files/ \
                      --output-path:./generated/typescript/ \
-                     --compare-old --package-name:test-package --version:3.0.6192 --use:@autorest/modelerfour@4.2.108 --use:$AUTOREST_TYPESCRIPT \
+                     --compare-old --package-name:test-package --version:3.0.6192 --use:@autorest/modelerfour@4.4.158 --use:$AUTOREST_TYPESCRIPT \
                      --compare-new --package-name:test-package --version:3.0.6192 --use:./modelerfour --use:$AUTOREST_TYPESCRIPT
 
                      # Disabled due to issues with TypeScript generator and OData properties

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -35,11 +35,9 @@ steps:
 - script : |
     export AUTOREST_TYPESCRIPT=@autorest/typescript@0.1.0-dev.20200203.1
     autorest-compare --typescript \
-                     --spec-path:azure-parameter-grouping.json \
                      --spec-path:azure-report.json \
                      --spec-path:azure-resource-x.json \
                      --spec-path:azure-resource.json \
-                     --spec-path:body-array.json \
                      --spec-path:body-boolean.json \
                      --spec-path:body-boolean.quirks.json \
                      --spec-path:body-byte.json \
@@ -47,11 +45,8 @@ steps:
                      --spec-path:body-date.json \
                      --spec-path:body-datetime-rfc1123.json \
                      --spec-path:body-datetime.json \
-                     --spec-path:body-dictionary.json \
                      --spec-path:body-duration.json \
                      --spec-path:body-file.json \
-                     --spec-path:body-formdata-urlencoded.json \
-                     --spec-path:body-formdata.json \
                      --spec-path:body-integer.json \
                      --spec-path:body-number.json \
                      --spec-path:body-number.quirks.json \
@@ -59,18 +54,14 @@ steps:
                      --spec-path:body-string.quirks.json \
                      --spec-path:complex-model.json \
                      --spec-path:custom-baseUrl-more-options.json \
-                     --spec-path:custom-baseUrl-paging.json \
                      --spec-path:custom-baseUrl.json \
                      --spec-path:extensible-enums-swagger.json \
                      --spec-path:head-exceptions.json \
                      --spec-path:head.json \
-                     --spec-path:header.json \
                      --spec-path:httpInfrastructure.json \
                      --spec-path:httpInfrastructure.quirks.json \
-                     --spec-path:lro.json \
                      --spec-path:parameter-flattening.json \
                      --spec-path:report.json \
-                     --spec-path:required-optional.json \
                      --spec-path:storage.json \
                      --spec-path:subscriptionId-apiVersion.json \
                      --spec-path:url-multi-collectionFormat.json \
@@ -83,10 +74,19 @@ steps:
                      --compare-old --v3 --package-name:test-package --version=3.0.6200 --use:@autorest/modelerfour@4.4.158 --use:$AUTOREST_TYPESCRIPT \
                      --compare-new --v3 --package-name:test-package --version:3.0.6200 --use:./modelerfour --use:$AUTOREST_TYPESCRIPT
 
-                     # Disabled due to issues with TypeScript generator and OData properties
+                     # Disabled due to errors in the TypeScript generator
                      # --spec-path:additionalProperties.json \
+                     # --spec-path:azure-parameter-grouping.json \
                      # --spec-path:azure-special-properties.json \
-                     # --spec-path:paging.json \
+                     # --spec-path:body-array.json \
+                     # --spec-path:body-dictionary.json \
+                     # --spec-path:body-formdata-urlencoded.json \
+                     # --spec-path:body-formdata.json \
+                     # --spec-path:custom-baseUrl-paging.json \
+                     # --spec-path:header.json \
+                     # --spec-path:lro.json \
                      # --spec-path:model-flattening.json \
+                     # --spec-path:paging.json \
+                     # --spec-path:required-optional.json \
   displayName: Regression Test - @autorest/typescript
   continueOnError: true # Don't make this a hard fail just yet

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -35,8 +35,53 @@ steps:
 - script : |
     export AUTOREST_TYPESCRIPT=@autorest/typescript@0.1.0-dev.20200116.5
     autorest-compare --typescript \
-                     --spec-path:body-string.json \
+                     --spec-path:additionalProperties.json \
+                     --spec-path:azure-parameter-grouping.json \
+                     --spec-path:azure-report.json \
+                     --spec-path:azure-resource-x.json \
+                     --spec-path:azure-resource.json \
+                     --spec-path:azure-special-properties.json \
+                     --spec-path:body-array.json \
+                     --spec-path:body-boolean.json \
+                     --spec-path:body-boolean.quirks.json \
+                     --spec-path:body-byte.json \
                      --spec-path:body-complex.json \
+                     --spec-path:body-date.json \
+                     --spec-path:body-datetime-rfc1123.json \
+                     --spec-path:body-datetime.json \
+                     --spec-path:body-dictionary.json \
+                     --spec-path:body-duration.json \
+                     --spec-path:body-file.json \
+                     --spec-path:body-formdata-urlencoded.json \
+                     --spec-path:body-formdata.json \
+                     --spec-path:body-integer.json \
+                     --spec-path:body-number.json \
+                     --spec-path:body-number.quirks.json \
+                     --spec-path:body-string.json \
+                     --spec-path:body-string.quirks.json \
+                     --spec-path:complex-model.json \
+                     --spec-path:custom-baseUrl-more-options.json \
+                     --spec-path:custom-baseUrl-paging.json \
+                     --spec-path:custom-baseUrl.json \
+                     --spec-path:extensible-enums-swagger.json \
+                     --spec-path:head-exceptions.json \
+                     --spec-path:head.json \
+                     --spec-path:header.json \
+                     --spec-path:httpInfrastructure.json \
+                     --spec-path:httpInfrastructure.quirks.json \
+                     --spec-path:lro.json \
+                     --spec-path:model-flattening.json \
+                     --spec-path:paging.json \
+                     --spec-path:parameter-flattening.json \
+                     --spec-path:report.json \
+                     --spec-path:required-optional.json \
+                     --spec-path:storage.json \
+                     --spec-path:subscriptionId-apiVersion.json \
+                     --spec-path:url-multi-collectionFormat.json \
+                     --spec-path:url.json \
+                     --spec-path:validation.json \
+                     --spec-path:xml-service.json \
+                     --spec-path:xms-error-responses.json \
                      --spec-root-path:./modelerfour/node_modules/@microsoft.azure/autorest.testserver/__files/ \
                      --output-path:./generated/typescript/ \
                      --compare-old --package-name:test-package --version:3.0.6192 --use:@autorest/modelerfour@4.2.108 --use:$AUTOREST_TYPESCRIPT \

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -33,7 +33,7 @@ steps:
   displayName: Install autorest-compare
 
 - script : |
-    export AUTOREST_TYPESCRIPT=@autorest/typescript@0.1.0-dev.20200116.5
+    export AUTOREST_TYPESCRIPT=@autorest/typescript@0.1.0-dev.20200203.1
     autorest-compare --typescript \
                      --spec-path:azure-parameter-grouping.json \
                      --spec-path:azure-report.json \

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -35,12 +35,10 @@ steps:
 - script : |
     export AUTOREST_TYPESCRIPT=@autorest/typescript@0.1.0-dev.20200116.5
     autorest-compare --typescript \
-                     --spec-path:additionalProperties.json \
                      --spec-path:azure-parameter-grouping.json \
                      --spec-path:azure-report.json \
                      --spec-path:azure-resource-x.json \
                      --spec-path:azure-resource.json \
-                     --spec-path:azure-special-properties.json \
                      --spec-path:body-array.json \
                      --spec-path:body-boolean.json \
                      --spec-path:body-boolean.quirks.json \
@@ -70,8 +68,6 @@ steps:
                      --spec-path:httpInfrastructure.json \
                      --spec-path:httpInfrastructure.quirks.json \
                      --spec-path:lro.json \
-                     --spec-path:model-flattening.json \
-                     --spec-path:paging.json \
                      --spec-path:parameter-flattening.json \
                      --spec-path:report.json \
                      --spec-path:required-optional.json \
@@ -86,4 +82,11 @@ steps:
                      --output-path:./generated/typescript/ \
                      --compare-old --package-name:test-package --version:3.0.6192 --use:@autorest/modelerfour@4.2.108 --use:$AUTOREST_TYPESCRIPT \
                      --compare-new --package-name:test-package --version:3.0.6192 --use:./modelerfour --use:$AUTOREST_TYPESCRIPT
+
+                     # Disabled due to issues with TypeScript generator and OData properties
+                     # --spec-path:additionalProperties.json \
+                     # --spec-path:azure-special-properties.json \
+                     # --spec-path:paging.json \
+                     # --spec-path:model-flattening.json \
   displayName: Regression Test - @autorest/typescript
+  continueOnError: true # Don't make this a hard fail just yet

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- master 
+- master
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -16,14 +16,29 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
-    npm install -g npm 
+    npm install -g npm
     npm cache clear --force
 
-    npx @microsoft/rush update 
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi 
-    npx @microsoft/rush rebuild 
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi 
-    npx @microsoft/rush test 
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi 
-    
+    npx @microsoft/rush update
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
+    npx @microsoft/rush rebuild
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
+    npx @microsoft/rush test
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
+
   displayName: 'Rush install, build and test'
+
+- script : |
+    npm install -g @autorest/compare
+  displayName: Install autorest-compare
+
+- script : |
+    export AUTOREST_TYPESCRIPT=@autorest/typescript@0.1.0-dev.20200116.5
+    autorest-compare --typescript \
+                     --spec-path:body-string.json \
+                     --spec-path:body-complex.json \
+                     --spec-root-path:./modelerfour/node_modules/@microsoft.azure/autorest.testserver/__files/ \
+                     --output-path:./generated/typescript/ \
+                     --compare-old --package-name:test-package --version:3.0.6192 --use:@autorest/modelerfour@4.2.108 --use:$AUTOREST_TYPESCRIPT \
+                     --compare-new --package-name:test-package --version:3.0.6192 --use:./modelerfour --use:$AUTOREST_TYPESCRIPT
+  displayName: Regression Test - @autorest/typescript


### PR DESCRIPTION
This change uses [`autorest-compare`](https://github.com/Azure/autorest.compare) to implement regression testing for `@autorest/modelerfour` when PRs are sent.  For now it only compares the output of the v3 `@autorest/typescript` generator using both previous version of `@autorest/modelerfour` and the changes in the PR, but more languages will be added later as support comes to `autorest-compare`.

One thing to note is that I'm not currently using any specs from the `azure-rest-api-specs` repo since they generally tend to fail on the (temporary) lack of multi API support in `modelerfour`.  Once that comes online I'll add tests with a subset of the specs found there.

An example CI run that [simulates a regression](https://github.com/Azure/autorest.modelerfour/commit/8ed4fad82b07b8688085e7f4f17ca944cdac56f9) with detected changes can be seen here:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=243436&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=bd05475d-acb5-5619-3ccb-c46842dbc997

**Question:**  Which other specs from `@microsoft.azure/autorest.testserver` should we use?  Right now I'm only using `body-string.json` and `body-complex.json`, but I'm sure there are 3-5 others that might be useful.