### PR TITLE
updated to support more formatting options

### DIFF
--- a/modelerfour/prenamer/plugin-prenamer.ts
+++ b/modelerfour/prenamer/plugin-prenamer.ts
@@ -16,7 +16,7 @@ export async function processRequest(host: Host) {
     const options = <any>await session.getValue('modelerfour', {});
 
     // process
-    const plugin = new PreNamer(session);
+    const plugin = await new PreNamer(session).init();
 
     // go!
     const result = plugin.process();

--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -102,6 +102,23 @@ modelerfour:
   # defaults to false if not specified
   group-parameters: false|true
 
+  # customization of the identifier normalization and naming provided by the prenamer.
+  # pascalcase - MultiWordIdentifier 
+  # camelcase - multiWordIdentifier 
+  # snakecase - multi_word_identifier
+  # uppercase - MULTI_WORD_IDENTIFIER 
+  # kebabcase - multi-word-identifier 
+  # default is the first one in the list below:
+  naming: 
+    parameter: camelcase | pascalcase | snakecase | uppercase | kebabcase
+    property: camelcase| pascalcase | snakecase | uppercase | kebabcase
+    operation: pascalcase | camelcase | snakecase | uppercase | kebabcase
+    operationGroup:  pascalcase | camelcase | snakecase | uppercase | kebabcase
+    choice:  pascalcase | camelcase | snakecase | uppercase | kebabcase
+    choiceValue:  pascalcase | camelcase | snakecase | uppercase | kebabcase
+    constant:  pascalcase | camelcase | snakecase | uppercase | kebabcase
+    type:  pascalcase | camelcase | snakecase | uppercase | kebabcase
+
 ```
 ~~~
 

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: Basic Id
         protocol: !<!Protocols> {}
       serializedName: id
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Basic Id
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_59
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: basic-name
+            name: BasicName
             description: Name property with a very long description that does not fit on a single line and a line break.
         protocol: !<!Protocols> {}
       serializedName: name
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: Name property with a very long description that does not fit on a single line and a line break.
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ChoiceSchema> &ref_22
@@ -48,7 +46,7 @@ schemas: !<!Schemas>
           value: cyan
           language:
             default:
-              name: cyan
+              name: Cyan
               description: ''
         - !<!ChoiceValue> 
           value: Magenta
@@ -60,13 +58,13 @@ schemas: !<!Schemas>
           value: YELLOW
           language:
             default:
-              name: YELLOW
+              name: Yellow
               description: ''
         - !<!ChoiceValue> 
           value: blacK
           language:
             default:
-              name: blacK
+              name: BlacK
               description: ''
         type: choice
         apiVersions:
@@ -76,12 +74,12 @@ schemas: !<!Schemas>
           type: string
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: simple string
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CMYKColors
+            name: CmykColors
             description: ''
         protocol: !<!Protocols> {}
       serializedName: color
@@ -89,11 +87,10 @@ schemas: !<!Schemas>
         default:
           name: color
           description: ''
-          originalName: color
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: basic
+        name: Basic
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -109,7 +106,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -117,7 +114,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_60
@@ -127,7 +123,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -135,7 +131,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -155,7 +150,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForfield1
+            name: TypeForfield1
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field1
@@ -163,7 +158,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: ''
-          originalName: field1
       protocol: !<!Protocols> {}
     - !<!Property> &ref_89
       schema: !<!NumberSchema> &ref_47
@@ -171,7 +165,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForfield2
+            name: TypeForfield2
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field2
@@ -179,11 +173,10 @@ schemas: !<!Schemas>
         default:
           name: field2
           description: ''
-          originalName: field2
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: int-wrapper
+        name: IntWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -199,7 +192,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: typeForfield1
+            name: TypeForfield1
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field1
@@ -207,7 +200,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: ''
-          originalName: field1
       protocol: !<!Protocols> {}
     - !<!Property> &ref_95
       schema: !<!NumberSchema> &ref_49
@@ -215,7 +207,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: typeForfield2
+            name: TypeForfield2
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field2
@@ -223,11 +215,10 @@ schemas: !<!Schemas>
         default:
           name: field2
           description: ''
-          originalName: field2
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: long-wrapper
+        name: LongWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -243,7 +234,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForfield1
+            name: TypeForfield1
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field1
@@ -251,7 +242,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: ''
-          originalName: field1
       protocol: !<!Protocols> {}
     - !<!Property> &ref_101
       schema: !<!NumberSchema> &ref_51
@@ -259,7 +249,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForfield2
+            name: TypeForfield2
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field2
@@ -267,11 +257,10 @@ schemas: !<!Schemas>
         default:
           name: field2
           description: ''
-          originalName: field2
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: float-wrapper
+        name: FloatWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -287,7 +276,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: typeForfield1
+            name: TypeForfield1
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field1
@@ -295,7 +284,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: ''
-          originalName: field1
       protocol: !<!Protocols> {}
     - !<!Property> &ref_107
       schema: !<!NumberSchema> &ref_53
@@ -303,7 +291,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: typeForfield_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
+            name: TypeForfield56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
@@ -311,11 +299,10 @@ schemas: !<!Schemas>
         default:
           name: field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
           description: ''
-          originalName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: double-wrapper
+        name: DoubleWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -330,7 +317,7 @@ schemas: !<!Schemas>
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForfield_true
+            name: TypeForfieldTrue
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field_true
@@ -338,14 +325,13 @@ schemas: !<!Schemas>
         default:
           name: fieldTrue
           description: ''
-          originalName: field_true
       protocol: !<!Protocols> {}
     - !<!Property> &ref_113
       schema: !<!BooleanSchema> &ref_30
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForfield_false
+            name: TypeForfieldFalse
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field_false
@@ -353,11 +339,10 @@ schemas: !<!Schemas>
         default:
           name: fieldFalse
           description: ''
-          originalName: field_false
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: boolean-wrapper
+        name: BooleanWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -375,7 +360,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: string-wrapper-field
+            name: StringWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -383,7 +368,6 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_62
@@ -393,7 +377,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: string-wrapper-empty
+            name: StringWrapperEmpty
             description: ''
         protocol: !<!Protocols> {}
       serializedName: empty
@@ -401,7 +385,6 @@ schemas: !<!Schemas>
         default:
           name: empty
           description: ''
-          originalName: empty
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_63
@@ -411,7 +394,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: string-wrapper-null
+            name: StringWrapperNull
             description: ''
         protocol: !<!Protocols> {}
       serializedName: 'null'
@@ -419,11 +402,10 @@ schemas: !<!Schemas>
         default:
           name: 'null'
           description: ''
-          originalName: 'null'
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: string-wrapper
+        name: StringWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -441,7 +423,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: date-wrapper-field
+            name: DateWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -449,7 +431,6 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     - !<!Property> &ref_121
       schema: !<!DateSchema> &ref_42
@@ -459,7 +440,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: date-wrapper-leap
+            name: DateWrapperLeap
             description: ''
         protocol: !<!Protocols> {}
       serializedName: leap
@@ -467,11 +448,10 @@ schemas: !<!Schemas>
         default:
           name: leap
           description: ''
-          originalName: leap
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: date-wrapper
+        name: DateWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -490,7 +470,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: datetime-wrapper-field
+            name: DatetimeWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -498,7 +478,6 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     - !<!Property> &ref_127
       schema: !<!DateTimeSchema> &ref_37
@@ -509,7 +488,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: datetime-wrapper-now
+            name: DatetimeWrapperNow
             description: ''
         protocol: !<!Protocols> {}
       serializedName: now
@@ -517,11 +496,10 @@ schemas: !<!Schemas>
         default:
           name: now
           description: ''
-          originalName: now
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: datetime-wrapper
+        name: DatetimeWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -540,7 +518,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: datetimerfc1123-wrapper-field
+            name: Datetimerfc1123WrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -548,7 +526,6 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     - !<!Property> &ref_133
       schema: !<!DateTimeSchema> &ref_39
@@ -559,7 +536,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: datetimerfc1123-wrapper-now
+            name: Datetimerfc1123WrapperNow
             description: ''
         protocol: !<!Protocols> {}
       serializedName: now
@@ -567,11 +544,10 @@ schemas: !<!Schemas>
         default:
           name: now
           description: ''
-          originalName: now
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: datetimerfc1123-wrapper
+        name: Datetimerfc1123Wrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -589,7 +565,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: duration-wrapper-field
+            name: DurationWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -597,11 +573,10 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: duration-wrapper
+        name: DurationWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -620,7 +595,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: byte-wrapper-field
+            name: ByteWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -628,11 +603,10 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: byte-wrapper
+        name: ByteWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -655,24 +629,23 @@ schemas: !<!Schemas>
             version: '2016-02-29'
           language: !<!Languages> 
             default:
-              name: array-wrapper-arrayItem
+              name: ArrayWrapperArrayItem
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: array-wrapper-array
-            description: ''
+            name: ArrayWrapperArray
+            description: Array of ArrayWrapperArrayItem
         protocol: !<!Protocols> {}
       serializedName: array
       language: !<!Languages> 
         default:
           name: array
           description: ''
-          originalName: array
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: array-wrapper
+        name: ArrayWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -692,24 +665,23 @@ schemas: !<!Schemas>
             version: '2016-02-29'
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Dictionary of string
-            description: Dictionary of <components·schemas·dictionary_wrapper·properties·defaultprogram·additionalproperties>
+            name: DictionaryWrapperDefaultProgram
+            description: Dictionary of String
         protocol: !<!Protocols> {}
       serializedName: defaultProgram
       language: !<!Languages> 
         default:
           name: defaultProgram
           description: Dictionary of <components·schemas·dictionary_wrapper·properties·defaultprogram·additionalproperties>
-          originalName: defaultProgram
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: dictionary-wrapper
+        name: DictionaryWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -739,7 +711,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: dog-food
+                name: DogFood
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: food
@@ -747,11 +719,10 @@ schemas: !<!Schemas>
             default:
               name: food
               description: ''
-              originalName: food
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: dog
+            name: Dog
             description: ''
             namespace: Api20160229
         protocol: !<!Protocols> {}
@@ -782,7 +753,7 @@ schemas: !<!Schemas>
                   version: '2016-02-29'
                 language: !<!Languages> 
                   default:
-                    name: siamese-breed
+                    name: SiameseBreed
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: breed
@@ -790,11 +761,10 @@ schemas: !<!Schemas>
                 default:
                   name: breed
                   description: ''
-                  originalName: breed
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: siamese
+                name: Siamese
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -814,7 +784,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: cat-color
+                name: CatColor
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: color
@@ -822,7 +792,6 @@ schemas: !<!Schemas>
             default:
               name: color
               description: ''
-              originalName: color
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ArraySchema> &ref_25
@@ -833,19 +802,18 @@ schemas: !<!Schemas>
             elementType: *ref_3
             language: !<!Languages> 
               default:
-                name: cat-hates
-                description: ''
+                name: CatHates
+                description: Array of dog
             protocol: !<!Protocols> {}
           serializedName: hates
           language: !<!Languages> 
             default:
               name: hates
               description: ''
-              originalName: hates
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: cat
+            name: Cat
             description: ''
             namespace: Api20160229
         protocol: !<!Protocols> {}
@@ -860,7 +828,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       serializedName: id
@@ -868,7 +836,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_66
@@ -878,7 +845,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: pet-name
+            name: PetName
             description: ''
         protocol: !<!Protocols> {}
       serializedName: name
@@ -886,11 +853,10 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: pet
+        name: Pet
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -931,7 +897,7 @@ schemas: !<!Schemas>
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
-                    name: smart_salmon
+                    name: SmartSalmon
                     description: Dictionary of <any>
                 protocol: !<!Protocols> {}
               - *ref_5
@@ -948,7 +914,7 @@ schemas: !<!Schemas>
                   version: '2016-02-29'
                 language: !<!Languages> 
                   default:
-                    name: smart_salmon-college_degree
+                    name: SmartSalmonCollegeDegree
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: college_degree
@@ -956,11 +922,10 @@ schemas: !<!Schemas>
                 default:
                   name: collegeDegree
                   description: ''
-                  originalName: college_degree
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: smart_salmon
+                name: SmartSalmon
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -979,7 +944,7 @@ schemas: !<!Schemas>
                 version: '2016-02-29'
               language: !<!Languages> 
                 default:
-                  name: Fish-fishtype
+                  name: FishFishtype
                   description: ''
               protocol: !<!Protocols> {}
             isDiscriminator: true
@@ -989,7 +954,6 @@ schemas: !<!Schemas>
               default:
                 name: fishtype
                 description: ''
-                originalName: fishtype
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
         parents: !<!Relations> 
@@ -1006,7 +970,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: salmon-location
+                name: SalmonLocation
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: location
@@ -1014,14 +978,13 @@ schemas: !<!Schemas>
             default:
               name: location
               description: ''
-              originalName: location
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_32
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForiswild
+                name: TypeForiswild
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: iswild
@@ -1029,11 +992,10 @@ schemas: !<!Schemas>
             default:
               name: iswild
               description: ''
-              originalName: iswild
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: salmon
+            name: Salmon
             description: ''
             namespace: Api20160229
         protocol: !<!Protocols> {}
@@ -1067,7 +1029,7 @@ schemas: !<!Schemas>
                   version: '2016-02-29'
                 language: !<!Languages> 
                   default:
-                    name: sawshark-picture
+                    name: SawsharkPicture
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: picture
@@ -1075,11 +1037,10 @@ schemas: !<!Schemas>
                 default:
                   name: picture
                   description: ''
-                  originalName: picture
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: sawshark
+                name: Sawshark
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -1102,7 +1063,7 @@ schemas: !<!Schemas>
                 precision: 32
                 language: !<!Languages> 
                   default:
-                    name: typeForjawsize
+                    name: TypeForjawsize
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: jawsize
@@ -1110,7 +1071,6 @@ schemas: !<!Schemas>
                 default:
                   name: jawsize
                   description: ''
-                  originalName: jawsize
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!ChoiceSchema> &ref_23
@@ -1119,19 +1079,19 @@ schemas: !<!Schemas>
                   value: pink
                   language:
                     default:
-                      name: pink
+                      name: Pink
                       description: ''
                 - !<!ChoiceValue> 
                   value: gray
                   language:
                     default:
-                      name: gray
+                      name: Gray
                       description: ''
                 - !<!ChoiceValue> 
                   value: brown
                   language:
                     default:
-                      name: brown
+                      name: Brown
                       description: ''
                 type: choice
                 apiVersions:
@@ -1149,13 +1109,12 @@ schemas: !<!Schemas>
                 default:
                   name: color
                   description: Colors possible
-                  originalName: color
               protocol: !<!Protocols> {}
             extensions:
               x-ms-discriminator-value: goblin
             language: !<!Languages> 
               default:
-                name: goblinshark
+                name: Goblinshark
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -1173,7 +1132,7 @@ schemas: !<!Schemas>
               - *ref_8
             language: !<!Languages> 
               default:
-                name: cookiecuttershark
+                name: Cookiecuttershark
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -1204,7 +1163,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeForage
+                name: TypeForage
                 description: ''
             protocol: !<!Protocols> {}
           required: false
@@ -1213,7 +1172,6 @@ schemas: !<!Schemas>
             default:
               name: age
               description: ''
-              originalName: age
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!DateTimeSchema> &ref_40
@@ -1224,7 +1182,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: shark-birthday
+                name: SharkBirthday
                 description: ''
             protocol: !<!Protocols> {}
           required: true
@@ -1233,11 +1191,10 @@ schemas: !<!Schemas>
             default:
               name: birthday
               description: ''
-              originalName: birthday
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: shark
+            name: Shark
             description: ''
             namespace: Api20160229
         protocol: !<!Protocols> {}
@@ -1269,7 +1226,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: Fish-species
+            name: FishSpecies
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -1278,7 +1235,6 @@ schemas: !<!Schemas>
         default:
           name: species
           description: ''
-          originalName: species
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!NumberSchema> &ref_55
@@ -1286,7 +1242,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForlength
+            name: TypeForlength
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -1295,7 +1251,6 @@ schemas: !<!Schemas>
         default:
           name: length
           description: ''
-          originalName: length
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_26
@@ -1306,8 +1261,8 @@ schemas: !<!Schemas>
         elementType: *ref_5
         language: !<!Languages> 
           default:
-            name: Fish-siblings
-            description: ''
+            name: FishSiblings
+            description: Array of Fish
         protocol: !<!Protocols> {}
       required: false
       serializedName: siblings
@@ -1315,7 +1270,6 @@ schemas: !<!Schemas>
         default:
           name: siblings
           description: ''
-          originalName: siblings
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1350,7 +1304,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: DotSalmon-location
+                name: DotSalmonLocation
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: location
@@ -1358,14 +1312,13 @@ schemas: !<!Schemas>
             default:
               name: location
               description: ''
-              originalName: location
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_31
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForiswild
+                name: TypeForiswild
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: iswild
@@ -1373,7 +1326,6 @@ schemas: !<!Schemas>
             default:
               name: iswild
               description: ''
-              originalName: iswild
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -1396,7 +1348,7 @@ schemas: !<!Schemas>
             version: '2016-02-29'
           language: !<!Languages> 
             default:
-              name: DotFish-fish.type
+              name: DotFishType
               description: ''
           protocol: !<!Protocols> {}
         isDiscriminator: true
@@ -1406,7 +1358,6 @@ schemas: !<!Schemas>
           default:
             name: fishType
             description: ''
-            originalName: fish.type
         protocol: !<!Protocols> {}
     properties:
     - *ref_16
@@ -1418,7 +1369,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: DotFish-species
+            name: DotFishSpecies
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -1427,7 +1378,6 @@ schemas: !<!Schemas>
         default:
           name: species
           description: ''
-          originalName: species
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1448,7 +1398,6 @@ schemas: !<!Schemas>
         default:
           name: sampleSalmon
           description: ''
-          originalName: sampleSalmon
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_27
@@ -1459,15 +1408,14 @@ schemas: !<!Schemas>
         elementType: *ref_15
         language: !<!Languages> 
           default:
-            name: DotFishMarket-salmons
-            description: ''
+            name: DotFishMarketSalmons
+            description: Array of DotSalmon
         protocol: !<!Protocols> {}
       serializedName: salmons
       language: !<!Languages> 
         default:
           name: salmons
           description: ''
-          originalName: salmons
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_14
@@ -1476,7 +1424,6 @@ schemas: !<!Schemas>
         default:
           name: sampleFish
           description: ''
-          originalName: sampleFish
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_28
@@ -1487,15 +1434,14 @@ schemas: !<!Schemas>
         elementType: *ref_14
         language: !<!Languages> 
           default:
-            name: DotFishMarket-fishes
-            description: ''
+            name: DotFishMarketFishes
+            description: Array of DotFish
         protocol: !<!Protocols> {}
       serializedName: fishes
       language: !<!Languages> 
         default:
           name: fishes
           description: ''
-          originalName: fishes
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1519,7 +1465,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: readonly-obj-id
+            name: ReadonlyObjId
             description: ''
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1528,7 +1474,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> &ref_165
       schema: !<!NumberSchema> &ref_56
@@ -1536,7 +1481,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForsize
+            name: TypeForsize
             description: ''
         protocol: !<!Protocols> {}
       serializedName: size
@@ -1544,11 +1489,10 @@ schemas: !<!Schemas>
         default:
           name: size
           description: ''
-          originalName: size
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: readonly-obj
+        name: ReadonlyObj
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -1579,7 +1523,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: MyDerivedType-propD1
+                name: MyDerivedTypePropD1
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: propD1
@@ -1587,7 +1531,6 @@ schemas: !<!Schemas>
             default:
               name: propD1
               description: ''
-              originalName: propD1
           protocol: !<!Protocols> {}
         extensions:
           x-ms-discriminator-value: Kind1
@@ -1629,7 +1572,6 @@ schemas: !<!Schemas>
           default:
             name: kind
             description: ''
-            originalName: kind
         protocol: !<!Protocols> {}
     properties:
     - *ref_19
@@ -1641,7 +1583,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: MyBaseType-propB1
+            name: MyBaseTypePropB1
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -1650,7 +1592,6 @@ schemas: !<!Schemas>
         default:
           name: propB1
           description: ''
-          originalName: propB1
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_20
@@ -1660,7 +1601,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: MyBaseHelperType-propBH1
+            name: MyBaseHelperTypePropBh1
             description: ''
         protocol: !<!Protocols> {}
       flattenedNames:
@@ -1670,9 +1611,8 @@ schemas: !<!Schemas>
       serializedName: propBH1
       language: !<!Languages> 
         default:
-          name: propBH1
+          name: propBh1
           description: ''
-          originalName: propBH1
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1691,9 +1631,8 @@ schemas: !<!Schemas>
       serializedName: propBH1
       language: !<!Languages> 
         default:
-          name: propBH1
+          name: propBh1
           description: ''
-          originalName: propBH1
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -1741,7 +1680,7 @@ schemas: !<!Schemas>
     valueType: *ref_9
     language: !<!Languages> 
       default:
-        name: ApiVersion-2016-02-29
+        name: ApiVersion20160229
         description: Api Version (2016-02-29)
     protocol: !<!Protocols> {}
   - *ref_35
@@ -1878,7 +1817,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: 'Get complex type {id: 2, name: ''abc'', color: ''YELLOW''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1945,7 +1884,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: 'Please put {id: 2, name: ''abc'', color: ''Magenta''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1995,7 +1934,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: danceDanceRevolution
+        name: DanceRevolution
         description: Get a basic complex type that is invalid for the local strong type
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2045,7 +1984,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get a basic complex type that is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2095,7 +2034,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get a basic complex type whose properties are null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2145,12 +2084,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotProvided
+        name: GetNotProvided
         description: Get a basic complex type while the server doesn't provide a response payload
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: basic
+      name: Basic
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -2203,7 +2142,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInt
+        name: GetInt
         description: Get complex types with integer properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2295,7 +2234,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putInt
+        name: PutInt
         description: Put complex types with integer properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2345,7 +2284,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLong
+        name: GetLong
         description: Get complex types with long properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2437,7 +2376,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putLong
+        name: PutLong
         description: Put complex types with long properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2487,7 +2426,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFloat
+        name: GetFloat
         description: Get complex types with float properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2579,7 +2518,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putFloat
+        name: PutFloat
         description: Put complex types with float properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2629,7 +2568,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDouble
+        name: GetDouble
         description: Get complex types with double properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2675,7 +2614,7 @@ operationGroups:
         targetProperty: *ref_107
         language: !<!Languages> 
           default:
-            name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
+            name: field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
             description: ''
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -2721,7 +2660,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDouble
+        name: PutDouble
         description: Put complex types with double properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2771,7 +2710,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBool
+        name: GetBool
         description: Get complex types with bool properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2805,7 +2744,7 @@ operationGroups:
         targetProperty: *ref_112
         language: !<!Languages> 
           default:
-            name: field_true
+            name: fieldTrue
             description: ''
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_115
@@ -2817,7 +2756,7 @@ operationGroups:
         targetProperty: *ref_113
         language: !<!Languages> 
           default:
-            name: field_false
+            name: fieldFalse
             description: ''
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -2863,7 +2802,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBool
+        name: PutBool
         description: Put complex types with bool properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2913,7 +2852,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getString
+        name: GetString
         description: Get complex types with string properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2979,7 +2918,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putString
+        name: PutString
         description: Put complex types with string properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3029,7 +2968,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDate
+        name: GetDate
         description: Get complex types with date properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3121,7 +3060,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDate
+        name: PutDate
         description: Put complex types with date properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3171,7 +3110,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTime
+        name: GetDateTime
         description: Get complex types with datetime properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3263,7 +3202,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateTime
+        name: PutDateTime
         description: Put complex types with datetime properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3313,7 +3252,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeRfc1123
+        name: GetDateTimeRfc1123
         description: Get complex types with datetimeRfc1123 properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3405,7 +3344,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateTimeRfc1123
+        name: PutDateTimeRfc1123
         description: Put complex types with datetimeRfc1123 properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3455,7 +3394,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDuration
+        name: GetDuration
         description: Get complex types with duration properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3534,7 +3473,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDuration
+        name: PutDuration
         description: Put complex types with duration properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3584,7 +3523,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getByte
+        name: GetByte
         description: Get complex types with byte properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3663,12 +3602,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putByte
+        name: PutByte
         description: Put complex types with byte properties
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: primitive
+      name: Primitive
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -3721,7 +3660,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types with array property
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3800,7 +3739,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types with array property
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3850,7 +3789,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get complex types with array property which is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3929,7 +3868,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmpty
+        name: PutEmpty
         description: Put complex types with array property which is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3979,12 +3918,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotProvided
+        name: GetNotProvided
         description: Get complex types with array property while server doesn't provide a response payload
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: array
+      name: Array
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4037,7 +3976,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types with dictionary property
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4116,7 +4055,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types with dictionary property
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4166,7 +4105,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get complex types with dictionary property which is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4245,7 +4184,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmpty
+        name: PutEmpty
         description: Put complex types with dictionary property which is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4295,7 +4234,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get complex types with dictionary property which is null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4345,12 +4284,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotProvided
+        name: GetNotProvided
         description: Get complex types with dictionary property while server doesn't provide a response payload
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: dictionary
+      name: Dictionary
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4403,7 +4342,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types that extend others
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4469,12 +4408,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types that extend others
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: inheritance
+      name: Inheritance
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4527,7 +4466,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types that are polymorphic
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4626,7 +4565,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types that are polymorphic
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4676,7 +4615,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDotSyntax
+        name: GetDotSyntax
         description: 'Get complex types that are polymorphic, JSON key contains a dot'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4726,7 +4665,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComposedWithDiscriminator
+        name: GetComposedWithDiscriminator
         description: 'Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4776,7 +4715,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComposedWithoutDiscriminator
+        name: GetComposedWithoutDiscriminator
         description: 'Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4826,7 +4765,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplicated
+        name: GetComplicated
         description: 'Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4892,7 +4831,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putComplicated
+        name: PutComplicated
         description: 'Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4962,7 +4901,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMissingDiscriminator
+        name: PutMissingDiscriminator
         description: 'Put complex types that are polymorphic, omitting the discriminator'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5061,12 +5000,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValidMissingRequired
+        name: PutValidMissingRequired
         description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: polymorphism
+      name: Polymorphism
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -5119,7 +5058,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types that are polymorphic and have recursive references
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5218,12 +5157,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types that are polymorphic and have recursive references
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: polymorphicrecursive
+      name: Polymorphicrecursive
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -5276,7 +5215,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types that have readonly properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5355,12 +5294,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types that have readonly properties
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: readonlyproperty
+      name: Readonlyproperty
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -5399,12 +5338,12 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: ''
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: flattencomplex
+      name: Flattencomplex
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/additionalProperties/namer.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: PetAPTrue
+                name: PetApTrue
                 description: Dictionary of <any>
             protocol: !<!Protocols> {}
           immediate:
@@ -38,7 +38,7 @@ schemas: !<!Schemas>
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForfriendly
+                name: TypeForfriendly
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: friendly
@@ -46,11 +46,10 @@ schemas: !<!Schemas>
             default:
               name: friendly
               description: ''
-              originalName: friendly
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CatAPTrue
+            name: CatApTrue
             description: ''
             namespace: Api100
         protocol: !<!Protocols> {}
@@ -68,7 +67,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -77,7 +76,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> &ref_33
       schema: !<!StringSchema> &ref_22
@@ -87,7 +85,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: PetAPTrue-name
+            name: PetApTrueName
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -96,14 +94,13 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_10
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       readOnly: true
@@ -113,11 +110,10 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: PetAPTrue
+        name: PetApTrue
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -133,7 +129,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -141,7 +137,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_23
@@ -151,7 +146,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -159,7 +154,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -186,7 +180,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: PetAPObject
+            name: PetApObject
             description: Dictionary of <any>
         protocol: !<!Protocols> {}
       immediate:
@@ -198,7 +192,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -207,7 +201,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> &ref_41
       schema: !<!StringSchema> &ref_24
@@ -217,7 +210,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: PetAPObject-name
+            name: PetApObjectName
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -226,14 +219,13 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_12
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       readOnly: true
@@ -243,11 +235,10 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: PetAPObject
+        name: PetApObject
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -267,13 +258,13 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Dictionary of string
-            description: Dictionary of <components·schemas·petapstring·additionalproperties>
+            name: PetApString
+            description: Dictionary of String
         protocol: !<!Protocols> {}
       immediate:
       - *ref_4
@@ -284,7 +275,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -293,7 +284,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> &ref_47
       schema: !<!StringSchema> &ref_25
@@ -303,7 +293,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: PetAPString-name
+            name: PetApStringName
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -312,14 +302,13 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_13
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       readOnly: true
@@ -329,11 +318,10 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: PetAPString
+        name: PetApString
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -349,7 +337,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -358,7 +346,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_26
@@ -368,7 +355,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: PetAPInProperties-name
+            name: PetApInPropertiesName
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -377,14 +364,13 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_14
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       readOnly: true
@@ -394,7 +380,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_8
@@ -407,13 +392,13 @@ schemas: !<!Schemas>
           precision: 32
           language: !<!Languages> 
             default:
-              name: number
+              name: Number
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Dictionary of number
-            description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
+            name: PetApInPropertiesAdditionalProperties
+            description: Dictionary of Number
         protocol: !<!Protocols> {}
       required: false
       serializedName: additionalProperties
@@ -421,11 +406,10 @@ schemas: !<!Schemas>
         default:
           name: additionalProperties
           description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
-          originalName: additionalProperties
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: PetAPInProperties
+        name: PetApInProperties
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -441,8 +425,8 @@ schemas: !<!Schemas>
         elementType: *ref_5
         language: !<!Languages> 
           default:
-            name: Dictionary of string
-            description: Dictionary of <components·schemas·petapstring·additionalproperties>
+            name: PetApInPropertiesWithApstring
+            description: Dictionary of String
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
@@ -453,7 +437,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -462,7 +446,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_27
@@ -472,7 +455,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: PetAPInPropertiesWithAPString-name
+            name: PetApInPropertiesWithApstringName
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -481,14 +464,13 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_15
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       readOnly: true
@@ -498,7 +480,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_28
@@ -508,16 +489,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: PetAPInPropertiesWithAPString-@odata.location
+            name: PetApInPropertiesWithApstringOdataLocation
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: '@odata.location'
       language: !<!Languages> 
         default:
-          name: OdataLocation
+          name: odataLocation
           description: ''
-          originalName: '@odata.location'
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_9
@@ -525,8 +505,8 @@ schemas: !<!Schemas>
         elementType: *ref_7
         language: !<!Languages> 
           default:
-            name: Dictionary of number
-            description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
+            name: PetApInPropertiesWithApstringAdditionalProperties
+            description: Dictionary of Number
         protocol: !<!Protocols> {}
       required: false
       serializedName: additionalProperties
@@ -534,11 +514,10 @@ schemas: !<!Schemas>
         default:
           name: additionalProperties
           description: Dictionary of <components·schemas·petapinproperties·properties·additionalproperties·additionalproperties>
-          originalName: additionalProperties
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: PetAPInPropertiesWithAPString
+        name: PetApInPropertiesWithApstring
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -569,7 +548,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_22
@@ -698,7 +677,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: CreateAPTrue
+        name: CreateApTrue
         description: Create a Pet which contains more properties than what is defined.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -768,7 +747,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: CreateCatAPTrue
+        name: CreateCatApTrue
         description: Create a CatAPTrue which contains more properties than what is defined.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -866,7 +845,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: CreateAPObject
+        name: CreateApObject
         description: Create a Pet which contains more properties than what is defined.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -964,7 +943,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: CreateAPString
+        name: CreateApString
         description: Create a Pet which contains more properties than what is defined.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1034,7 +1013,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: CreateAPInProperties
+        name: CreateApInProperties
         description: Create a Pet which contains more properties than what is defined.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1104,7 +1083,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: CreateAPInPropertiesWithAPString
+        name: CreateApInPropertiesWithApstring
         description: Create a Pet which contains more properties than what is defined.
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_13
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -59,7 +57,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -99,7 +97,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -153,7 +151,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -395,7 +393,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_0
@@ -477,7 +475,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequired
+        name: PostRequired
         description: Post a bunch of required parameters grouped
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -527,7 +525,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postOptional
+        name: PostOptional
         description: Post a bunch of optional parameters grouped
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -581,7 +579,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postMultiParamGroups
+        name: PostMultiParamGroups
         description: Post parameters from multiple different parameter groups
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -631,12 +629,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postSharedParameterGroupObject
+        name: PostSharedParameterGroupObject
         description: Post parameters with a shared parameter group object
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: parameterGrouping
+      name: ParameterGrouping
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/azure-report/namer.yaml
+++ b/modelerfour/test/scenarios/azure-report/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_2
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -58,13 +56,13 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: integer
+          name: Integer
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Dictionary of integer
-        description: Dictionary of <paths·report-azure·get·responses·200·content·application-json·schema·additionalproperties>
+        name: DictionaryOfInteger
+        description: Dictionary of Integer
     protocol: !<!Protocols> {}
   numbers:
   - *ref_0
@@ -74,7 +72,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_5
@@ -84,7 +82,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_2
@@ -170,7 +168,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getReport
+        name: GetReport
         description: Get test coverage report
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: FlattenedResourceProperties-pname
+                name: FlattenedResourcePropertiesPname
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -38,7 +38,6 @@ schemas: !<!Schemas>
             default:
               name: pname
               description: ''
-              originalName: pname
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!NumberSchema> &ref_3
@@ -46,7 +45,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeForlsize
+                name: TypeForlsize
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -57,7 +56,6 @@ schemas: !<!Schemas>
             default:
               name: lsize
               description: ''
-              originalName: lsize
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_4
@@ -67,7 +65,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: FlattenedResourceProperties-provisioningState
+                name: FlattenedResourcePropertiesProvisioningState
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -78,7 +76,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningState
               description: ''
-              originalName: provisioningState
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -97,7 +94,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ResourceX-id
+            name: ResourceXId
             description: Resource Id
         protocol: !<!Protocols> {}
       readOnly: true
@@ -106,7 +103,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Resource Id
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_10
@@ -116,7 +112,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ResourceX-type
+            name: ResourceXType
             description: Resource Type
         protocol: !<!Protocols> {}
       readOnly: true
@@ -125,7 +121,6 @@ schemas: !<!Schemas>
         default:
           name: type
           description: Resource Type
-          originalName: type
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_5
@@ -137,20 +132,19 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Dictionary of string
-            description: Dictionary of <components·schemas·resourcex·properties·tags·additionalproperties>
+            name: ResourceXTags
+            description: Dictionary of String
         protocol: !<!Protocols> {}
       serializedName: tags
       language: !<!Languages> 
         default:
           name: tags
           description: Dictionary of <components·schemas·resourcex·properties·tags·additionalproperties>
-          originalName: tags
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_12
@@ -160,7 +154,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ResourceX-location
+            name: ResourceXLocation
             description: Resource Location
         protocol: !<!Protocols> {}
       serializedName: location
@@ -168,7 +162,6 @@ schemas: !<!Schemas>
         default:
           name: location
           description: Resource Location
-          originalName: location
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_13
@@ -178,7 +171,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ResourceX-name
+            name: ResourceXName
             description: Resource Name
         protocol: !<!Protocols> {}
       readOnly: true
@@ -187,7 +180,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: Resource Name
-          originalName: name
       protocol: !<!Protocols> {}
     extensions:
       x-ms-azure-resource: true
@@ -209,7 +201,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -217,7 +209,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_14
@@ -227,7 +218,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -235,7 +226,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -257,7 +247,6 @@ schemas: !<!Schemas>
         default:
           name: pname
           description: ''
-          originalName: pname
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_3
@@ -266,7 +255,6 @@ schemas: !<!Schemas>
         default:
           name: lsize
           description: ''
-          originalName: lsize
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_4
@@ -275,7 +263,6 @@ schemas: !<!Schemas>
         default:
           name: provisioningState
           description: ''
-          originalName: provisioningState
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -298,7 +285,6 @@ schemas: !<!Schemas>
         default:
           name: productresource
           description: ''
-          originalName: productresource
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_7
@@ -309,15 +295,14 @@ schemas: !<!Schemas>
         elementType: *ref_1
         language: !<!Languages> 
           default:
-            name: ResourceCollection-arrayofresources
-            description: ''
+            name: ResourceCollectionArrayofresources
+            description: Array of FlattenedProduct
         protocol: !<!Protocols> {}
       serializedName: arrayofresources
       language: !<!Languages> 
         default:
           name: arrayofresources
           description: ''
-          originalName: arrayofresources
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_6
@@ -325,7 +310,7 @@ schemas: !<!Schemas>
         elementType: *ref_1
         language: !<!Languages> 
           default:
-            name: ResourceCollection-dictionaryofresources
+            name: ResourceCollectionDictionaryofresources
             description: Dictionary of <FlattenedProduct>
         protocol: !<!Protocols> {}
       serializedName: dictionaryofresources
@@ -333,7 +318,6 @@ schemas: !<!Schemas>
         default:
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
-          originalName: dictionaryofresources
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -361,8 +345,8 @@ schemas: !<!Schemas>
     elementType: *ref_0
     language: !<!Languages> 
       default:
-        name: Array of ResourceX
-        description: ''
+        name: ArrayOfResourceX
+        description: Array of ResourceX
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_20
     type: array
@@ -372,8 +356,8 @@ schemas: !<!Schemas>
     elementType: *ref_1
     language: !<!Languages> 
       default:
-        name: Array of FlattenedProduct
-        description: ''
+        name: ArrayOfFlattenedProduct
+        description: Array of FlattenedProduct
     protocol: !<!Protocols> {}
   - *ref_7
   numbers:
@@ -384,7 +368,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_9
@@ -432,7 +416,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceArray
         language: !<!Languages> 
           default:
-            name: ResourceArray
+            name: resourceArray
             description: External Resource as an Array to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -480,7 +464,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putArray
+        name: PutArray
         description: Put External Resource as an Array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -530,7 +514,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArray
+        name: GetArray
         description: Get External Resource as an Array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -547,7 +531,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceDictionary
         language: !<!Languages> 
           default:
-            name: ResourceDictionary
+            name: resourceDictionary
             description: External Resource as a Dictionary to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -595,7 +579,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDictionary
+        name: PutDictionary
         description: Put External Resource as a Dictionary
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -645,7 +629,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionary
+        name: GetDictionary
         description: Get External Resource as a Dictionary
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -662,7 +646,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceComplexObject
         language: !<!Languages> 
           default:
-            name: ResourceComplexObject
+            name: resourceComplexObject
             description: External Resource as a ResourceCollection to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -710,7 +694,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putResourceCollection
+        name: PutResourceCollection
         description: Put External Resource as a ResourceCollection
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -760,7 +744,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getResourceCollection
+        name: GetResourceCollection
         description: Get External Resource as a ResourceCollection
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: FlattenedResourceProperties-pname
+                name: FlattenedResourcePropertiesPname
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -38,7 +38,6 @@ schemas: !<!Schemas>
             default:
               name: pname
               description: ''
-              originalName: pname
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!NumberSchema> &ref_3
@@ -46,7 +45,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeForlsize
+                name: TypeForlsize
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -57,7 +56,6 @@ schemas: !<!Schemas>
             default:
               name: lsize
               description: ''
-              originalName: lsize
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_4
@@ -67,7 +65,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: FlattenedResourceProperties-provisioningState
+                name: FlattenedResourcePropertiesProvisioningState
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -78,7 +76,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningState
               description: ''
-              originalName: provisioningState
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -97,7 +94,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-id
+            name: ResourceId
             description: Resource Id
         protocol: !<!Protocols> {}
       readOnly: true
@@ -106,7 +103,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Resource Id
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_10
@@ -116,7 +112,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-type
+            name: ResourceType
             description: Resource Type
         protocol: !<!Protocols> {}
       readOnly: true
@@ -125,7 +121,6 @@ schemas: !<!Schemas>
         default:
           name: type
           description: Resource Type
-          originalName: type
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_5
@@ -137,20 +132,19 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Dictionary of string
-            description: Dictionary of <components·schemas·resource·properties·tags·additionalproperties>
+            name: ResourceTags
+            description: Dictionary of String
         protocol: !<!Protocols> {}
       serializedName: tags
       language: !<!Languages> 
         default:
           name: tags
           description: Dictionary of <components·schemas·resource·properties·tags·additionalproperties>
-          originalName: tags
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_12
@@ -160,7 +154,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-location
+            name: ResourceLocation
             description: Resource Location
         protocol: !<!Protocols> {}
       serializedName: location
@@ -168,7 +162,6 @@ schemas: !<!Schemas>
         default:
           name: location
           description: Resource Location
-          originalName: location
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_13
@@ -178,7 +171,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-name
+            name: ResourceName
             description: Resource Name
         protocol: !<!Protocols> {}
       readOnly: true
@@ -187,7 +180,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: Resource Name
-          originalName: name
       protocol: !<!Protocols> {}
     extensions:
       x-ms-azure-resource: true
@@ -209,7 +201,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -217,7 +209,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_14
@@ -227,7 +218,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -235,7 +226,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -257,7 +247,6 @@ schemas: !<!Schemas>
         default:
           name: pname
           description: ''
-          originalName: pname
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_3
@@ -266,7 +255,6 @@ schemas: !<!Schemas>
         default:
           name: lsize
           description: ''
-          originalName: lsize
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_4
@@ -275,7 +263,6 @@ schemas: !<!Schemas>
         default:
           name: provisioningState
           description: ''
-          originalName: provisioningState
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -298,7 +285,6 @@ schemas: !<!Schemas>
         default:
           name: productresource
           description: ''
-          originalName: productresource
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_7
@@ -309,15 +295,14 @@ schemas: !<!Schemas>
         elementType: *ref_1
         language: !<!Languages> 
           default:
-            name: ResourceCollection-arrayofresources
-            description: ''
+            name: ResourceCollectionArrayofresources
+            description: Array of FlattenedProduct
         protocol: !<!Protocols> {}
       serializedName: arrayofresources
       language: !<!Languages> 
         default:
           name: arrayofresources
           description: ''
-          originalName: arrayofresources
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_6
@@ -325,7 +310,7 @@ schemas: !<!Schemas>
         elementType: *ref_1
         language: !<!Languages> 
           default:
-            name: ResourceCollection-dictionaryofresources
+            name: ResourceCollectionDictionaryofresources
             description: Dictionary of <FlattenedProduct>
         protocol: !<!Protocols> {}
       serializedName: dictionaryofresources
@@ -333,7 +318,6 @@ schemas: !<!Schemas>
         default:
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
-          originalName: dictionaryofresources
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -361,8 +345,8 @@ schemas: !<!Schemas>
     elementType: *ref_0
     language: !<!Languages> 
       default:
-        name: Array of Resource
-        description: ''
+        name: ArrayOfResource
+        description: Array of Resource
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_20
     type: array
@@ -372,8 +356,8 @@ schemas: !<!Schemas>
     elementType: *ref_1
     language: !<!Languages> 
       default:
-        name: Array of FlattenedProduct
-        description: ''
+        name: ArrayOfFlattenedProduct
+        description: Array of FlattenedProduct
     protocol: !<!Protocols> {}
   - *ref_7
   numbers:
@@ -384,7 +368,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_9
@@ -432,7 +416,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceArray
         language: !<!Languages> 
           default:
-            name: ResourceArray
+            name: resourceArray
             description: External Resource as an Array to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -480,7 +464,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putArray
+        name: PutArray
         description: Put External Resource as an Array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -530,7 +514,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArray
+        name: GetArray
         description: Get External Resource as an Array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -547,7 +531,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceDictionary
         language: !<!Languages> 
           default:
-            name: ResourceDictionary
+            name: resourceDictionary
             description: External Resource as a Dictionary to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -595,7 +579,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDictionary
+        name: PutDictionary
         description: Put External Resource as a Dictionary
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -645,7 +629,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionary
+        name: GetDictionary
         description: Get External Resource as a Dictionary
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -662,7 +646,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceComplexObject
         language: !<!Languages> 
           default:
-            name: ResourceComplexObject
+            name: resourceComplexObject
             description: External Resource as a ResourceCollection to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -710,7 +694,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putResourceCollection
+        name: PutResourceCollection
         description: Put External Resource as a ResourceCollection
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -760,7 +744,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getResourceCollection
+        name: GetResourceCollection
         description: Get External Resource as a ResourceCollection
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/azure-special-properties/namer.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -22,7 +22,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ConstantSchema> &ref_0
@@ -38,12 +37,12 @@ schemas: !<!Schemas>
           precision: 32
           language: !<!Languages> 
             default:
-              name: number
+              name: Number
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: typeForconstantId
+            name: TypeForconstantId
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -52,7 +51,6 @@ schemas: !<!Schemas>
         default:
           name: constantId
           description: ''
-          originalName: constantId
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_7
@@ -62,7 +60,7 @@ schemas: !<!Schemas>
           version: 2015-07-01-preview
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -71,7 +69,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -91,7 +88,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       serializedName: id
@@ -99,7 +96,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_8
@@ -109,7 +105,7 @@ schemas: !<!Schemas>
           version: 2015-07-01-preview
         language: !<!Languages> 
           default:
-            name: OdataFilter-name
+            name: OdataFilterName
             description: ''
         protocol: !<!Protocols> {}
       serializedName: name
@@ -117,7 +113,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -139,12 +134,12 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -158,7 +153,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -172,7 +167,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -186,7 +181,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -200,7 +195,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -214,7 +209,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -228,7 +223,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -242,7 +237,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -256,7 +251,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-07-01-preview
+        name: ApiVersion20150701Preview
         description: Api Version (2015-07-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_21
@@ -270,7 +265,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: Constant0
+        name: Constant10
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_25
@@ -284,7 +279,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: Constant1
+        name: Constant11
         description: ''
     protocol: !<!Protocols> {}
   groups:
@@ -299,7 +294,7 @@ schemas: !<!Schemas>
           version: 2015-07-01-preview
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
             header: foo-request-id
         protocol: !<!Protocols> {}
@@ -350,7 +345,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_6
@@ -463,7 +458,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: 'This should appear as a method parameter, use value ''9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'''
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -511,7 +506,7 @@ operationGroups:
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: x-ms-client-request-id
+      name: XMSClientRequestId
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -561,7 +556,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postMethodGlobalValid
+        name: PostMethodGlobalValid
         description: POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -608,7 +603,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postMethodGlobalNull
+        name: PostMethodGlobalNull
         description: 'POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -656,7 +651,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postMethodGlobalNotProvidedValid
+        name: PostMethodGlobalNotProvidedValid
         description: POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -703,7 +698,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postPathGlobalValid
+        name: PostPathGlobalValid
         description: POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -750,12 +745,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postSwaggerGlobalValid
+        name: PostSwaggerGlobalValid
         description: POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: subscriptionInCredentials
+      name: SubscriptionInCredentials
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -817,7 +812,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postMethodLocalValid
+        name: PostMethodLocalValid
         description: POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -876,7 +871,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postMethodLocalNull
+        name: PostMethodLocalNull
         description: 'POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -935,7 +930,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postPathLocalValid
+        name: PostPathLocalValid
         description: POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -994,12 +989,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postSwaggerLocalValid
+        name: PostSwaggerLocalValid
         description: POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: subscriptionInMethod
+      name: SubscriptionInMethod
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1049,7 +1044,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMethodGlobalValid
+        name: GetMethodGlobalValid
         description: GET method with api-version modeled in global settings.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1096,7 +1091,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMethodGlobalNotProvidedValid
+        name: GetMethodGlobalNotProvidedValid
         description: GET method with api-version modeled in global settings.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1143,7 +1138,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getPathGlobalValid
+        name: GetPathGlobalValid
         description: GET method with api-version modeled in global settings.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1190,12 +1185,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSwaggerGlobalValid
+        name: GetSwaggerGlobalValid
         description: GET method with api-version modeled in global settings.
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: apiVersionDefault
+      name: ApiVersionDefault
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1245,7 +1240,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMethodLocalValid
+        name: GetMethodLocalValid
         description: Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1292,7 +1287,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMethodLocalNull
+        name: GetMethodLocalNull
         description: Get method with api-version modeled in the method.  pass in api-version = null to succeed
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1339,7 +1334,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getPathLocalValid
+        name: GetPathLocalValid
         description: Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1386,12 +1381,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSwaggerLocalValid
+        name: GetSwaggerLocalValid
         description: Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: apiVersionLocal
+      name: ApiVersionLocal
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1455,7 +1450,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMethodPathValid
+        name: GetMethodPathValid
         description: Get method with unencoded path parameter with value 'path1/path2/path3'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1516,7 +1511,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getPathPathValid
+        name: GetPathValid
         description: Get method with unencoded path parameter with value 'path1/path2/path3'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1576,7 +1571,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSwaggerPathValid
+        name: GetSwaggerPathValid
         description: Get method with unencoded path parameter with value 'path1/path2/path3'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1637,7 +1632,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMethodQueryValid
+        name: GetMethodQueryValid
         description: Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1697,7 +1692,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMethodQueryNull
+        name: GetMethodQueryNull
         description: Get method with unencoded query parameter with value null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1758,7 +1753,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getPathQueryValid
+        name: GetPathQueryValid
         description: Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1818,12 +1813,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSwaggerQueryValid
+        name: GetSwaggerQueryValid
         description: Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: skipUrlEncoding
+      name: SkipUrlEncoding
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1841,7 +1836,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: $filter
+            name: filter
             description: The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
             serializedName: $filter
         protocol: !<!Protocols> 
@@ -1852,7 +1847,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: $top
+            name: top
             description: The top parameter with value 10.
             serializedName: $top
         protocol: !<!Protocols> 
@@ -1863,7 +1858,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: $orderby
+            name: orderby
             description: The orderby parameter with value id.
             serializedName: $orderby
         protocol: !<!Protocols> 
@@ -1910,12 +1905,12 @@ operationGroups:
       x-ms-odata: '#/components/schemas/OdataFilter'
     language: !<!Languages> 
       default:
-        name: getWithFilter
+        name: GetWithFilter
         description: Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: odata
+      name: Odata
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1936,7 +1931,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: foo-client-request-id
+            name: fooClientRequestId
             description: The fooRequestId
             serializedName: foo-client-request-id
         protocol: !<!Protocols> 
@@ -1985,7 +1980,7 @@ operationGroups:
       x-ms-request-id: foo-request-id
     language: !<!Languages> 
       default:
-        name: customNamedRequestId
+        name: CustomNamedRequestId
         description: Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2040,7 +2035,7 @@ operationGroups:
       x-ms-request-id: foo-request-id
     language: !<!Languages> 
       default:
-        name: customNamedRequestIdParamGrouping
+        name: CustomNamedRequestIdParamGrouping
         description: 'Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2058,7 +2053,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: foo-client-request-id
+            name: fooClientRequestId
             description: The fooRequestId
             serializedName: foo-client-request-id
         protocol: !<!Protocols> 
@@ -2116,12 +2111,12 @@ operationGroups:
       x-ms-request-id: foo-request-id
     language: !<!Languages> 
       default:
-        name: customNamedRequestIdHead
+        name: CustomNamedRequestIdHead
         description: Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: header
+      name: Header
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -22,64 +22,60 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: Logging-Version
+                name: LoggingVersion
                 description: The version of Storage Analytics to configure.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Version
           language: !<!Languages> 
             default:
-              name: Version
+              name: version
               description: The version of Storage Analytics to configure.
-              originalName: Version
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_42
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForDelete
+                name: TypeForDelete
                 description: Indicates whether all delete requests should be logged.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Delete
           language: !<!Languages> 
             default:
-              name: Delete
+              name: delete
               description: Indicates whether all delete requests should be logged.
-              originalName: Delete
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_43
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForRead
+                name: TypeForRead
                 description: Indicates whether all read requests should be logged.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Read
           language: !<!Languages> 
             default:
-              name: Read
+              name: read
               description: Indicates whether all read requests should be logged.
-              originalName: Read
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_44
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForWrite
+                name: TypeForWrite
                 description: Indicates whether all write requests should be logged.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Write
           language: !<!Languages> 
             default:
-              name: Write
+              name: write
               description: Indicates whether all write requests should be logged.
-              originalName: Write
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ObjectSchema> &ref_0
@@ -93,16 +89,15 @@ schemas: !<!Schemas>
                 type: boolean
                 language: !<!Languages> 
                   default:
-                    name: typeForEnabled
+                    name: TypeForEnabled
                     description: Indicates whether a retention policy is enabled for the storage service
                 protocol: !<!Protocols> {}
               required: true
               serializedName: Enabled
               language: !<!Languages> 
                 default:
-                  name: Enabled
+                  name: enabled
                   description: Indicates whether a retention policy is enabled for the storage service
-                  originalName: Enabled
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!NumberSchema> &ref_181
@@ -111,16 +106,15 @@ schemas: !<!Schemas>
                 precision: 32
                 language: !<!Languages> 
                   default:
-                    name: typeForDays
+                    name: TypeForDays
                     description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
                 protocol: !<!Protocols> {}
               required: false
               serializedName: Days
               language: !<!Languages> 
                 default:
-                  name: Days
+                  name: days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
-                  originalName: Days
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -132,9 +126,8 @@ schemas: !<!Schemas>
           serializedName: RetentionPolicy
           language: !<!Languages> 
             default:
-              name: RetentionPolicy
+              name: retentionPolicy
               description: the retention policy which determines how long the associated data should persist
-              originalName: RetentionPolicy
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -145,9 +138,8 @@ schemas: !<!Schemas>
       serializedName: Logging
       language: !<!Languages> 
         default:
-          name: Logging
+          name: logging
           description: Azure Analytics Logging settings.
-          originalName: Logging
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_1
@@ -164,48 +156,45 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: Metrics-Version
+                name: MetricsVersion
                 description: The version of Storage Analytics to configure.
             protocol: !<!Protocols> {}
           required: false
           serializedName: Version
           language: !<!Languages> 
             default:
-              name: Version
+              name: version
               description: The version of Storage Analytics to configure.
-              originalName: Version
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_46
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForEnabled
+                name: TypeForEnabled
                 description: Indicates whether metrics are enabled for the Blob service.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Enabled
           language: !<!Languages> 
             default:
-              name: Enabled
+              name: enabled
               description: Indicates whether metrics are enabled for the Blob service.
-              originalName: Enabled
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_47
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForIncludeAPIs
+                name: TypeForIncludeApIs
                 description: Indicates whether metrics should generate summary statistics for called API operations.
             protocol: !<!Protocols> {}
           required: false
           serializedName: IncludeAPIs
           language: !<!Languages> 
             default:
-              name: IncludeAPIs
+              name: includeApIs
               description: Indicates whether metrics should generate summary statistics for called API operations.
-              originalName: IncludeAPIs
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_0
@@ -213,9 +202,8 @@ schemas: !<!Schemas>
           serializedName: RetentionPolicy
           language: !<!Languages> 
             default:
-              name: RetentionPolicy
+              name: retentionPolicy
               description: the retention policy which determines how long the associated data should persist
-              originalName: RetentionPolicy
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -226,18 +214,16 @@ schemas: !<!Schemas>
       serializedName: HourMetrics
       language: !<!Languages> 
         default:
-          name: HourMetrics
+          name: hourMetrics
           description: a summary of request statistics grouped by API in hour or minute aggregates for blobs
-          originalName: HourMetrics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_1
       serializedName: MinuteMetrics
       language: !<!Languages> 
         default:
-          name: MinuteMetrics
+          name: minuteMetrics
           description: a summary of request statistics grouped by API in hour or minute aggregates for blobs
-          originalName: MinuteMetrics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_29
@@ -259,7 +245,7 @@ schemas: !<!Schemas>
                 version: '2019-02-02'
               language: !<!Languages> 
                 default:
-                  name: CorsRule-AllowedOrigins
+                  name: CorsRuleAllowedOrigins
                   description: >-
                     The origin domains that are permitted to make a request against the storage service via CORS. The origin domain is the domain from which the request originates. Note that the origin must be an exact case-sensitive match
                     with the origin that the user age sends to the service. You can also use the wildcard character '*' to allow all origin domains to make requests via CORS.
@@ -268,11 +254,10 @@ schemas: !<!Schemas>
             serializedName: AllowedOrigins
             language: !<!Languages> 
               default:
-                name: AllowedOrigins
+                name: allowedOrigins
                 description: >-
                   The origin domains that are permitted to make a request against the storage service via CORS. The origin domain is the domain from which the request originates. Note that the origin must be an exact case-sensitive match
                   with the origin that the user age sends to the service. You can also use the wildcard character '*' to allow all origin domains to make requests via CORS.
-                originalName: AllowedOrigins
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_200
@@ -282,16 +267,15 @@ schemas: !<!Schemas>
                 version: '2019-02-02'
               language: !<!Languages> 
                 default:
-                  name: CorsRule-AllowedMethods
+                  name: CorsRuleAllowedMethods
                   description: The methods (HTTP request verbs) that the origin domain may use for a CORS request. (comma separated)
               protocol: !<!Protocols> {}
             required: true
             serializedName: AllowedMethods
             language: !<!Languages> 
               default:
-                name: AllowedMethods
+                name: allowedMethods
                 description: The methods (HTTP request verbs) that the origin domain may use for a CORS request. (comma separated)
-                originalName: AllowedMethods
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_201
@@ -301,16 +285,15 @@ schemas: !<!Schemas>
                 version: '2019-02-02'
               language: !<!Languages> 
                 default:
-                  name: CorsRule-AllowedHeaders
+                  name: CorsRuleAllowedHeaders
                   description: the request headers that the origin domain may specify on the CORS request.
               protocol: !<!Protocols> {}
             required: true
             serializedName: AllowedHeaders
             language: !<!Languages> 
               default:
-                name: AllowedHeaders
+                name: allowedHeaders
                 description: the request headers that the origin domain may specify on the CORS request.
-                originalName: AllowedHeaders
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_202
@@ -320,16 +303,15 @@ schemas: !<!Schemas>
                 version: '2019-02-02'
               language: !<!Languages> 
                 default:
-                  name: CorsRule-ExposedHeaders
+                  name: CorsRuleExposedHeaders
                   description: The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer
               protocol: !<!Protocols> {}
             required: true
             serializedName: ExposedHeaders
             language: !<!Languages> 
               default:
-                name: ExposedHeaders
+                name: exposedHeaders
                 description: The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer
-                originalName: ExposedHeaders
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!NumberSchema> &ref_182
@@ -338,16 +320,15 @@ schemas: !<!Schemas>
               precision: 32
               language: !<!Languages> 
                 default:
-                  name: typeForMaxAgeInSeconds
+                  name: TypeForMaxAgeInSeconds
                   description: The maximum amount time that a browser should cache the preflight OPTIONS request.
               protocol: !<!Protocols> {}
             required: true
             serializedName: MaxAgeInSeconds
             language: !<!Languages> 
               default:
-                name: MaxAgeInSeconds
+                name: maxAgeInSeconds
                 description: The maximum amount time that a browser should cache the preflight OPTIONS request.
-                originalName: MaxAgeInSeconds
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -363,15 +344,14 @@ schemas: !<!Schemas>
             wrapped: true
         language: !<!Languages> 
           default:
-            name: StorageServiceProperties-Cors
+            name: StorageServicePropertiesCors
             description: The set of CORS rules.
         protocol: !<!Protocols> {}
       serializedName: Cors
       language: !<!Languages> 
         default:
-          name: Cors
+          name: cors
           description: The set of CORS rules.
-          originalName: Cors
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_203
@@ -381,24 +361,22 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: StorageServiceProperties-DefaultServiceVersion
+            name: StorageServicePropertiesDefaultServiceVersion
             description: The default version to use for requests to the Blob service if an incoming request's version is not specified. Possible values include version 2008-10-27 and all more recent versions
         protocol: !<!Protocols> {}
       serializedName: DefaultServiceVersion
       language: !<!Languages> 
         default:
-          name: DefaultServiceVersion
+          name: defaultServiceVersion
           description: The default version to use for requests to the Blob service if an incoming request's version is not specified. Possible values include version 2008-10-27 and all more recent versions
-          originalName: DefaultServiceVersion
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_0
       serializedName: DeleteRetentionPolicy
       language: !<!Languages> 
         default:
-          name: DeleteRetentionPolicy
+          name: deleteRetentionPolicy
           description: the retention policy which determines how long the associated data should persist
-          originalName: DeleteRetentionPolicy
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_4
@@ -412,16 +390,15 @@ schemas: !<!Schemas>
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForEnabled
+                name: TypeForEnabled
                 description: Indicates whether this account is hosting a static website
             protocol: !<!Protocols> {}
           required: true
           serializedName: Enabled
           language: !<!Languages> 
             default:
-              name: Enabled
+              name: enabled
               description: Indicates whether this account is hosting a static website
-              originalName: Enabled
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_204
@@ -431,16 +408,15 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: StaticWebsite-IndexDocument
+                name: StaticWebsiteIndexDocument
                 description: The default name of the index page under each directory
             protocol: !<!Protocols> {}
           required: false
           serializedName: IndexDocument
           language: !<!Languages> 
             default:
-              name: IndexDocument
+              name: indexDocument
               description: The default name of the index page under each directory
-              originalName: IndexDocument
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_205
@@ -450,16 +426,15 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: StaticWebsite-ErrorDocument404Path
+                name: StaticWebsiteErrorDocument404Path
                 description: The absolute path of the custom 404 page
             protocol: !<!Protocols> {}
           required: false
           serializedName: ErrorDocument404Path
           language: !<!Languages> 
             default:
-              name: ErrorDocument404Path
+              name: errorDocument404Path
               description: The absolute path of the custom 404 page
-              originalName: ErrorDocument404Path
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -470,9 +445,8 @@ schemas: !<!Schemas>
       serializedName: StaticWebsite
       language: !<!Languages> 
         default:
-          name: StaticWebsite
+          name: staticWebsite
           description: The properties that enable an account to host a static website
-          originalName: StaticWebsite
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -499,15 +473,14 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: StorageError-Message
+            name: StorageErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: Message
       language: !<!Languages> 
         default:
-          name: Message
+          name: message
           description: ''
-          originalName: Message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -535,19 +508,19 @@ schemas: !<!Schemas>
               value: live
               language:
                 default:
-                  name: live
+                  name: Live
                   description: ''
             - !<!ChoiceValue> 
               value: bootstrap
               language:
                 default:
-                  name: bootstrap
+                  name: Bootstrap
                   description: ''
             - !<!ChoiceValue> 
               value: unavailable
               language:
                 default:
-                  name: unavailable
+                  name: Unavailable
                   description: ''
             type: choice
             apiVersions:
@@ -557,7 +530,7 @@ schemas: !<!Schemas>
               type: string
               language: !<!Languages> 
                 default:
-                  name: string
+                  name: String
                   description: simple string
               protocol: !<!Protocols> {}
             language: !<!Languages> 
@@ -569,9 +542,8 @@ schemas: !<!Schemas>
           serializedName: Status
           language: !<!Languages> 
             default:
-              name: Status
+              name: status
               description: The status of the secondary location
-              originalName: Status
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!DateTimeSchema> &ref_56
@@ -582,7 +554,7 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: GeoReplication-LastSyncTime
+                name: GeoReplicationLastSyncTime
                 description: >-
                   A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for
                   reads.
@@ -591,11 +563,10 @@ schemas: !<!Schemas>
           serializedName: LastSyncTime
           language: !<!Languages> 
             default:
-              name: LastSyncTime
+              name: lastSyncTime
               description: >-
                 A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for
                 reads.
-              originalName: LastSyncTime
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -606,9 +577,8 @@ schemas: !<!Schemas>
       serializedName: GeoReplication
       language: !<!Languages> 
         default:
-          name: GeoReplication
+          name: geoReplication
           description: Geo-Replication information for the Secondary Storage Service
-          originalName: GeoReplication
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -635,16 +605,15 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: ListContainersSegmentResponse-ServiceEndpoint
+            name: ListContainersSegmentResponseServiceEndpoint
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: ServiceEndpoint
       language: !<!Languages> 
         default:
-          name: ServiceEndpoint
+          name: serviceEndpoint
           description: ''
-          originalName: ServiceEndpoint
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_208
@@ -654,16 +623,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListContainersSegmentResponse-Prefix
+            name: ListContainersSegmentResponsePrefix
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: Prefix
       language: !<!Languages> 
         default:
-          name: Prefix
+          name: prefix
           description: ''
-          originalName: Prefix
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_209
@@ -673,16 +641,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListContainersSegmentResponse-Marker
+            name: ListContainersSegmentResponseMarker
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: Marker
       language: !<!Languages> 
         default:
-          name: Marker
+          name: marker
           description: ''
-          originalName: Marker
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!NumberSchema> &ref_183
@@ -690,16 +657,15 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForMaxResults
+            name: TypeForMaxResults
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: MaxResults
       language: !<!Languages> 
         default:
-          name: MaxResults
+          name: maxResults
           description: ''
-          originalName: MaxResults
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_30
@@ -721,16 +687,15 @@ schemas: !<!Schemas>
                 version: '2019-02-02'
               language: !<!Languages> 
                 default:
-                  name: ContainerItem-Name
+                  name: ContainerItemName
                   description: ''
               protocol: !<!Protocols> {}
             required: true
             serializedName: Name
             language: !<!Languages> 
               default:
-                name: Name
+                name: name
                 description: ''
-                originalName: Name
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_8
@@ -748,7 +713,7 @@ schemas: !<!Schemas>
                     version: '2019-02-02'
                   language: !<!Languages> 
                     default:
-                      name: ContainerProperties-Last-Modified
+                      name: ContainerPropertiesLastModified
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
@@ -757,7 +722,6 @@ schemas: !<!Schemas>
                   default:
                     name: lastModified
                     description: ''
-                    originalName: Last-Modified
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_211
@@ -767,16 +731,15 @@ schemas: !<!Schemas>
                     version: '2019-02-02'
                   language: !<!Languages> 
                     default:
-                      name: ContainerProperties-Etag
+                      name: ContainerPropertiesEtag
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Etag
                 language: !<!Languages> 
                   default:
-                    name: Etag
+                    name: etag
                     description: ''
-                    originalName: Etag
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!SealedChoiceSchema> &ref_10
@@ -785,13 +748,13 @@ schemas: !<!Schemas>
                     value: locked
                     language:
                       default:
-                        name: locked
+                        name: Locked
                         description: ''
                   - !<!ChoiceValue> 
                     value: unlocked
                     language:
                       default:
-                        name: unlocked
+                        name: Unlocked
                         description: ''
                   type: sealed-choice
                   apiVersions:
@@ -808,9 +771,8 @@ schemas: !<!Schemas>
                 serializedName: LeaseStatus
                 language: !<!Languages> 
                   default:
-                    name: LeaseStatus
+                    name: leaseStatus
                     description: ''
-                    originalName: LeaseStatus
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!SealedChoiceSchema> &ref_11
@@ -819,31 +781,31 @@ schemas: !<!Schemas>
                     value: available
                     language:
                       default:
-                        name: available
+                        name: Available
                         description: ''
                   - !<!ChoiceValue> 
                     value: leased
                     language:
                       default:
-                        name: leased
+                        name: Leased
                         description: ''
                   - !<!ChoiceValue> 
                     value: expired
                     language:
                       default:
-                        name: expired
+                        name: Expired
                         description: ''
                   - !<!ChoiceValue> 
                     value: breaking
                     language:
                       default:
-                        name: breaking
+                        name: Breaking
                         description: ''
                   - !<!ChoiceValue> 
                     value: broken
                     language:
                       default:
-                        name: broken
+                        name: Broken
                         description: ''
                   type: sealed-choice
                   apiVersions:
@@ -860,9 +822,8 @@ schemas: !<!Schemas>
                 serializedName: LeaseState
                 language: !<!Languages> 
                   default:
-                    name: LeaseState
+                    name: leaseState
                     description: ''
-                    originalName: LeaseState
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!SealedChoiceSchema> &ref_12
@@ -871,13 +832,13 @@ schemas: !<!Schemas>
                     value: infinite
                     language:
                       default:
-                        name: infinite
+                        name: Infinite
                         description: ''
                   - !<!ChoiceValue> 
                     value: fixed
                     language:
                       default:
-                        name: fixed
+                        name: Fixed
                         description: ''
                   type: sealed-choice
                   apiVersions:
@@ -894,9 +855,8 @@ schemas: !<!Schemas>
                 serializedName: LeaseDuration
                 language: !<!Languages> 
                   default:
-                    name: LeaseDuration
+                    name: leaseDuration
                     description: ''
-                    originalName: LeaseDuration
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!ChoiceSchema> &ref_26
@@ -905,13 +865,13 @@ schemas: !<!Schemas>
                     value: container
                     language:
                       default:
-                        name: container
+                        name: Container
                         description: ''
                   - !<!ChoiceValue> 
                     value: blob
                     language:
                       default:
-                        name: blob
+                        name: Blob
                         description: ''
                   type: choice
                   apiVersions:
@@ -928,41 +888,38 @@ schemas: !<!Schemas>
                 serializedName: PublicAccess
                 language: !<!Languages> 
                   default:
-                    name: PublicAccess
+                    name: publicAccess
                     description: ''
-                    originalName: PublicAccess
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!BooleanSchema> &ref_49
                   type: boolean
                   language: !<!Languages> 
                     default:
-                      name: typeForHasImmutabilityPolicy
+                      name: TypeForHasImmutabilityPolicy
                       description: ''
                   protocol: !<!Protocols> {}
                 required: false
                 serializedName: HasImmutabilityPolicy
                 language: !<!Languages> 
                   default:
-                    name: HasImmutabilityPolicy
+                    name: hasImmutabilityPolicy
                     description: ''
-                    originalName: HasImmutabilityPolicy
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!BooleanSchema> &ref_50
                   type: boolean
                   language: !<!Languages> 
                     default:
-                      name: typeForHasLegalHold
+                      name: TypeForHasLegalHold
                       description: ''
                   protocol: !<!Protocols> {}
                 required: false
                 serializedName: HasLegalHold
                 language: !<!Languages> 
                   default:
-                    name: HasLegalHold
+                    name: hasLegalHold
                     description: ''
-                    originalName: HasLegalHold
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -974,9 +931,8 @@ schemas: !<!Schemas>
             serializedName: Properties
             language: !<!Languages> 
               default:
-                name: Properties
+                name: properties
                 description: Properties of a container
-                originalName: Properties
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_24
@@ -988,21 +944,20 @@ schemas: !<!Schemas>
                   version: '2019-02-02'
                 language: !<!Languages> 
                   default:
-                    name: string
+                    name: String
                     description: ''
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: Dictionary of string
-                  description: Dictionary of <components·schemas·containermetadata·additionalproperties>
+                  name: ContainerMetadata
+                  description: Dictionary of String
               protocol: !<!Protocols> {}
             required: false
             serializedName: Metadata
             language: !<!Languages> 
               default:
-                name: Metadata
+                name: metadata
                 description: Dictionary of <components·schemas·containermetadata·additionalproperties>
-                originalName: Metadata
             protocol: !<!Protocols> {}
           serialization:
             xml:
@@ -1022,16 +977,15 @@ schemas: !<!Schemas>
             wrapped: true
         language: !<!Languages> 
           default:
-            name: ListContainersSegmentResponse-ContainerItems
-            description: ''
+            name: ListContainersSegmentResponseContainerItems
+            description: Array of ContainerItem
         protocol: !<!Protocols> {}
       required: true
       serializedName: ContainerItems
       language: !<!Languages> 
         default:
-          name: ContainerItems
+          name: containerItems
           description: ''
-          originalName: ContainerItems
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_213
@@ -1041,16 +995,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListContainersSegmentResponse-NextMarker
+            name: ListContainersSegmentResponseNextMarker
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: NextMarker
       language: !<!Languages> 
         default:
-          name: NextMarker
+          name: nextMarker
           description: ''
-          originalName: NextMarker
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -1079,16 +1032,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: KeyInfo-Start
+            name: KeyInfoStart
             description: The date-time the key is active in ISO 8601 UTC time
         protocol: !<!Protocols> {}
       required: true
       serializedName: Start
       language: !<!Languages> 
         default:
-          name: Start
+          name: start
           description: The date-time the key is active in ISO 8601 UTC time
-          originalName: Start
       protocol: !<!Protocols> {}
     - !<!Property> &ref_314
       schema: !<!StringSchema> &ref_215
@@ -1098,16 +1050,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: KeyInfo-Expiry
+            name: KeyInfoExpiry
             description: The date-time the key expires in ISO 8601 UTC time
         protocol: !<!Protocols> {}
       required: true
       serializedName: Expiry
       language: !<!Languages> 
         default:
-          name: Expiry
+          name: expiry
           description: The date-time the key expires in ISO 8601 UTC time
-          originalName: Expiry
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1129,16 +1080,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: UserDelegationKey-SignedOid
+            name: UserDelegationKeySignedOid
             description: The Azure Active Directory object ID in GUID format.
         protocol: !<!Protocols> {}
       required: true
       serializedName: SignedOid
       language: !<!Languages> 
         default:
-          name: SignedOid
+          name: signedOid
           description: The Azure Active Directory object ID in GUID format.
-          originalName: SignedOid
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_217
@@ -1148,16 +1098,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: UserDelegationKey-SignedTid
+            name: UserDelegationKeySignedTid
             description: The Azure Active Directory tenant ID in GUID format
         protocol: !<!Protocols> {}
       required: true
       serializedName: SignedTid
       language: !<!Languages> 
         default:
-          name: SignedTid
+          name: signedTid
           description: The Azure Active Directory tenant ID in GUID format
-          originalName: SignedTid
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DateTimeSchema> &ref_58
@@ -1168,16 +1117,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: UserDelegationKey-SignedStart
+            name: UserDelegationKeySignedStart
             description: The date-time the key is active
         protocol: !<!Protocols> {}
       required: true
       serializedName: SignedStart
       language: !<!Languages> 
         default:
-          name: SignedStart
+          name: signedStart
           description: The date-time the key is active
-          originalName: SignedStart
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DateTimeSchema> &ref_59
@@ -1188,16 +1136,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: UserDelegationKey-SignedExpiry
+            name: UserDelegationKeySignedExpiry
             description: The date-time the key expires
         protocol: !<!Protocols> {}
       required: true
       serializedName: SignedExpiry
       language: !<!Languages> 
         default:
-          name: SignedExpiry
+          name: signedExpiry
           description: The date-time the key expires
-          originalName: SignedExpiry
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_218
@@ -1207,16 +1154,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: UserDelegationKey-SignedService
+            name: UserDelegationKeySignedService
             description: Abbreviation of the Azure Storage service that accepts the key
         protocol: !<!Protocols> {}
       required: true
       serializedName: SignedService
       language: !<!Languages> 
         default:
-          name: SignedService
+          name: signedService
           description: Abbreviation of the Azure Storage service that accepts the key
-          originalName: SignedService
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_219
@@ -1226,16 +1172,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: UserDelegationKey-SignedVersion
+            name: UserDelegationKeySignedVersion
             description: The service version that created the key
         protocol: !<!Protocols> {}
       required: true
       serializedName: SignedVersion
       language: !<!Languages> 
         default:
-          name: SignedVersion
+          name: signedVersion
           description: The service version that created the key
-          originalName: SignedVersion
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_220
@@ -1245,16 +1190,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: UserDelegationKey-Value
+            name: UserDelegationKeyValue
             description: The key as a base64 string
         protocol: !<!Protocols> {}
       required: true
       serializedName: Value
       language: !<!Languages> 
         default:
-          name: Value
+          name: value
           description: The key as a base64 string
-          originalName: Value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1276,16 +1220,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: SignedIdentifier-Id
+            name: SignedIdentifierId
             description: a unique id
         protocol: !<!Protocols> {}
       required: true
       serializedName: Id
       language: !<!Languages> 
         default:
-          name: Id
+          name: id
           description: a unique id
-          originalName: Id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_9
@@ -1303,16 +1246,15 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: AccessPolicy-Start
+                name: AccessPolicyStart
                 description: the date-time the policy is active
             protocol: !<!Protocols> {}
           required: true
           serializedName: Start
           language: !<!Languages> 
             default:
-              name: Start
+              name: start
               description: the date-time the policy is active
-              originalName: Start
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!DateTimeSchema> &ref_61
@@ -1323,16 +1265,15 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: AccessPolicy-Expiry
+                name: AccessPolicyExpiry
                 description: the date-time the policy expires
             protocol: !<!Protocols> {}
           required: true
           serializedName: Expiry
           language: !<!Languages> 
             default:
-              name: Expiry
+              name: expiry
               description: the date-time the policy expires
-              originalName: Expiry
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_222
@@ -1342,16 +1283,15 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: AccessPolicy-Permission
+                name: AccessPolicyPermission
                 description: the permissions for the acl policy
             protocol: !<!Protocols> {}
           required: true
           serializedName: Permission
           language: !<!Languages> 
             default:
-              name: Permission
+              name: permission
               description: the permissions for the acl policy
-              originalName: Permission
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -1363,9 +1303,8 @@ schemas: !<!Schemas>
       serializedName: AccessPolicy
       language: !<!Languages> 
         default:
-          name: AccessPolicy
+          name: accessPolicy
           description: An Access policy
-          originalName: AccessPolicy
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -1397,16 +1336,15 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: ListBlobsFlatSegmentResponse-ServiceEndpoint
+            name: ListBlobsFlatSegmentResponseServiceEndpoint
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: ServiceEndpoint
       language: !<!Languages> 
         default:
-          name: ServiceEndpoint
+          name: serviceEndpoint
           description: ''
-          originalName: ServiceEndpoint
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_224
@@ -1420,16 +1358,15 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: ListBlobsFlatSegmentResponse-ContainerName
+            name: ListBlobsFlatSegmentResponseContainerName
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: ContainerName
       language: !<!Languages> 
         default:
-          name: ContainerName
+          name: containerName
           description: ''
-          originalName: ContainerName
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_225
@@ -1439,16 +1376,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListBlobsFlatSegmentResponse-Prefix
+            name: ListBlobsFlatSegmentResponsePrefix
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: Prefix
       language: !<!Languages> 
         default:
-          name: Prefix
+          name: prefix
           description: ''
-          originalName: Prefix
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_226
@@ -1458,16 +1394,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListBlobsFlatSegmentResponse-Marker
+            name: ListBlobsFlatSegmentResponseMarker
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: Marker
       language: !<!Languages> 
         default:
-          name: Marker
+          name: marker
           description: ''
-          originalName: Marker
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!NumberSchema> &ref_184
@@ -1475,16 +1410,15 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForMaxResults
+            name: TypeForMaxResults
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: MaxResults
       language: !<!Languages> 
         default:
-          name: MaxResults
+          name: maxResults
           description: ''
-          originalName: MaxResults
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_14
@@ -1513,32 +1447,30 @@ schemas: !<!Schemas>
                     version: '2019-02-02'
                   language: !<!Languages> 
                     default:
-                      name: BlobItem-Name
+                      name: BlobItemName
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Name
                 language: !<!Languages> 
                   default:
-                    name: Name
+                    name: name
                     description: ''
-                    originalName: Name
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!BooleanSchema> &ref_51
                   type: boolean
                   language: !<!Languages> 
                     default:
-                      name: typeForDeleted
+                      name: TypeForDeleted
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Deleted
                 language: !<!Languages> 
                   default:
-                    name: Deleted
+                    name: deleted
                     description: ''
-                    originalName: Deleted
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_228
@@ -1548,16 +1480,15 @@ schemas: !<!Schemas>
                     version: '2019-02-02'
                   language: !<!Languages> 
                     default:
-                      name: BlobItem-Snapshot
+                      name: BlobItemSnapshot
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Snapshot
                 language: !<!Languages> 
                   default:
-                    name: Snapshot
+                    name: snapshot
                     description: ''
-                    originalName: Snapshot
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_16
@@ -1575,7 +1506,7 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Creation-Time
+                          name: BlobPropertiesCreationTime
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1584,7 +1515,6 @@ schemas: !<!Schemas>
                       default:
                         name: creationTime
                         description: ''
-                        originalName: Creation-Time
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!DateTimeSchema> &ref_63
@@ -1595,7 +1525,7 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Last-Modified
+                          name: BlobPropertiesLastModified
                           description: ''
                       protocol: !<!Protocols> {}
                     required: true
@@ -1604,7 +1534,6 @@ schemas: !<!Schemas>
                       default:
                         name: lastModified
                         description: ''
-                        originalName: Last-Modified
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_229
@@ -1614,16 +1543,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Etag
+                          name: BlobPropertiesEtag
                           description: ''
                       protocol: !<!Protocols> {}
                     required: true
                     serializedName: Etag
                     language: !<!Languages> 
                       default:
-                        name: Etag
+                        name: etag
                         description: ''
-                        originalName: Etag
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!NumberSchema> &ref_185
@@ -1631,7 +1559,7 @@ schemas: !<!Schemas>
                       precision: 64
                       language: !<!Languages> 
                         default:
-                          name: typeForContent-Length
+                          name: TypeForContentLength
                           description: Size in bytes
                       protocol: !<!Protocols> {}
                     required: false
@@ -1640,7 +1568,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentLength
                         description: Size in bytes
-                        originalName: Content-Length
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_230
@@ -1650,7 +1577,7 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-Type
+                          name: BlobPropertiesContentType
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1659,7 +1586,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentType
                         description: ''
-                        originalName: Content-Type
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_231
@@ -1669,7 +1595,7 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-Encoding
+                          name: BlobPropertiesContentEncoding
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1678,7 +1604,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentEncoding
                         description: ''
-                        originalName: Content-Encoding
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_232
@@ -1688,7 +1613,7 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-Language
+                          name: BlobPropertiesContentLanguage
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1697,7 +1622,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentLanguage
                         description: ''
-                        originalName: Content-Language
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!ByteArraySchema> &ref_55
@@ -1708,7 +1632,7 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-MD5
+                          name: BlobPropertiesContentMd5
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1717,7 +1641,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentMd5
                         description: ''
-                        originalName: Content-MD5
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_233
@@ -1727,7 +1650,7 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-Disposition
+                          name: BlobPropertiesContentDisposition
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1736,7 +1659,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentDisposition
                         description: ''
-                        originalName: Content-Disposition
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_234
@@ -1746,7 +1668,7 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Cache-Control
+                          name: BlobPropertiesCacheControl
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1755,7 +1677,6 @@ schemas: !<!Schemas>
                       default:
                         name: cacheControl
                         description: ''
-                        originalName: Cache-Control
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!NumberSchema> &ref_186
@@ -1763,7 +1684,7 @@ schemas: !<!Schemas>
                       precision: 64
                       language: !<!Languages> 
                         default:
-                          name: blobSequenceNumber
+                          name: BlobSequenceNumber
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1772,7 +1693,6 @@ schemas: !<!Schemas>
                       default:
                         name: blobSequenceNumber
                         description: ''
-                        originalName: blobSequenceNumber
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!SealedChoiceSchema> &ref_195
@@ -1810,9 +1730,8 @@ schemas: !<!Schemas>
                     serializedName: BlobType
                     language: !<!Languages> 
                       default:
-                        name: BlobType
+                        name: blobType
                         description: ''
-                        originalName: BlobType
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: *ref_10
@@ -1820,9 +1739,8 @@ schemas: !<!Schemas>
                     serializedName: LeaseStatus
                     language: !<!Languages> 
                       default:
-                        name: LeaseStatus
+                        name: leaseStatus
                         description: ''
-                        originalName: LeaseStatus
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: *ref_11
@@ -1830,9 +1748,8 @@ schemas: !<!Schemas>
                     serializedName: LeaseState
                     language: !<!Languages> 
                       default:
-                        name: LeaseState
+                        name: leaseState
                         description: ''
-                        originalName: LeaseState
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: *ref_12
@@ -1840,9 +1757,8 @@ schemas: !<!Schemas>
                     serializedName: LeaseDuration
                     language: !<!Languages> 
                       default:
-                        name: LeaseDuration
+                        name: leaseDuration
                         description: ''
-                        originalName: LeaseDuration
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_235
@@ -1852,16 +1768,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopyId
+                          name: BlobPropertiesCopyId
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopyId
                     language: !<!Languages> 
                       default:
-                        name: CopyId
+                        name: copyId
                         description: ''
-                        originalName: CopyId
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!SealedChoiceSchema> &ref_196
@@ -1870,25 +1785,25 @@ schemas: !<!Schemas>
                         value: pending
                         language:
                           default:
-                            name: pending
+                            name: Pending
                             description: ''
                       - !<!ChoiceValue> 
                         value: success
                         language:
                           default:
-                            name: success
+                            name: Success
                             description: ''
                       - !<!ChoiceValue> 
                         value: aborted
                         language:
                           default:
-                            name: aborted
+                            name: Aborted
                             description: ''
                       - !<!ChoiceValue> 
                         value: failed
                         language:
                           default:
-                            name: failed
+                            name: Failed
                             description: ''
                       type: sealed-choice
                       apiVersions:
@@ -1905,9 +1820,8 @@ schemas: !<!Schemas>
                     serializedName: CopyStatus
                     language: !<!Languages> 
                       default:
-                        name: CopyStatus
+                        name: copyStatus
                         description: ''
-                        originalName: CopyStatus
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_236
@@ -1917,16 +1831,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopySource
+                          name: BlobPropertiesCopySource
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopySource
                     language: !<!Languages> 
                       default:
-                        name: CopySource
+                        name: copySource
                         description: ''
-                        originalName: CopySource
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_237
@@ -1936,16 +1849,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopyProgress
+                          name: BlobPropertiesCopyProgress
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopyProgress
                     language: !<!Languages> 
                       default:
-                        name: CopyProgress
+                        name: copyProgress
                         description: ''
-                        originalName: CopyProgress
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!DateTimeSchema> &ref_64
@@ -1956,16 +1868,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopyCompletionTime
+                          name: BlobPropertiesCopyCompletionTime
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopyCompletionTime
                     language: !<!Languages> 
                       default:
-                        name: CopyCompletionTime
+                        name: copyCompletionTime
                         description: ''
-                        originalName: CopyCompletionTime
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_238
@@ -1975,48 +1886,45 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopyStatusDescription
+                          name: BlobPropertiesCopyStatusDescription
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopyStatusDescription
                     language: !<!Languages> 
                       default:
-                        name: CopyStatusDescription
+                        name: copyStatusDescription
                         description: ''
-                        originalName: CopyStatusDescription
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!BooleanSchema> &ref_52
                       type: boolean
                       language: !<!Languages> 
                         default:
-                          name: typeForServerEncrypted
+                          name: TypeForServerEncrypted
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: ServerEncrypted
                     language: !<!Languages> 
                       default:
-                        name: ServerEncrypted
+                        name: serverEncrypted
                         description: ''
-                        originalName: ServerEncrypted
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!BooleanSchema> &ref_53
                       type: boolean
                       language: !<!Languages> 
                         default:
-                          name: typeForIncrementalCopy
+                          name: TypeForIncrementalCopy
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: IncrementalCopy
                     language: !<!Languages> 
                       default:
-                        name: IncrementalCopy
+                        name: incrementalCopy
                         description: ''
-                        originalName: IncrementalCopy
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_239
@@ -2026,16 +1934,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-DestinationSnapshot
+                          name: BlobPropertiesDestinationSnapshot
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: DestinationSnapshot
                     language: !<!Languages> 
                       default:
-                        name: DestinationSnapshot
+                        name: destinationSnapshot
                         description: ''
-                        originalName: DestinationSnapshot
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!DateTimeSchema> &ref_65
@@ -2046,16 +1953,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-DeletedTime
+                          name: BlobPropertiesDeletedTime
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: DeletedTime
                     language: !<!Languages> 
                       default:
-                        name: DeletedTime
+                        name: deletedTime
                         description: ''
-                        originalName: DeletedTime
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!NumberSchema> &ref_187
@@ -2063,16 +1969,15 @@ schemas: !<!Schemas>
                       precision: 32
                       language: !<!Languages> 
                         default:
-                          name: typeForRemainingRetentionDays
+                          name: TypeForRemainingRetentionDays
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: RemainingRetentionDays
                     language: !<!Languages> 
                       default:
-                        name: RemainingRetentionDays
+                        name: remainingRetentionDays
                         description: ''
-                        originalName: RemainingRetentionDays
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!ChoiceSchema> &ref_27
@@ -2175,25 +2080,23 @@ schemas: !<!Schemas>
                     serializedName: AccessTier
                     language: !<!Languages> 
                       default:
-                        name: AccessTier
+                        name: accessTier
                         description: ''
-                        originalName: AccessTier
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!BooleanSchema> &ref_54
                       type: boolean
                       language: !<!Languages> 
                         default:
-                          name: typeForAccessTierInferred
+                          name: TypeForAccessTierInferred
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: AccessTierInferred
                     language: !<!Languages> 
                       default:
-                        name: AccessTierInferred
+                        name: accessTierInferred
                         description: ''
-                        originalName: AccessTierInferred
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!ChoiceSchema> &ref_28
@@ -2202,13 +2105,13 @@ schemas: !<!Schemas>
                         value: rehydrate-pending-to-hot
                         language:
                           default:
-                            name: rehydrate-pending-to-hot
+                            name: RehydratePendingToHot
                             description: ''
                       - !<!ChoiceValue> 
                         value: rehydrate-pending-to-cool
                         language:
                           default:
-                            name: rehydrate-pending-to-cool
+                            name: RehydratePendingToCool
                             description: ''
                       type: choice
                       apiVersions:
@@ -2224,9 +2127,8 @@ schemas: !<!Schemas>
                     serializedName: ArchiveStatus
                     language: !<!Languages> 
                       default:
-                        name: ArchiveStatus
+                        name: archiveStatus
                         description: ''
-                        originalName: ArchiveStatus
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_240
@@ -2236,16 +2138,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CustomerProvidedKeySha256
+                          name: BlobPropertiesCustomerProvidedKeySha256
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CustomerProvidedKeySha256
                     language: !<!Languages> 
                       default:
-                        name: CustomerProvidedKeySha256
+                        name: customerProvidedKeySha256
                         description: ''
-                        originalName: CustomerProvidedKeySha256
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!DateTimeSchema> &ref_66
@@ -2256,16 +2157,15 @@ schemas: !<!Schemas>
                         version: '2019-02-02'
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-AccessTierChangeTime
+                          name: BlobPropertiesAccessTierChangeTime
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: AccessTierChangeTime
                     language: !<!Languages> 
                       default:
-                        name: AccessTierChangeTime
+                        name: accessTierChangeTime
                         description: ''
-                        originalName: AccessTierChangeTime
                     protocol: !<!Protocols> {}
                   serialization:
                     xml:
@@ -2282,9 +2182,8 @@ schemas: !<!Schemas>
                 serializedName: Properties
                 language: !<!Languages> 
                   default:
-                    name: Properties
+                    name: properties
                     description: Properties of a blob
-                    originalName: Properties
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_17
@@ -2303,13 +2202,13 @@ schemas: !<!Schemas>
                           version: '2019-02-02'
                         language: !<!Languages> 
                           default:
-                            name: string
+                            name: String
                             description: ''
                         protocol: !<!Protocols> {}
                       language: !<!Languages> 
                         default:
-                          name: Dictionary of string
-                          description: Dictionary of <components·schemas·blobmetadata·additionalproperties>
+                          name: BlobMetadata
+                          description: Dictionary of String
                       protocol: !<!Protocols> {}
                     immediate:
                     - *ref_13
@@ -2326,15 +2225,14 @@ schemas: !<!Schemas>
                           wrapped: false
                       language: !<!Languages> 
                         default:
-                          name: BlobMetadata-Encrypted
+                          name: BlobMetadataEncrypted
                           description: ''
                       protocol: !<!Protocols> {}
                     serializedName: Encrypted
                     language: !<!Languages> 
                       default:
-                        name: Encrypted
+                        name: encrypted
                         description: ''
-                        originalName: Encrypted
                     protocol: !<!Protocols> {}
                   serialization:
                     xml:
@@ -2351,9 +2249,8 @@ schemas: !<!Schemas>
                 serializedName: Metadata
                 language: !<!Languages> 
                   default:
-                    name: Metadata
+                    name: metadata
                     description: ''
-                    originalName: Metadata
                 protocol: !<!Protocols> {}
               serialization:
                 xml:
@@ -2368,16 +2265,15 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: BlobFlatListSegment-BlobItems
-                description: ''
+                name: BlobFlatListSegmentBlobItems
+                description: Array of BlobItem
             protocol: !<!Protocols> {}
           required: true
           serializedName: BlobItems
           language: !<!Languages> 
             default:
-              name: BlobItems
+              name: blobItems
               description: ''
-              originalName: BlobItems
           protocol: !<!Protocols> {}
         serialization:
           xml:
@@ -2394,9 +2290,8 @@ schemas: !<!Schemas>
       serializedName: Segment
       language: !<!Languages> 
         default:
-          name: Segment
+          name: segment
           description: ''
-          originalName: Segment
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_243
@@ -2406,16 +2301,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListBlobsFlatSegmentResponse-NextMarker
+            name: ListBlobsFlatSegmentResponseNextMarker
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: NextMarker
       language: !<!Languages> 
         default:
-          name: NextMarker
+          name: nextMarker
           description: ''
-          originalName: NextMarker
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -2450,16 +2344,15 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: ListBlobsHierarchySegmentResponse-ServiceEndpoint
+            name: ListBlobsHierarchySegmentResponseServiceEndpoint
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: ServiceEndpoint
       language: !<!Languages> 
         default:
-          name: ServiceEndpoint
+          name: serviceEndpoint
           description: ''
-          originalName: ServiceEndpoint
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_245
@@ -2473,16 +2366,15 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: ListBlobsHierarchySegmentResponse-ContainerName
+            name: ListBlobsHierarchySegmentResponseContainerName
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: ContainerName
       language: !<!Languages> 
         default:
-          name: ContainerName
+          name: containerName
           description: ''
-          originalName: ContainerName
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_246
@@ -2492,16 +2384,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListBlobsHierarchySegmentResponse-Prefix
+            name: ListBlobsHierarchySegmentResponsePrefix
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: Prefix
       language: !<!Languages> 
         default:
-          name: Prefix
+          name: prefix
           description: ''
-          originalName: Prefix
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_247
@@ -2511,16 +2402,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListBlobsHierarchySegmentResponse-Marker
+            name: ListBlobsHierarchySegmentResponseMarker
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: Marker
       language: !<!Languages> 
         default:
-          name: Marker
+          name: marker
           description: ''
-          originalName: Marker
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!NumberSchema> &ref_188
@@ -2528,16 +2418,15 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForMaxResults
+            name: TypeForMaxResults
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: MaxResults
       language: !<!Languages> 
         default:
-          name: MaxResults
+          name: maxResults
           description: ''
-          originalName: MaxResults
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_248
@@ -2547,16 +2436,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListBlobsHierarchySegmentResponse-Delimiter
+            name: ListBlobsHierarchySegmentResponseDelimiter
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: Delimiter
       language: !<!Languages> 
         default:
-          name: Delimiter
+          name: delimiter
           description: ''
-          originalName: Delimiter
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_18
@@ -2585,16 +2473,15 @@ schemas: !<!Schemas>
                     version: '2019-02-02'
                   language: !<!Languages> 
                     default:
-                      name: BlobPrefix-Name
+                      name: BlobPrefixName
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Name
                 language: !<!Languages> 
                   default:
-                    name: Name
+                    name: name
                     description: ''
-                    originalName: Name
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -2604,16 +2491,15 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: BlobHierarchyListSegment-BlobPrefixes
-                description: ''
+                name: BlobHierarchyListSegmentBlobPrefixes
+                description: Array of BlobPrefix
             protocol: !<!Protocols> {}
           required: false
           serializedName: BlobPrefixes
           language: !<!Languages> 
             default:
-              name: BlobPrefixes
+              name: blobPrefixes
               description: ''
-              originalName: BlobPrefixes
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ArraySchema> &ref_34
@@ -2624,16 +2510,15 @@ schemas: !<!Schemas>
             elementType: *ref_15
             language: !<!Languages> 
               default:
-                name: BlobHierarchyListSegment-BlobItems
-                description: ''
+                name: BlobHierarchyListSegmentBlobItems
+                description: Array of BlobItem
             protocol: !<!Protocols> {}
           required: true
           serializedName: BlobItems
           language: !<!Languages> 
             default:
-              name: BlobItems
+              name: blobItems
               description: ''
-              originalName: BlobItems
           protocol: !<!Protocols> {}
         serialization:
           xml:
@@ -2650,9 +2535,8 @@ schemas: !<!Schemas>
       serializedName: Segment
       language: !<!Languages> 
         default:
-          name: Segment
+          name: segment
           description: ''
-          originalName: Segment
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_250
@@ -2662,16 +2546,15 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: ListBlobsHierarchySegmentResponse-NextMarker
+            name: ListBlobsHierarchySegmentResponseNextMarker
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: NextMarker
       language: !<!Languages> 
         default:
-          name: NextMarker
+          name: nextMarker
           description: ''
-          originalName: NextMarker
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -2707,15 +2590,14 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: DataLakeStorageError-error-Code
+                name: DataLakeStorageErrorCode
                 description: The service error code.
             protocol: !<!Protocols> {}
           serializedName: Code
           language: !<!Languages> 
             default:
-              name: Code
+              name: code
               description: The service error code.
-              originalName: Code
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_252
@@ -2725,19 +2607,18 @@ schemas: !<!Schemas>
               version: '2019-02-02'
             language: !<!Languages> 
               default:
-                name: DataLakeStorageError-error-Message
+                name: DataLakeStorageErrorMessage
                 description: The service error message.
             protocol: !<!Protocols> {}
           serializedName: Message
           language: !<!Languages> 
             default:
-              name: Message
+              name: message
               description: The service error message.
-              originalName: Message
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: DataLakeStorageError-error
+            name: DataLakeStorageError
             description: The service error response object.
             namespace: Api20190202
         protocol: !<!Protocols> {}
@@ -2746,7 +2627,6 @@ schemas: !<!Schemas>
         default:
           name: error
           description: The service error response object.
-          originalName: error
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2779,20 +2659,19 @@ schemas: !<!Schemas>
               wrapped: false
           language: !<!Languages> 
             default:
-              name: BlockLookupList-CommittedItem
+              name: BlockLookupListCommittedItem
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: BlockLookupList-Committed
-            description: ''
+            name: BlockLookupListCommitted
+            description: Array of BlockLookupListCommittedItem
         protocol: !<!Protocols> {}
       serializedName: Committed
       language: !<!Languages> 
         default:
-          name: Committed
+          name: committed
           description: ''
-          originalName: Committed
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_36
@@ -2812,20 +2691,19 @@ schemas: !<!Schemas>
               wrapped: false
           language: !<!Languages> 
             default:
-              name: BlockLookupList-UncommittedItem
+              name: BlockLookupListUncommittedItem
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: BlockLookupList-Uncommitted
-            description: ''
+            name: BlockLookupListUncommitted
+            description: Array of BlockLookupListUncommittedItem
         protocol: !<!Protocols> {}
       serializedName: Uncommitted
       language: !<!Languages> 
         default:
-          name: Uncommitted
+          name: uncommitted
           description: ''
-          originalName: Uncommitted
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_37
@@ -2845,20 +2723,19 @@ schemas: !<!Schemas>
               wrapped: false
           language: !<!Languages> 
             default:
-              name: BlockLookupList-LatestItem
+              name: BlockLookupListLatestItem
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: BlockLookupList-Latest
-            description: ''
+            name: BlockLookupListLatest
+            description: Array of BlockLookupListLatestItem
         protocol: !<!Protocols> {}
       serializedName: Latest
       language: !<!Languages> 
         default:
-          name: Latest
+          name: latest
           description: ''
-          originalName: Latest
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -2897,16 +2774,15 @@ schemas: !<!Schemas>
                 version: '2019-02-02'
               language: !<!Languages> 
                 default:
-                  name: Block-Name
+                  name: BlockName
                   description: The base64 encoded block ID.
               protocol: !<!Protocols> {}
             required: true
             serializedName: Name
             language: !<!Languages> 
               default:
-                name: Name
+                name: name
                 description: The base64 encoded block ID.
-                originalName: Name
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!NumberSchema> &ref_189
@@ -2914,16 +2790,15 @@ schemas: !<!Schemas>
               precision: 32
               language: !<!Languages> 
                 default:
-                  name: typeForSize
+                  name: TypeForSize
                   description: The block size in bytes.
               protocol: !<!Protocols> {}
             required: true
             serializedName: Size
             language: !<!Languages> 
               default:
-                name: Size
+                name: size
                 description: The block size in bytes.
-                originalName: Size
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -2937,15 +2812,14 @@ schemas: !<!Schemas>
             wrapped: true
         language: !<!Languages> 
           default:
-            name: BlockList-CommittedBlocks
-            description: ''
+            name: BlockListCommittedBlocks
+            description: Array of Block
         protocol: !<!Protocols> {}
       serializedName: CommittedBlocks
       language: !<!Languages> 
         default:
-          name: CommittedBlocks
+          name: committedBlocks
           description: ''
-          originalName: CommittedBlocks
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_39
@@ -2960,15 +2834,14 @@ schemas: !<!Schemas>
             wrapped: true
         language: !<!Languages> 
           default:
-            name: BlockList-UncommittedBlocks
-            description: ''
+            name: BlockListUncommittedBlocks
+            description: Array of Block
         protocol: !<!Protocols> {}
       serializedName: UncommittedBlocks
       language: !<!Languages> 
         default:
-          name: UncommittedBlocks
+          name: uncommittedBlocks
           description: ''
-          originalName: UncommittedBlocks
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -3006,16 +2879,15 @@ schemas: !<!Schemas>
                   wrapped: false
               language: !<!Languages> 
                 default:
-                  name: typeForStart
+                  name: TypeForStart
                   description: ''
               protocol: !<!Protocols> {}
             required: true
             serializedName: Start
             language: !<!Languages> 
               default:
-                name: Start
+                name: start
                 description: ''
-                originalName: Start
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!NumberSchema> &ref_191
@@ -3028,16 +2900,15 @@ schemas: !<!Schemas>
                   wrapped: false
               language: !<!Languages> 
                 default:
-                  name: typeForEnd
+                  name: TypeForEnd
                   description: ''
               protocol: !<!Protocols> {}
             required: true
             serializedName: End
             language: !<!Languages> 
               default:
-                name: End
+                name: end
                 description: ''
-                originalName: End
             protocol: !<!Protocols> {}
           serialization:
             xml:
@@ -3052,15 +2923,14 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: PageList-PageRange
-            description: ''
+            name: PageListPageRange
+            description: Array of PageRange
         protocol: !<!Protocols> {}
       serializedName: PageRange
       language: !<!Languages> 
         default:
-          name: PageRange
+          name: pageRange
           description: ''
-          originalName: PageRange
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_41
@@ -3085,16 +2955,15 @@ schemas: !<!Schemas>
                   wrapped: false
               language: !<!Languages> 
                 default:
-                  name: typeForStart
+                  name: TypeForStart
                   description: ''
               protocol: !<!Protocols> {}
             required: true
             serializedName: Start
             language: !<!Languages> 
               default:
-                name: Start
+                name: start
                 description: ''
-                originalName: Start
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!NumberSchema> &ref_193
@@ -3107,16 +2976,15 @@ schemas: !<!Schemas>
                   wrapped: false
               language: !<!Languages> 
                 default:
-                  name: typeForEnd
+                  name: TypeForEnd
                   description: ''
               protocol: !<!Protocols> {}
             required: true
             serializedName: End
             language: !<!Languages> 
               default:
-                name: End
+                name: end
                 description: ''
-                originalName: End
             protocol: !<!Protocols> {}
           serialization:
             xml:
@@ -3131,15 +2999,14 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: PageList-ClearRange
-            description: ''
+            name: PageListClearRange
+            description: Array of ClearRange
         protocol: !<!Protocols> {}
       serializedName: ClearRange
       language: !<!Languages> 
         default:
-          name: ClearRange
+          name: clearRange
           description: ''
-          originalName: ClearRange
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -3961,31 +3828,31 @@ schemas: !<!Schemas>
         value: copy
         language:
           default:
-            name: copy
+            name: Copy
             description: ''
       - !<!ChoiceValue> 
         value: deleted
         language:
           default:
-            name: deleted
+            name: Deleted
             description: ''
       - !<!ChoiceValue> 
         value: metadata
         language:
           default:
-            name: metadata
+            name: Metadata
             description: ''
       - !<!ChoiceValue> 
         value: snapshots
         language:
           default:
-            name: snapshots
+            name: Snapshots
             description: ''
       - !<!ChoiceValue> 
         value: uncommittedblobs
         language:
           default:
-            name: uncommittedblobs
+            name: Uncommittedblobs
             description: ''
       type: sealed-choice
       apiVersions:
@@ -3999,8 +3866,8 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of ListBlobsIncludeItem
-        description: ''
+        name: ArrayOfListBlobsIncludeItem
+        description: Array of ListBlobsIncludeItem
     protocol: !<!Protocols> {}
   - *ref_32
   - *ref_33
@@ -4070,7 +3937,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-has-immutability-policy
     protocol: !<!Protocols> {}
@@ -4081,7 +3948,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-has-legal-hold
     protocol: !<!Protocols> {}
@@ -4096,7 +3963,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_687
@@ -4106,7 +3973,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_713
@@ -4116,7 +3983,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_714
@@ -4126,7 +3993,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_753
@@ -4136,7 +4003,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-server-encrypted
     protocol: !<!Protocols> {}
@@ -4147,7 +4014,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-server-encrypted
     protocol: !<!Protocols> {}
@@ -4158,7 +4025,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-incremental-copy
     protocol: !<!Protocols> {}
@@ -4169,7 +4036,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-server-encrypted
     protocol: !<!Protocols> {}
@@ -4180,7 +4047,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-access-tier-inferred
     protocol: !<!Protocols> {}
@@ -4191,7 +4058,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4202,7 +4069,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4213,7 +4080,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4224,7 +4091,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4235,7 +4102,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4246,7 +4113,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4257,7 +4124,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4268,7 +4135,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4279,7 +4146,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4290,7 +4157,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4301,7 +4168,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4312,7 +4179,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: x-ms-request-server-encrypted
     protocol: !<!Protocols> {}
@@ -4326,7 +4193,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4338,7 +4205,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-blob-content-md5
     protocol: !<!Protocols> {}
@@ -4350,7 +4217,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4362,7 +4229,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4374,7 +4241,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-blob-content-md5
     protocol: !<!Protocols> {}
@@ -4386,7 +4253,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4398,7 +4265,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_1218
@@ -4409,7 +4276,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4421,7 +4288,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4433,7 +4300,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_1566
@@ -4444,7 +4311,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4456,7 +4323,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_1149
@@ -4467,7 +4334,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4479,7 +4346,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4491,7 +4358,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_1590
@@ -4502,7 +4369,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4514,7 +4381,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4526,7 +4393,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_1618
@@ -4537,7 +4404,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4549,7 +4416,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4561,7 +4428,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4573,7 +4440,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4585,7 +4452,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4597,7 +4464,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4609,7 +4476,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4621,7 +4488,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4633,7 +4500,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4645,7 +4512,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4657,7 +4524,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4669,7 +4536,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4681,7 +4548,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -4693,7 +4560,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: x-ms-content-crc64
     protocol: !<!Protocols> {}
@@ -4709,7 +4576,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant0
+        name: Constant19
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_261
@@ -4723,7 +4590,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant1
+        name: Constant20
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_257
@@ -4737,7 +4604,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant2
+        name: Constant21
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_281
@@ -4751,7 +4618,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant3
+        name: Constant22
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_282
@@ -4765,7 +4632,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant4
+        name: Constant23
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_292
@@ -4779,7 +4646,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant5
+        name: Constant24
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_296
@@ -4810,7 +4677,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant6
+        name: Constant26
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_309
@@ -4824,7 +4691,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant7
+        name: Constant27
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_325
@@ -4838,7 +4705,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant8
+        name: Constant28
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_326
@@ -4852,7 +4719,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant9
+        name: Constant29
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_335
@@ -4866,7 +4733,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant10
+        name: Constant30
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_347
@@ -4880,7 +4747,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant11
+        name: Constant31
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_388
@@ -4894,7 +4761,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant12
+        name: Constant32
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_389
@@ -4908,7 +4775,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant13
+        name: Constant33
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_405
@@ -4922,7 +4789,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant14
+        name: Constant34
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_406
@@ -4936,7 +4803,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant15
+        name: Constant35
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_436
@@ -4950,7 +4817,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant16
+        name: Constant36
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_437
@@ -4964,7 +4831,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant17
+        name: Constant37
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_438
@@ -4992,7 +4859,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant18
+        name: Constant39
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_457
@@ -5006,7 +4873,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant19
+        name: Constant40
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_458
@@ -5034,7 +4901,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant20
+        name: Constant42
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_474
@@ -5048,7 +4915,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant21
+        name: Constant43
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_475
@@ -5076,7 +4943,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant22
+        name: Constant45
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_491
@@ -5090,7 +4957,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant23
+        name: Constant46
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_492
@@ -5118,7 +4985,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant24
+        name: Constant48
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_509
@@ -5132,7 +4999,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant25
+        name: Constant49
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_510
@@ -5160,7 +5027,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant26
+        name: Constant51
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_528
@@ -5174,7 +5041,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant27
+        name: Constant52
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_544
@@ -5188,7 +5055,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant28
+        name: Constant53
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_545
@@ -5202,7 +5069,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant29
+        name: Constant54
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_562
@@ -5216,7 +5083,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant30
+        name: Constant55
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_563
@@ -5230,7 +5097,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant31
+        name: Constant56
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_570
@@ -5244,7 +5111,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant32
+        name: Constant57
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_661
@@ -5258,7 +5125,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant33
+        name: Constant58
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_686
@@ -5272,7 +5139,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant34
+        name: Constant59
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_156
@@ -5303,7 +5170,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant35
+        name: Constant61
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_868
@@ -5317,7 +5184,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant36
+        name: Constant62
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1189
@@ -5373,7 +5240,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant37
+        name: Constant66
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_934
@@ -5387,7 +5254,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant38
+        name: Constant67
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_958
@@ -5401,7 +5268,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant39
+        name: Constant68
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_981
@@ -5415,7 +5282,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant40
+        name: Constant69
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_982
@@ -5443,7 +5310,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant41
+        name: Constant71
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1001
@@ -5471,7 +5338,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant42
+        name: Constant73
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1018
@@ -5499,7 +5366,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant43
+        name: Constant75
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1036
@@ -5527,7 +5394,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant44
+        name: Constant77
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1055
@@ -5555,7 +5422,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant45
+        name: Constant79
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1122
@@ -5569,7 +5436,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant46
+        name: Constant80
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1148
@@ -5601,7 +5468,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant47
+        name: Constant82
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1153
@@ -5615,7 +5482,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant48
+        name: Constant83
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1166
@@ -5629,7 +5496,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant49
+        name: Constant84
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1181
@@ -5643,7 +5510,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant50
+        name: Constant85
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1182
@@ -5657,7 +5524,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant51
+        name: Constant86
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1574
@@ -5671,7 +5538,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant52
+        name: Constant87
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1599
@@ -5685,7 +5552,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant53
+        name: Constant88
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1627
@@ -5699,7 +5566,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant54
+        name: Constant89
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1226
@@ -5713,7 +5580,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant55
+        name: Constant90
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1227
@@ -5741,7 +5608,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant56
+        name: Constant92
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1264
@@ -5769,7 +5636,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant57
+        name: Constant94
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1293
@@ -5797,7 +5664,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant58
+        name: Constant96
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1355
@@ -5811,7 +5678,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant59
+        name: Constant97
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1377
@@ -5825,7 +5692,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant60
+        name: Constant98
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1399
@@ -5839,7 +5706,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant61
+        name: Constant99
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1420
@@ -5853,7 +5720,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant62
+        name: Constant100
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1468
@@ -5867,7 +5734,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant63
+        name: Constant101
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_1501
@@ -5881,7 +5748,7 @@ schemas: !<!Schemas>
     valueType: *ref_6
     language: !<!Languages> 
       default:
-        name: Constant64
+        name: Constant102
         description: ''
     protocol: !<!Protocols> {}
   dateTimes:
@@ -5893,7 +5760,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -5907,7 +5774,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -5921,7 +5788,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -5933,7 +5800,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -5945,7 +5812,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -5957,7 +5824,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -5969,7 +5836,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -5981,7 +5848,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
     protocol: !<!Protocols> {}
   - !<!DateTimeSchema> &ref_71
@@ -5992,7 +5859,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
     protocol: !<!Protocols> {}
   - !<!DateTimeSchema> &ref_386
@@ -6003,7 +5870,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6015,7 +5882,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6027,7 +5894,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6039,7 +5906,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6051,7 +5918,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6065,7 +5932,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6077,7 +5944,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6089,7 +5956,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6101,7 +5968,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6113,7 +5980,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6125,7 +5992,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6137,7 +6004,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6149,7 +6016,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6161,7 +6028,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6173,7 +6040,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6185,7 +6052,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6197,7 +6064,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6209,7 +6076,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6226,7 +6093,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6238,7 +6105,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6250,7 +6117,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6262,7 +6129,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6274,7 +6141,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
     protocol: !<!Protocols> {}
   - !<!DateTimeSchema> &ref_127
@@ -6285,7 +6152,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
     protocol: !<!Protocols> {}
   - !<!DateTimeSchema> &ref_632
@@ -6296,7 +6163,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6308,7 +6175,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6320,7 +6187,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6332,7 +6199,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6344,7 +6211,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6356,7 +6223,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6368,7 +6235,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6380,7 +6247,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6392,7 +6259,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: x-ms-copy-completion-time
     protocol: !<!Protocols> {}
@@ -6404,7 +6271,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6416,7 +6283,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6428,7 +6295,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: x-ms-copy-completion-time
     protocol: !<!Protocols> {}
@@ -6440,7 +6307,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6452,7 +6319,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6464,7 +6331,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: x-ms-creation-time
     protocol: !<!Protocols> {}
@@ -6476,7 +6343,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: x-ms-copy-completion-time
     protocol: !<!Protocols> {}
@@ -6488,7 +6355,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6500,7 +6367,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: x-ms-access-tier-change-time
     protocol: !<!Protocols> {}
@@ -6512,7 +6379,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6524,7 +6391,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6536,7 +6403,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6548,7 +6415,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6560,7 +6427,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6572,7 +6439,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6584,7 +6451,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6596,7 +6463,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6608,7 +6475,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6620,7 +6487,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6632,7 +6499,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6644,7 +6511,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6656,7 +6523,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6668,7 +6535,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6680,7 +6547,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6692,7 +6559,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6704,7 +6571,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6716,7 +6583,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6728,7 +6595,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6740,7 +6607,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6752,7 +6619,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6764,7 +6631,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6776,7 +6643,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6788,7 +6655,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6800,7 +6667,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6812,7 +6679,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6824,7 +6691,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6836,7 +6703,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6848,7 +6715,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6860,7 +6727,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6872,7 +6739,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6884,7 +6751,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6896,7 +6763,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6908,7 +6775,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6920,7 +6787,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6932,7 +6799,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6944,7 +6811,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6956,7 +6823,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6968,7 +6835,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -6980,7 +6847,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -6992,7 +6859,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7004,7 +6871,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7016,7 +6883,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7028,7 +6895,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7040,7 +6907,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7052,7 +6919,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7064,7 +6931,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7076,7 +6943,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7088,7 +6955,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7100,7 +6967,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7112,7 +6979,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7124,7 +6991,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7136,7 +7003,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7148,7 +7015,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7160,7 +7027,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7172,7 +7039,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7184,7 +7051,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7196,7 +7063,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7208,7 +7075,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7220,7 +7087,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7232,7 +7099,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -7244,7 +7111,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -7260,7 +7127,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -9366,7 +9233,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -9804,7 +9671,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -10250,7 +10117,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -10325,7 +10192,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -10379,7 +10246,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -10433,7 +10300,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -10487,7 +10354,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -10784,7 +10651,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -10886,7 +10753,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -10996,7 +10863,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -11352,7 +11219,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -11771,7 +11638,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -11884,7 +11751,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12031,7 +11898,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12109,7 +11976,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12187,7 +12054,7 @@ schemas: !<!Schemas>
           version: '2019-02-02'
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12274,7 +12141,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12350,7 +12217,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12405,7 +12272,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12468,7 +12335,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12531,7 +12398,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -12586,7 +12453,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_181
@@ -12600,7 +12467,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_183
@@ -12612,7 +12479,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_439
@@ -12623,7 +12490,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_493
@@ -12634,7 +12501,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_502
@@ -12645,7 +12512,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-lease-time
     protocol: !<!Protocols> {}
@@ -12662,7 +12529,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -12674,7 +12541,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -12686,7 +12553,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -12698,7 +12565,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12710,7 +12577,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-committed-block-count
     protocol: !<!Protocols> {}
@@ -12722,7 +12589,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -12734,7 +12601,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12746,7 +12613,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-committed-block-count
     protocol: !<!Protocols> {}
@@ -12758,7 +12625,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -12770,7 +12637,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12782,7 +12649,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-committed-block-count
     protocol: !<!Protocols> {}
@@ -12794,7 +12661,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -12806,7 +12673,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_1206
@@ -12818,7 +12685,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_952
@@ -12829,7 +12696,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12841,7 +12708,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-lease-time
     protocol: !<!Protocols> {}
@@ -12853,7 +12720,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-content-length
     protocol: !<!Protocols> {}
@@ -12869,7 +12736,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12881,7 +12748,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12893,7 +12760,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12905,7 +12772,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-content-length
     protocol: !<!Protocols> {}
@@ -12921,7 +12788,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-content-length
     protocol: !<!Protocols> {}
@@ -12933,7 +12800,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12945,7 +12812,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-sequence-number
     protocol: !<!Protocols> {}
@@ -12959,7 +12826,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-committed-block-count
     protocol: !<!Protocols> {}
@@ -12971,7 +12838,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: x-ms-blob-committed-block-count
     protocol: !<!Protocols> {}
@@ -12983,7 +12850,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   sealedChoices:
@@ -12996,31 +12863,31 @@ schemas: !<!Schemas>
       value: Standard_LRS
       language:
         default:
-          name: Standard_LRS
+          name: StandardLrs
           description: ''
     - !<!ChoiceValue> 
       value: Standard_GRS
       language:
         default:
-          name: Standard_GRS
+          name: StandardGrs
           description: ''
     - !<!ChoiceValue> 
       value: Standard_RAGRS
       language:
         default:
-          name: Standard_RAGRS
+          name: StandardRagrs
           description: ''
     - !<!ChoiceValue> 
       value: Standard_ZRS
       language:
         default:
-          name: Standard_ZRS
+          name: StandardZrs
           description: ''
     - !<!ChoiceValue> 
       value: Premium_LRS
       language:
         default:
-          name: Premium_LRS
+          name: PremiumLrs
           description: ''
     type: sealed-choice
     apiVersions:
@@ -13073,13 +12940,13 @@ schemas: !<!Schemas>
       value: legacy
       language:
         default:
-          name: legacy
+          name: Legacy
           description: ''
     - !<!ChoiceValue> 
       value: posix
       language:
         default:
-          name: posix
+          name: Posix
           description: ''
     type: sealed-choice
     apiVersions:
@@ -13097,13 +12964,13 @@ schemas: !<!Schemas>
       value: include
       language:
         default:
-          name: include
+          name: Include
           description: ''
     - !<!ChoiceValue> 
       value: only
       language:
         default:
-          name: only
+          name: Only
           description: ''
     type: sealed-choice
     apiVersions:
@@ -13121,19 +12988,19 @@ schemas: !<!Schemas>
       value: committed
       language:
         default:
-          name: committed
+          name: Committed
           description: ''
     - !<!ChoiceValue> 
       value: uncommitted
       language:
         default:
-          name: uncommitted
+          name: Uncommitted
           description: ''
     - !<!ChoiceValue> 
       value: all
       language:
         default:
-          name: all
+          name: All
           description: ''
     type: sealed-choice
     apiVersions:
@@ -13152,19 +13019,19 @@ schemas: !<!Schemas>
       value: max
       language:
         default:
-          name: max
+          name: Max
           description: ''
     - !<!ChoiceValue> 
       value: update
       language:
         default:
-          name: update
+          name: Update
           description: ''
     - !<!ChoiceValue> 
       value: increment
       language:
         default:
-          name: increment
+          name: Increment
           description: ''
     type: sealed-choice
     apiVersions:
@@ -13185,7 +13052,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_197
@@ -13204,7 +13071,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13215,7 +13082,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13226,7 +13093,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13237,7 +13104,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13249,7 +13116,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13260,7 +13127,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13271,7 +13138,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13282,7 +13149,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13293,7 +13160,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13304,7 +13171,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13315,7 +13182,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13326,7 +13193,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13337,7 +13204,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_294
@@ -13347,7 +13214,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_304
@@ -13357,7 +13224,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13368,7 +13235,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13379,7 +13246,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13397,7 +13264,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13410,7 +13277,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13421,7 +13288,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13432,7 +13299,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13448,7 +13315,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13459,7 +13326,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13470,7 +13337,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13481,7 +13348,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13492,7 +13359,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13503,7 +13370,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_343
@@ -13513,7 +13380,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -13524,7 +13391,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13535,7 +13402,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13546,7 +13413,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13557,7 +13424,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_354
@@ -13567,7 +13434,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -13578,7 +13445,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13589,7 +13456,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13600,7 +13467,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13611,7 +13478,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13623,7 +13490,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-meta
     protocol: !<!Protocols> {}
@@ -13634,7 +13501,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -13645,7 +13512,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13656,7 +13523,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13667,7 +13534,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13678,7 +13545,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13689,7 +13556,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13700,7 +13567,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13711,7 +13578,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13722,7 +13589,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13733,7 +13600,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -13744,7 +13611,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13755,7 +13622,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13766,7 +13633,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13777,7 +13644,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13788,7 +13655,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -13799,7 +13666,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13810,7 +13677,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13821,7 +13688,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13834,7 +13701,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13845,7 +13712,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -13856,7 +13723,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13867,7 +13734,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13878,7 +13745,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13889,7 +13756,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13900,7 +13767,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_448
@@ -13910,7 +13777,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -13921,7 +13788,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-id
     protocol: !<!Protocols> {}
@@ -13932,7 +13799,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -13943,7 +13810,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -13954,7 +13821,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -13965,7 +13832,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -13976,7 +13843,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_466
@@ -13986,7 +13853,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -13997,7 +13864,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14008,7 +13875,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14019,7 +13886,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14030,7 +13897,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -14041,7 +13908,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -14052,7 +13919,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-id
     protocol: !<!Protocols> {}
@@ -14063,7 +13930,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14074,7 +13941,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14085,7 +13952,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14096,7 +13963,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -14107,7 +13974,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -14118,7 +13985,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14129,7 +13996,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14140,7 +14007,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14151,7 +14018,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -14162,7 +14029,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_519
@@ -14172,7 +14039,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -14183,7 +14050,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-id
     protocol: !<!Protocols> {}
@@ -14194,7 +14061,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14205,7 +14072,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14216,7 +14083,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14227,7 +14094,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -14238,7 +14105,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -14249,7 +14116,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14260,7 +14127,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14271,7 +14138,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14303,7 +14170,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -14314,7 +14181,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_556
@@ -14324,7 +14191,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -14335,7 +14202,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14346,7 +14213,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14357,7 +14224,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14375,7 +14242,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -14386,7 +14253,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14397,7 +14264,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14408,7 +14275,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14419,7 +14286,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -14430,7 +14297,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_572
@@ -14440,7 +14307,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_573
@@ -14450,7 +14317,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_116
@@ -14467,7 +14334,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -14478,7 +14345,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14489,7 +14356,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14500,7 +14367,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14511,7 +14378,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14522,7 +14389,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14533,7 +14400,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14546,7 +14413,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_604
@@ -14556,7 +14423,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_611
@@ -14566,7 +14433,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_135
@@ -14578,7 +14445,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-continuation
     protocol: !<!Protocols> {}
@@ -14589,7 +14456,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -14600,7 +14467,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14611,7 +14478,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14622,7 +14489,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14633,7 +14500,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14644,7 +14511,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14655,7 +14522,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14666,7 +14533,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-continuation
     protocol: !<!Protocols> {}
@@ -14677,7 +14544,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14688,7 +14555,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14699,7 +14566,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14710,7 +14577,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14721,7 +14588,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14732,7 +14599,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14743,7 +14610,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_664
@@ -14753,7 +14620,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_665
@@ -14763,7 +14630,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_679
@@ -14773,7 +14640,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -14784,7 +14651,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14795,7 +14662,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14806,7 +14673,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14817,7 +14684,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14828,7 +14695,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14839,7 +14706,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -14850,7 +14717,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-owner
     protocol: !<!Protocols> {}
@@ -14861,7 +14728,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-group
     protocol: !<!Protocols> {}
@@ -14872,7 +14739,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-permissions
     protocol: !<!Protocols> {}
@@ -14883,7 +14750,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-acl
     protocol: !<!Protocols> {}
@@ -14894,7 +14761,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14905,7 +14772,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14916,7 +14783,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -14927,7 +14794,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -14938,7 +14805,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -14949,7 +14816,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_711
@@ -14959,7 +14826,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_137
@@ -14971,7 +14838,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-meta
     protocol: !<!Protocols> {}
@@ -14982,7 +14849,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -14993,7 +14860,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Range
     protocol: !<!Protocols> {}
@@ -15004,7 +14871,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -15015,7 +14882,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Encoding
     protocol: !<!Protocols> {}
@@ -15026,7 +14893,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Cache-Control
     protocol: !<!Protocols> {}
@@ -15037,7 +14904,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Disposition
     protocol: !<!Protocols> {}
@@ -15048,7 +14915,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Language
     protocol: !<!Protocols> {}
@@ -15059,7 +14926,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-status-description
     protocol: !<!Protocols> {}
@@ -15070,7 +14937,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-id
     protocol: !<!Protocols> {}
@@ -15081,7 +14948,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-progress
     protocol: !<!Protocols> {}
@@ -15092,7 +14959,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-source
     protocol: !<!Protocols> {}
@@ -15103,7 +14970,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15114,7 +14981,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15125,7 +14992,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15136,7 +15003,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Accept-Ranges
     protocol: !<!Protocols> {}
@@ -15147,7 +15014,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -15158,7 +15025,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-meta
     protocol: !<!Protocols> {}
@@ -15169,7 +15036,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -15180,7 +15047,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Range
     protocol: !<!Protocols> {}
@@ -15191,7 +15058,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -15202,7 +15069,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Encoding
     protocol: !<!Protocols> {}
@@ -15213,7 +15080,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Cache-Control
     protocol: !<!Protocols> {}
@@ -15224,7 +15091,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Disposition
     protocol: !<!Protocols> {}
@@ -15235,7 +15102,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Language
     protocol: !<!Protocols> {}
@@ -15246,7 +15113,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-status-description
     protocol: !<!Protocols> {}
@@ -15257,7 +15124,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-id
     protocol: !<!Protocols> {}
@@ -15268,7 +15135,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-progress
     protocol: !<!Protocols> {}
@@ -15279,7 +15146,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-source
     protocol: !<!Protocols> {}
@@ -15290,7 +15157,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15301,7 +15168,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15312,7 +15179,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15323,7 +15190,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Accept-Ranges
     protocol: !<!Protocols> {}
@@ -15334,7 +15201,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -15345,7 +15212,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -15356,7 +15223,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-meta
     protocol: !<!Protocols> {}
@@ -15367,7 +15234,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-status-description
     protocol: !<!Protocols> {}
@@ -15378,7 +15245,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-id
     protocol: !<!Protocols> {}
@@ -15389,7 +15256,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-progress
     protocol: !<!Protocols> {}
@@ -15400,7 +15267,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-source
     protocol: !<!Protocols> {}
@@ -15411,7 +15278,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-destination-snapshot
     protocol: !<!Protocols> {}
@@ -15422,7 +15289,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -15433,7 +15300,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -15444,7 +15311,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Encoding
     protocol: !<!Protocols> {}
@@ -15455,7 +15322,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Disposition
     protocol: !<!Protocols> {}
@@ -15466,7 +15333,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Language
     protocol: !<!Protocols> {}
@@ -15477,7 +15344,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Cache-Control
     protocol: !<!Protocols> {}
@@ -15488,7 +15355,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15499,7 +15366,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15510,7 +15377,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15521,7 +15388,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Accept-Ranges
     protocol: !<!Protocols> {}
@@ -15532,7 +15399,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -15543,7 +15410,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-access-tier
     protocol: !<!Protocols> {}
@@ -15554,7 +15421,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-archive-status
     protocol: !<!Protocols> {}
@@ -15565,7 +15432,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -15576,7 +15443,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15587,7 +15454,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15598,7 +15465,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15609,7 +15476,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -15620,7 +15487,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -15631,7 +15498,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15642,7 +15509,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15653,7 +15520,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15664,7 +15531,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15675,7 +15542,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15686,7 +15553,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -15697,7 +15564,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-owner
     protocol: !<!Protocols> {}
@@ -15708,7 +15575,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-group
     protocol: !<!Protocols> {}
@@ -15719,7 +15586,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-permissions
     protocol: !<!Protocols> {}
@@ -15730,7 +15597,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-acl
     protocol: !<!Protocols> {}
@@ -15741,7 +15608,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15752,7 +15619,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15763,7 +15630,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15774,7 +15641,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15785,7 +15652,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15796,7 +15663,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -15807,7 +15674,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15818,7 +15685,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15829,7 +15696,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15840,7 +15707,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15851,7 +15718,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15862,7 +15729,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15878,7 +15745,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -15889,7 +15756,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15900,7 +15767,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15911,7 +15778,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15922,7 +15789,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -15933,7 +15800,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -15944,7 +15811,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -15955,7 +15822,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -15966,7 +15833,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -15977,7 +15844,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -15988,7 +15855,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -15999,7 +15866,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16010,7 +15877,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16021,7 +15888,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16032,7 +15899,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16043,7 +15910,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16054,7 +15921,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -16065,7 +15932,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16076,7 +15943,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16087,7 +15954,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16098,7 +15965,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16109,7 +15976,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16120,7 +15987,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16131,7 +15998,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16142,7 +16009,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16153,7 +16020,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16164,7 +16031,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16175,7 +16042,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16186,7 +16053,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16197,7 +16064,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16208,7 +16075,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16219,7 +16086,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -16230,7 +16097,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16241,7 +16108,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16252,7 +16119,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-id
     protocol: !<!Protocols> {}
@@ -16263,7 +16130,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16274,7 +16141,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16285,7 +16152,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16296,7 +16163,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16307,7 +16174,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16318,7 +16185,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16329,7 +16196,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16340,7 +16207,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16351,7 +16218,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16362,7 +16229,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16373,7 +16240,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-id
     protocol: !<!Protocols> {}
@@ -16384,7 +16251,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16395,7 +16262,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16406,7 +16273,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16417,7 +16284,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16428,7 +16295,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16439,7 +16306,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16450,7 +16317,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16461,7 +16328,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-id
     protocol: !<!Protocols> {}
@@ -16472,7 +16339,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16483,7 +16350,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16494,7 +16361,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16505,7 +16372,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16516,7 +16383,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16527,7 +16394,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16538,7 +16405,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16549,7 +16416,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-snapshot
     protocol: !<!Protocols> {}
@@ -16560,7 +16427,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16571,7 +16438,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16582,7 +16449,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16593,7 +16460,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16604,7 +16471,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16615,7 +16482,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16626,7 +16493,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16637,7 +16504,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16648,7 +16515,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16659,7 +16526,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-id
     protocol: !<!Protocols> {}
@@ -16670,7 +16537,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16681,7 +16548,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -16692,7 +16559,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16703,7 +16570,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16714,7 +16581,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16725,7 +16592,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-id
     protocol: !<!Protocols> {}
@@ -16736,7 +16603,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16747,7 +16614,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_1161
@@ -16757,7 +16624,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16768,7 +16635,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16779,7 +16646,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16790,7 +16657,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16801,7 +16668,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16812,7 +16679,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16823,7 +16690,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16834,7 +16701,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16845,7 +16712,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16856,7 +16723,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16867,7 +16734,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16878,7 +16745,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16889,7 +16756,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16900,7 +16767,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16911,7 +16778,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16922,7 +16789,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_1591
@@ -16932,7 +16799,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -16943,7 +16810,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -16954,7 +16821,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -16965,7 +16832,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -16976,7 +16843,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -16987,7 +16854,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_1620
@@ -16997,7 +16864,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17008,7 +16875,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17019,7 +16886,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17030,7 +16897,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -17041,7 +16908,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17055,7 +16922,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17066,7 +16933,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17077,7 +16944,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17088,7 +16955,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17099,7 +16966,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -17110,7 +16977,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17121,7 +16988,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17132,7 +16999,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -17143,7 +17010,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17154,7 +17021,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17165,7 +17032,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17177,7 +17044,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17188,7 +17055,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17199,7 +17066,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17210,7 +17077,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17221,7 +17088,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17232,7 +17099,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -17243,7 +17110,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17254,7 +17121,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17265,7 +17132,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17276,7 +17143,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17287,7 +17154,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17298,7 +17165,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17309,7 +17176,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_1297
@@ -17319,7 +17186,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_1323
@@ -17329,7 +17196,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17340,7 +17207,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17351,7 +17218,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17362,7 +17229,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -17373,7 +17240,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17384,7 +17251,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17395,7 +17262,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17406,7 +17273,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17417,7 +17284,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17428,7 +17295,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17439,7 +17306,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_1370
@@ -17449,7 +17316,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17460,7 +17327,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17471,7 +17338,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17482,7 +17349,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17493,7 +17360,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17504,7 +17371,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17515,7 +17382,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17526,7 +17393,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17537,7 +17404,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17548,7 +17415,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17559,7 +17426,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17570,7 +17437,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17581,7 +17448,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17592,7 +17459,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17603,7 +17470,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17614,7 +17481,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17625,7 +17492,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17636,7 +17503,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17647,7 +17514,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17658,7 +17525,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-copy-id
     protocol: !<!Protocols> {}
@@ -17669,7 +17536,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17680,7 +17547,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17691,7 +17558,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-client-request-id
     protocol: !<!Protocols> {}
@@ -17702,7 +17569,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17713,7 +17580,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17724,7 +17591,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-blob-append-offset
     protocol: !<!Protocols> {}
@@ -17735,7 +17602,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -17746,7 +17613,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17757,7 +17624,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -17768,7 +17635,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -17779,7 +17646,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -17790,7 +17657,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-blob-append-offset
     protocol: !<!Protocols> {}
@@ -17801,7 +17668,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-encryption-key-sha256
     protocol: !<!Protocols> {}
@@ -17812,7 +17679,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-error-code
     protocol: !<!Protocols> {}
@@ -17823,7 +17690,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> 
@@ -17836,7 +17703,7 @@ schemas: !<!Schemas>
     pattern: '^[a-zA-Z0-9]+(?:/[a-zA-Z0-9]+)*(?:\.[a-zA-Z0-9]+){0,1}$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> 
@@ -17846,7 +17713,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> 
@@ -17856,7 +17723,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> 
@@ -17866,7 +17733,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   uris:
@@ -17877,7 +17744,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: uri
+        name: Uri
         description: ''
     protocol: !<!Protocols> {}
   - !<!UriSchema> &ref_1294
@@ -17887,7 +17754,7 @@ schemas: !<!Schemas>
       version: '2019-02-02'
     language: !<!Languages> 
       default:
-        name: uri
+        name: Uri
         description: ''
     protocol: !<!Protocols> {}
 globalParameters:
@@ -18888,7 +18755,7 @@ operationGroups:
           x-ms-requestBody-name: StorageServiceProperties
         language: !<!Languages> 
           default:
-            name: StorageServiceProperties
+            name: storageServiceProperties
             description: The StorageService properties.
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -19428,7 +19295,7 @@ operationGroups:
         targetProperty: *ref_313
         language: !<!Languages> 
           default:
-            name: Start
+            name: start
             description: The date-time the key is active in ISO 8601 UTC time
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_318
@@ -19441,7 +19308,7 @@ operationGroups:
         targetProperty: *ref_314
         language: !<!Languages> 
           default:
-            name: Expiry
+            name: expiry
             description: The date-time the key expires in ISO 8601 UTC time
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -19632,7 +19499,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -22713,7 +22580,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: rangeGetContentMD5
+            name: rangeGetContentMd5
             description: 'When set to true and specified together with the Range, the service returns the MD5 hash for the range, as long as the range is less than or equal to 4 MB in size.'
             serializedName: x-ms-range-get-content-md5
         protocol: !<!Protocols> 
@@ -22724,7 +22591,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: rangeGetContentCRC64
+            name: rangeGetContentCrc64
             description: 'When set to true and specified together with the Range, the service returns the CRC64 hash for the range, as long as the range is less than or equal to 4 MB in size.'
             serializedName: x-ms-range-get-content-crc64
         protocol: !<!Protocols> 
@@ -24092,7 +23959,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: SetHTTPHeaders
+        name: SetHttpHeaders
         description: The Set HTTP Headers operation sets system properties on the blob
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -25288,7 +25155,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: StartCopyFromURL
+        name: StartCopyFromUrl
         description: The Start Copy From URL operation copies a blob or an internet resource to a new blob.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -25390,7 +25257,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: sourceContentMD5
+            name: sourceContentMd5
             description: Specify the md5 calculated for the range of bytes that must be read from the copy source.
             serializedName: x-ms-source-content-md5
         protocol: !<!Protocols> 
@@ -25479,7 +25346,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: CopyFromURL
+        name: CopyFromUrl
         description: The Copy From URL operation copies a blob or an internet resource to a new blob. It will not return a response until the copy is complete.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -25609,7 +25476,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: AbortCopyFromURL
+        name: AbortCopyFromUrl
         description: 'The Abort Copy From URL operation aborts a pending Copy From URL operation, and leaves a destination blob with zero length and full metadata.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -25900,7 +25767,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -26108,7 +25975,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -26119,7 +25986,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: transactionalContentMD5
+            name: transactionalContentMd5
             description: 'Specify the transactional md5 for the body, to be validated by the service.'
             serializedName: Content-MD5
         protocol: !<!Protocols> 
@@ -26334,7 +26201,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -26533,7 +26400,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: sourceContentMD5
+            name: sourceContentMd5
             description: Specify the md5 calculated for the range of bytes that must be read from the copy source.
             serializedName: x-ms-source-content-md5
         protocol: !<!Protocols> 
@@ -26556,7 +26423,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -26703,7 +26570,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: UploadPagesFromURL
+        name: UploadPagesFromUrl
         description: The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -27487,7 +27354,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -27656,7 +27523,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -27667,7 +27534,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: transactionalContentMD5
+            name: transactionalContentMd5
             description: 'Specify the transactional md5 for the body, to be validated by the service.'
             serializedName: Content-MD5
         protocol: !<!Protocols> 
@@ -27868,7 +27735,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: sourceContentMD5
+            name: sourceContentMd5
             description: Specify the md5 calculated for the range of bytes that must be read from the copy source.
             serializedName: x-ms-source-content-md5
         protocol: !<!Protocols> 
@@ -27904,7 +27771,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -27915,7 +27782,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: transactionalContentMD5
+            name: transactionalContentMd5
             description: 'Specify the transactional md5 for the body, to be validated by the service.'
             serializedName: Content-MD5
         protocol: !<!Protocols> 
@@ -28089,7 +27956,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: transactionalContentMD5
+            name: transactionalContentMd5
             description: 'Specify the transactional md5 for the body, to be validated by the service.'
             serializedName: Content-MD5
         protocol: !<!Protocols> 
@@ -28101,7 +27968,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -28306,7 +28173,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -28317,7 +28184,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: transactionalContentMD5
+            name: transactionalContentMd5
             description: 'Specify the transactional md5 for the body, to be validated by the service.'
             serializedName: Content-MD5
         protocol: !<!Protocols> 
@@ -28500,7 +28367,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: The length of the request.
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -28534,7 +28401,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: sourceContentMD5
+            name: sourceContentMd5
             description: Specify the md5 calculated for the range of bytes that must be read from the copy source.
             serializedName: x-ms-source-content-md5
         protocol: !<!Protocols> 
@@ -28663,7 +28530,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: StageBlockFromURL
+        name: StageBlockFromUrl
         description: The Stage Block operation creates a new block to be committed as part of a blob where the contents are read from a URL.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -28708,7 +28575,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: transactionalContentMD5
+            name: transactionalContentMd5
             description: 'Specify the transactional md5 for the body, to be validated by the service.'
             serializedName: Content-MD5
         protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/body-array/namer.yaml
+++ b/modelerfour/test/scenarios/body-array/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_22
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -59,7 +57,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForinteger
+            name: TypeForinteger
             description: ''
         protocol: !<!Protocols> {}
       serializedName: integer
@@ -67,7 +65,6 @@ schemas: !<!Schemas>
         default:
           name: integer
           description: ''
-          originalName: integer
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_24
@@ -77,7 +74,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Product-string
+            name: ProductString
             description: ''
         protocol: !<!Protocols> {}
       serializedName: string
@@ -85,7 +82,6 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          originalName: string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -103,13 +99,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Dictionary of string
-        description: Dictionary of <paths·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema·items>
+        name: DictionaryOfString
+        description: Dictionary of String
     protocol: !<!Protocols> {}
   choices:
   - !<!ChoiceSchema> &ref_2
@@ -118,19 +114,19 @@ schemas: !<!Schemas>
       value: foo1
       language:
         default:
-          name: foo1
+          name: Foo1
           description: ''
     - !<!ChoiceValue> 
       value: foo2
       language:
         default:
-          name: foo2
+          name: Foo2
           description: ''
     - !<!ChoiceValue> 
       value: foo3
       language:
         default:
-          name: foo3
+          name: Foo3
           description: ''
     type: choice
     apiVersions:
@@ -140,7 +136,7 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -162,12 +158,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: get-200-application-json-itemsItem
+          name: Get200ApplicationJsonItemsItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfget-200-application-json-itemsItem
+        name: ArrayOfGet200ApplicationJsonItemsItem
         description: The null Array value
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_30
@@ -183,12 +179,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: integer
+          name: Integer
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfinteger
+        name: ArrayOfInteger
         description: 'The invalid Array [1, 2, 3'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_31
@@ -203,12 +199,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: put-content-schemaItem
+          name: PutContentSchemaItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfput-content-schemaItem
+        name: ArrayOfPutContentSchemaItem
         description: 'The empty array value []'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_33
@@ -223,12 +219,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: boolean
+          name: Boolean
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfboolean
+        name: ArrayOfBoolean
         description: 'The array value [true, false, false, true]'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_36
@@ -244,12 +240,12 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: integer
+          name: Integer
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfinteger
+        name: ArrayOfInteger
         description: 'The array value [1, -1, 3, 300]'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_38
@@ -265,12 +261,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfnumber
+        name: ArrayOfNumber
         description: 'The array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_40
@@ -286,12 +282,12 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfnumber
+        name: ArrayOfNumber
         description: 'The array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_4
@@ -302,7 +298,7 @@ schemas: !<!Schemas>
     elementType: *ref_0
     language: !<!Languages> 
       default:
-        name: ArrayOfstring
+        name: ArrayOfString
         description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_43
@@ -316,19 +312,19 @@ schemas: !<!Schemas>
         value: foo1
         language:
           default:
-            name: foo1
+            name: Foo1
             description: ''
       - !<!ChoiceValue> 
         value: foo2
         language:
           default:
-            name: foo2
+            name: Foo2
             description: ''
       - !<!ChoiceValue> 
         value: foo3
         language:
           default:
-            name: foo3
+            name: Foo3
             description: ''
       type: sealed-choice
       apiVersions:
@@ -368,12 +364,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: uuid
+          name: Uuid
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfuuid
+        name: ArrayOfUuid
         description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_49
@@ -388,12 +384,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date
+          name: Date
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfdate
+        name: ArrayOfDate
         description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_51
@@ -409,12 +405,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfdate-time
+        name: ArrayOfDateTime
         description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_53
@@ -430,12 +426,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfdate-time
+        name: ArrayOfDateTime
         description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_55
@@ -450,12 +446,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: duration
+          name: Duration
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfduration
+        name: ArrayOfDuration
         description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_57
@@ -471,12 +467,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: byte-array
+          name: ByteArray
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfbyte-array
+        name: ArrayOfByteArray
         description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_59
@@ -492,12 +488,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: byte-array
+          name: ByteArray
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfbyte-array
+        name: ArrayOfByteArray
         description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_60
@@ -519,7 +515,7 @@ schemas: !<!Schemas>
     elementType: *ref_4
     language: !<!Languages> 
       default:
-        name: ArrayOfArrayOfstring
+        name: ArrayOfString
         description: a null array
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_5
@@ -534,13 +530,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: put-content-schema-itemsItem
+          name: PutContentSchemaItemsItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of put-content-schema-itemsItem
-        description: ''
+        name: ArrayOfPutContentSchemaItemsItem
+        description: Array of PutContentSchemaItemsItem
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_63
     type: array
@@ -550,7 +546,7 @@ schemas: !<!Schemas>
     elementType: *ref_5
     language: !<!Languages> 
       default:
-        name: ArrayOfArray of put-content-schema-itemsItem
+        name: ArrayOfPutContentSchemaItemsItem
         description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_65
@@ -561,7 +557,7 @@ schemas: !<!Schemas>
     elementType: *ref_6
     language: !<!Languages> 
       default:
-        name: ArrayOfDictionary of string
+        name: ArrayOfDictionaryOfString
         description: An array of Dictionaries with value null
     protocol: !<!Protocols> {}
   booleans:
@@ -665,7 +661,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null array value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -715,7 +711,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: 'Get invalid array [1, 2, 3'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -765,7 +761,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: 'Get empty array value []'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -831,7 +827,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmpty
+        name: PutEmpty
         description: 'Set array value empty []'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -881,7 +877,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanTfft
+        name: GetBooleanTfft
         description: 'Get boolean array value [true, false, false, true]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -947,7 +943,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBooleanTfft
+        name: PutBooleanTfft
         description: 'Set array value empty [true, false, false, true]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -997,7 +993,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanInvalidNull
+        name: GetBooleanInvalidNull
         description: 'Get boolean array value [true, null, false]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1047,7 +1043,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanInvalidString
+        name: GetBooleanInvalidString
         description: 'Get boolean array value [true, ''boolean'', false]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1097,7 +1093,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntegerValid
+        name: GetIntegerValid
         description: 'Get integer array value [1, -1, 3, 300]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1163,7 +1159,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putIntegerValid
+        name: PutIntegerValid
         description: 'Set array value empty [1, -1, 3, 300]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1213,7 +1209,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntInvalidNull
+        name: GetIntInvalidNull
         description: 'Get integer array value [1, null, 0]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1263,7 +1259,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntInvalidString
+        name: GetIntInvalidString
         description: 'Get integer array value [1, ''integer'', 0]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1313,7 +1309,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLongValid
+        name: GetLongValid
         description: 'Get integer array value [1, -1, 3, 300]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1379,7 +1375,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putLongValid
+        name: PutLongValid
         description: 'Set array value empty [1, -1, 3, 300]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1429,7 +1425,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLongInvalidNull
+        name: GetLongInvalidNull
         description: 'Get long array value [1, null, 0]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1479,7 +1475,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLongInvalidString
+        name: GetLongInvalidString
         description: 'Get long array value [1, ''integer'', 0]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1529,7 +1525,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFloatValid
+        name: GetFloatValid
         description: 'Get float array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1595,7 +1591,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putFloatValid
+        name: PutFloatValid
         description: 'Set array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1645,7 +1641,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFloatInvalidNull
+        name: GetFloatInvalidNull
         description: 'Get float array value [0.0, null, -1.2e20]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1695,7 +1691,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFloatInvalidString
+        name: GetFloatInvalidString
         description: 'Get boolean array value [1.0, ''number'', 0.0]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1745,7 +1741,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDoubleValid
+        name: GetDoubleValid
         description: 'Get float array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1811,7 +1807,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDoubleValid
+        name: PutDoubleValid
         description: 'Set array value [0, -0.01, 1.2e20]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1861,7 +1857,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDoubleInvalidNull
+        name: GetDoubleInvalidNull
         description: 'Get float array value [0.0, null, -1.2e20]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1911,7 +1907,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDoubleInvalidString
+        name: GetDoubleInvalidString
         description: 'Get boolean array value [1.0, ''number'', 0.0]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1961,7 +1957,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getStringValid
+        name: GetStringValid
         description: 'Get string array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2027,7 +2023,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putStringValid
+        name: PutStringValid
         description: 'Set array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2077,7 +2073,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEnumValid
+        name: GetEnumValid
         description: 'Get enum array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2143,7 +2139,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEnumValid
+        name: PutEnumValid
         description: 'Set array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2193,7 +2189,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getStringEnumValid
+        name: GetStringEnumValid
         description: 'Get enum array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2259,7 +2255,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putStringEnumValid
+        name: PutStringEnumValid
         description: 'Set array value [''foo1'', ''foo2'', ''foo3'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2309,7 +2305,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getStringWithNull
+        name: GetStringWithNull
         description: 'Get string array value [''foo'', null, ''foo2'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2359,7 +2355,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getStringWithInvalid
+        name: GetStringWithInvalid
         description: 'Get string array value [''foo'', 123, ''foo2'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2409,7 +2405,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUuidValid
+        name: GetUuidValid
         description: 'Get uuid array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2475,7 +2471,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putUuidValid
+        name: PutUuidValid
         description: 'Set array value  [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2525,7 +2521,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUuidInvalidChars
+        name: GetUuidInvalidChars
         description: 'Get uuid array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''foo'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2575,7 +2571,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateValid
+        name: GetDateValid
         description: 'Get integer array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2641,7 +2637,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateValid
+        name: PutDateValid
         description: 'Set array value  [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2691,7 +2687,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateInvalidNull
+        name: GetDateInvalidNull
         description: 'Get date array value [''2012-01-01'', null, ''1776-07-04'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2741,7 +2737,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateInvalidChars
+        name: GetDateInvalidChars
         description: 'Get date array value [''2011-03-22'', ''date'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2791,7 +2787,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeValid
+        name: GetDateTimeValid
         description: 'Get date-time array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2857,7 +2853,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateTimeValid
+        name: PutDateTimeValid
         description: 'Set array value  [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2907,7 +2903,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeInvalidNull
+        name: GetDateTimeInvalidNull
         description: 'Get date array value [''2000-12-01t00:00:01z'', null]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2957,7 +2953,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeInvalidChars
+        name: GetDateTimeInvalidChars
         description: 'Get date array value [''2000-12-01t00:00:01z'', ''date-time'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3007,7 +3003,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeRfc1123Valid
+        name: GetDateTimeRfc1123Valid
         description: 'Get date-time array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3073,7 +3069,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateTimeRfc1123Valid
+        name: PutDateTimeRfc1123Valid
         description: 'Set array value  [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3123,7 +3119,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDurationValid
+        name: GetDurationValid
         description: 'Get duration array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3189,7 +3185,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDurationValid
+        name: PutDurationValid
         description: 'Set array value  [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3239,7 +3235,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getByteValid
+        name: GetByteValid
         description: 'Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3305,7 +3301,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putByteValid
+        name: PutByteValid
         description: 'Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3355,7 +3351,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getByteInvalidNull
+        name: GetByteInvalidNull
         description: 'Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3405,7 +3401,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBase64Url
+        name: GetBase64Url
         description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3455,7 +3451,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexNull
+        name: GetComplexNull
         description: Get array of complex type null value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3505,7 +3501,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexEmpty
+        name: GetComplexEmpty
         description: 'Get empty array of complex type []'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3555,7 +3551,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexItemNull
+        name: GetComplexItemNull
         description: 'Get array of complex type with null item [{''integer'': 1 ''string'': ''2''}, null, {''integer'': 5, ''string'': ''6''}]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3605,7 +3601,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexItemEmpty
+        name: GetComplexItemEmpty
         description: 'Get array of complex type with empty item [{''integer'': 1 ''string'': ''2''}, {}, {''integer'': 5, ''string'': ''6''}]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3655,7 +3651,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexValid
+        name: GetComplexValid
         description: 'Get array of complex type with [{''integer'': 1 ''string'': ''2''}, {''integer'': 3, ''string'': ''4''}, {''integer'': 5, ''string'': ''6''}]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3721,7 +3717,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putComplexValid
+        name: PutComplexValid
         description: 'Put an array of complex type with values [{''integer'': 1 ''string'': ''2''}, {''integer'': 3, ''string'': ''4''}, {''integer'': 5, ''string'': ''6''}]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3771,7 +3767,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayNull
+        name: GetArrayNull
         description: Get a null array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3821,7 +3817,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayEmpty
+        name: GetArrayEmpty
         description: 'Get an empty array []'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3871,7 +3867,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayItemNull
+        name: GetArrayItemNull
         description: 'Get an array of array of strings [[''1'', ''2'', ''3''], null, [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3921,7 +3917,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayItemEmpty
+        name: GetArrayItemEmpty
         description: 'Get an array of array of strings [[''1'', ''2'', ''3''], [], [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3971,7 +3967,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayValid
+        name: GetArrayValid
         description: 'Get an array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4037,7 +4033,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putArrayValid
+        name: PutArrayValid
         description: 'Put An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4087,7 +4083,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryNull
+        name: GetDictionaryNull
         description: Get an array of Dictionaries with value null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4137,7 +4133,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryEmpty
+        name: GetDictionaryEmpty
         description: 'Get an array of Dictionaries of type <string, string> with value []'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4187,7 +4183,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryItemNull
+        name: GetDictionaryItemNull
         description: 'Get an array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, null, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4237,7 +4233,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryItemEmpty
+        name: GetDictionaryItemEmpty
         description: 'Get an array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4287,7 +4283,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryValid
+        name: GetDictionaryValid
         description: 'Get an array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {''4'': ''four'', ''5'': ''five'', ''6'': ''six''}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4353,12 +4349,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDictionaryValid
+        name: PutDictionaryValid
         description: 'Get an array of Dictionaries of type <string, string> with value [{''1'': ''one'', ''2'': ''two'', ''3'': ''three''}, {''4'': ''four'', ''5'': ''five'', ''6'': ''six''}, {''7'': ''seven'', ''8'': ''eight'', ''9'': ''nine''}]'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: array
+      name: Array
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_1
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -55,7 +53,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   numbers:
@@ -65,7 +63,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_1
@@ -139,7 +137,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getTrue
+        name: GetTrue
         description: Get true Boolean value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -205,7 +203,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putTrue
+        name: PutTrue
         description: Set Boolean value true
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -255,7 +253,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFalse
+        name: GetFalse
         description: Get false Boolean value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -321,7 +319,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putFalse
+        name: PutFalse
         description: Set Boolean value false
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -371,7 +369,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null Boolean value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -421,12 +419,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: Get invalid Boolean value
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: bool
+      name: Bool
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-boolean/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_2
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -52,7 +50,7 @@ schemas: !<!Schemas>
     type: boolean
     language: !<!Languages> 
       default:
-        name: bool
+        name: Bool
         description: simple boolean
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_8
@@ -62,7 +60,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   constants:
@@ -107,7 +105,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_2
@@ -181,7 +179,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getTrue
+        name: GetTrue
         description: Get true Boolean value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -246,7 +244,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putTrue
+        name: PutTrue
         description: Set Boolean value true
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -296,7 +294,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFalse
+        name: GetFalse
         description: Get false Boolean value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -361,7 +359,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putFalse
+        name: PutFalse
         description: Set Boolean value false
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -411,7 +409,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null Boolean value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -461,12 +459,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: Get invalid Boolean value
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: bool
+      name: Bool
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-byte/namer.yaml
+++ b/modelerfour/test/scenarios/body-byte/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_3
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -56,7 +54,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: The null byte value
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_1
@@ -67,7 +65,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: The empty byte value ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_7
@@ -78,7 +76,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: Non-ascii base-64 encoded byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
     protocol: !<!Protocols> {}
   constants:
@@ -123,7 +121,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_3
@@ -197,7 +195,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null byte value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -247,7 +245,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get empty byte value ''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -297,7 +295,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNonAscii
+        name: GetNonAscii
         description: Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -363,7 +361,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNonAscii
+        name: PutNonAscii
         description: Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -413,12 +411,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: 'Get invalid byte value '':::SWAGGER::::'''
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: byte
+      name: Byte
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: Basic Id
         protocol: !<!Protocols> {}
       serializedName: id
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Basic Id
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_59
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: basic-name
+            name: BasicName
             description: Name property with a very long description that does not fit on a single line and a line break.
         protocol: !<!Protocols> {}
       serializedName: name
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: Name property with a very long description that does not fit on a single line and a line break.
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ChoiceSchema> &ref_22
@@ -48,7 +46,7 @@ schemas: !<!Schemas>
           value: cyan
           language:
             default:
-              name: cyan
+              name: Cyan
               description: ''
         - !<!ChoiceValue> 
           value: Magenta
@@ -60,13 +58,13 @@ schemas: !<!Schemas>
           value: YELLOW
           language:
             default:
-              name: YELLOW
+              name: Yellow
               description: ''
         - !<!ChoiceValue> 
           value: blacK
           language:
             default:
-              name: blacK
+              name: BlacK
               description: ''
         type: choice
         apiVersions:
@@ -76,12 +74,12 @@ schemas: !<!Schemas>
           type: string
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: simple string
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CMYKColors
+            name: CmykColors
             description: ''
         protocol: !<!Protocols> {}
       serializedName: color
@@ -89,11 +87,10 @@ schemas: !<!Schemas>
         default:
           name: color
           description: ''
-          originalName: color
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: basic
+        name: Basic
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -109,7 +106,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -117,7 +114,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_60
@@ -127,7 +123,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -135,7 +131,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -155,7 +150,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForfield1
+            name: TypeForfield1
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field1
@@ -163,7 +158,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: ''
-          originalName: field1
       protocol: !<!Protocols> {}
     - !<!Property> &ref_89
       schema: !<!NumberSchema> &ref_47
@@ -171,7 +165,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForfield2
+            name: TypeForfield2
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field2
@@ -179,11 +173,10 @@ schemas: !<!Schemas>
         default:
           name: field2
           description: ''
-          originalName: field2
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: int-wrapper
+        name: IntWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -199,7 +192,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: typeForfield1
+            name: TypeForfield1
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field1
@@ -207,7 +200,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: ''
-          originalName: field1
       protocol: !<!Protocols> {}
     - !<!Property> &ref_95
       schema: !<!NumberSchema> &ref_49
@@ -215,7 +207,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: typeForfield2
+            name: TypeForfield2
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field2
@@ -223,11 +215,10 @@ schemas: !<!Schemas>
         default:
           name: field2
           description: ''
-          originalName: field2
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: long-wrapper
+        name: LongWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -243,7 +234,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForfield1
+            name: TypeForfield1
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field1
@@ -251,7 +242,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: ''
-          originalName: field1
       protocol: !<!Protocols> {}
     - !<!Property> &ref_101
       schema: !<!NumberSchema> &ref_51
@@ -259,7 +249,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForfield2
+            name: TypeForfield2
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field2
@@ -267,11 +257,10 @@ schemas: !<!Schemas>
         default:
           name: field2
           description: ''
-          originalName: field2
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: float-wrapper
+        name: FloatWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -287,7 +276,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: typeForfield1
+            name: TypeForfield1
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field1
@@ -295,7 +284,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: ''
-          originalName: field1
       protocol: !<!Protocols> {}
     - !<!Property> &ref_107
       schema: !<!NumberSchema> &ref_53
@@ -303,7 +291,7 @@ schemas: !<!Schemas>
         precision: 64
         language: !<!Languages> 
           default:
-            name: typeForfield_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
+            name: TypeForfield56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
@@ -311,11 +299,10 @@ schemas: !<!Schemas>
         default:
           name: field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
           description: ''
-          originalName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: double-wrapper
+        name: DoubleWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -330,7 +317,7 @@ schemas: !<!Schemas>
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForfield_true
+            name: TypeForfieldTrue
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field_true
@@ -338,14 +325,13 @@ schemas: !<!Schemas>
         default:
           name: fieldTrue
           description: ''
-          originalName: field_true
       protocol: !<!Protocols> {}
     - !<!Property> &ref_113
       schema: !<!BooleanSchema> &ref_30
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForfield_false
+            name: TypeForfieldFalse
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field_false
@@ -353,11 +339,10 @@ schemas: !<!Schemas>
         default:
           name: fieldFalse
           description: ''
-          originalName: field_false
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: boolean-wrapper
+        name: BooleanWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -375,7 +360,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: string-wrapper-field
+            name: StringWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -383,7 +368,6 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_62
@@ -393,7 +377,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: string-wrapper-empty
+            name: StringWrapperEmpty
             description: ''
         protocol: !<!Protocols> {}
       serializedName: empty
@@ -401,7 +385,6 @@ schemas: !<!Schemas>
         default:
           name: empty
           description: ''
-          originalName: empty
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_63
@@ -411,7 +394,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: string-wrapper-null
+            name: StringWrapperNull
             description: ''
         protocol: !<!Protocols> {}
       serializedName: 'null'
@@ -419,11 +402,10 @@ schemas: !<!Schemas>
         default:
           name: 'null'
           description: ''
-          originalName: 'null'
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: string-wrapper
+        name: StringWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -441,7 +423,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: date-wrapper-field
+            name: DateWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -449,7 +431,6 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     - !<!Property> &ref_121
       schema: !<!DateSchema> &ref_42
@@ -459,7 +440,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: date-wrapper-leap
+            name: DateWrapperLeap
             description: ''
         protocol: !<!Protocols> {}
       serializedName: leap
@@ -467,11 +448,10 @@ schemas: !<!Schemas>
         default:
           name: leap
           description: ''
-          originalName: leap
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: date-wrapper
+        name: DateWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -490,7 +470,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: datetime-wrapper-field
+            name: DatetimeWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -498,7 +478,6 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     - !<!Property> &ref_127
       schema: !<!DateTimeSchema> &ref_37
@@ -509,7 +488,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: datetime-wrapper-now
+            name: DatetimeWrapperNow
             description: ''
         protocol: !<!Protocols> {}
       serializedName: now
@@ -517,11 +496,10 @@ schemas: !<!Schemas>
         default:
           name: now
           description: ''
-          originalName: now
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: datetime-wrapper
+        name: DatetimeWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -540,7 +518,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: datetimerfc1123-wrapper-field
+            name: Datetimerfc1123WrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -548,7 +526,6 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     - !<!Property> &ref_133
       schema: !<!DateTimeSchema> &ref_39
@@ -559,7 +536,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: datetimerfc1123-wrapper-now
+            name: Datetimerfc1123WrapperNow
             description: ''
         protocol: !<!Protocols> {}
       serializedName: now
@@ -567,11 +544,10 @@ schemas: !<!Schemas>
         default:
           name: now
           description: ''
-          originalName: now
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: datetimerfc1123-wrapper
+        name: Datetimerfc1123Wrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -589,7 +565,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: duration-wrapper-field
+            name: DurationWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -597,11 +573,10 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: duration-wrapper
+        name: DurationWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -620,7 +595,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: byte-wrapper-field
+            name: ByteWrapperField
             description: ''
         protocol: !<!Protocols> {}
       serializedName: field
@@ -628,11 +603,10 @@ schemas: !<!Schemas>
         default:
           name: field
           description: ''
-          originalName: field
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: byte-wrapper
+        name: ByteWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -655,24 +629,23 @@ schemas: !<!Schemas>
             version: '2016-02-29'
           language: !<!Languages> 
             default:
-              name: array-wrapper-arrayItem
+              name: ArrayWrapperArrayItem
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: array-wrapper-array
-            description: ''
+            name: ArrayWrapperArray
+            description: Array of ArrayWrapperArrayItem
         protocol: !<!Protocols> {}
       serializedName: array
       language: !<!Languages> 
         default:
           name: array
           description: ''
-          originalName: array
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: array-wrapper
+        name: ArrayWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -692,24 +665,23 @@ schemas: !<!Schemas>
             version: '2016-02-29'
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Dictionary of string
-            description: Dictionary of <components·schemas·dictionary_wrapper·properties·defaultprogram·additionalproperties>
+            name: DictionaryWrapperDefaultProgram
+            description: Dictionary of String
         protocol: !<!Protocols> {}
       serializedName: defaultProgram
       language: !<!Languages> 
         default:
           name: defaultProgram
           description: Dictionary of <components·schemas·dictionary_wrapper·properties·defaultprogram·additionalproperties>
-          originalName: defaultProgram
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: dictionary-wrapper
+        name: DictionaryWrapper
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -739,7 +711,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: dog-food
+                name: DogFood
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: food
@@ -747,11 +719,10 @@ schemas: !<!Schemas>
             default:
               name: food
               description: ''
-              originalName: food
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: dog
+            name: Dog
             description: ''
             namespace: Api20160229
         protocol: !<!Protocols> {}
@@ -782,7 +753,7 @@ schemas: !<!Schemas>
                   version: '2016-02-29'
                 language: !<!Languages> 
                   default:
-                    name: siamese-breed
+                    name: SiameseBreed
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: breed
@@ -790,11 +761,10 @@ schemas: !<!Schemas>
                 default:
                   name: breed
                   description: ''
-                  originalName: breed
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: siamese
+                name: Siamese
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -814,7 +784,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: cat-color
+                name: CatColor
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: color
@@ -822,7 +792,6 @@ schemas: !<!Schemas>
             default:
               name: color
               description: ''
-              originalName: color
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ArraySchema> &ref_25
@@ -833,19 +802,18 @@ schemas: !<!Schemas>
             elementType: *ref_3
             language: !<!Languages> 
               default:
-                name: cat-hates
-                description: ''
+                name: CatHates
+                description: Array of dog
             protocol: !<!Protocols> {}
           serializedName: hates
           language: !<!Languages> 
             default:
               name: hates
               description: ''
-              originalName: hates
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: cat
+            name: Cat
             description: ''
             namespace: Api20160229
         protocol: !<!Protocols> {}
@@ -860,7 +828,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       serializedName: id
@@ -868,7 +836,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_66
@@ -878,7 +845,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: pet-name
+            name: PetName
             description: ''
         protocol: !<!Protocols> {}
       serializedName: name
@@ -886,11 +853,10 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: pet
+        name: Pet
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -931,7 +897,7 @@ schemas: !<!Schemas>
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
-                    name: smart_salmon
+                    name: SmartSalmon
                     description: Dictionary of <any>
                 protocol: !<!Protocols> {}
               - *ref_5
@@ -948,7 +914,7 @@ schemas: !<!Schemas>
                   version: '2016-02-29'
                 language: !<!Languages> 
                   default:
-                    name: smart_salmon-college_degree
+                    name: SmartSalmonCollegeDegree
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: college_degree
@@ -956,11 +922,10 @@ schemas: !<!Schemas>
                 default:
                   name: collegeDegree
                   description: ''
-                  originalName: college_degree
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: smart_salmon
+                name: SmartSalmon
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -979,7 +944,7 @@ schemas: !<!Schemas>
                 version: '2016-02-29'
               language: !<!Languages> 
                 default:
-                  name: Fish-fishtype
+                  name: FishFishtype
                   description: ''
               protocol: !<!Protocols> {}
             isDiscriminator: true
@@ -989,7 +954,6 @@ schemas: !<!Schemas>
               default:
                 name: fishtype
                 description: ''
-                originalName: fishtype
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
         parents: !<!Relations> 
@@ -1006,7 +970,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: salmon-location
+                name: SalmonLocation
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: location
@@ -1014,14 +978,13 @@ schemas: !<!Schemas>
             default:
               name: location
               description: ''
-              originalName: location
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_32
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForiswild
+                name: TypeForiswild
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: iswild
@@ -1029,11 +992,10 @@ schemas: !<!Schemas>
             default:
               name: iswild
               description: ''
-              originalName: iswild
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: salmon
+            name: Salmon
             description: ''
             namespace: Api20160229
         protocol: !<!Protocols> {}
@@ -1067,7 +1029,7 @@ schemas: !<!Schemas>
                   version: '2016-02-29'
                 language: !<!Languages> 
                   default:
-                    name: sawshark-picture
+                    name: SawsharkPicture
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: picture
@@ -1075,11 +1037,10 @@ schemas: !<!Schemas>
                 default:
                   name: picture
                   description: ''
-                  originalName: picture
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: sawshark
+                name: Sawshark
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -1102,7 +1063,7 @@ schemas: !<!Schemas>
                 precision: 32
                 language: !<!Languages> 
                   default:
-                    name: typeForjawsize
+                    name: TypeForjawsize
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: jawsize
@@ -1110,7 +1071,6 @@ schemas: !<!Schemas>
                 default:
                   name: jawsize
                   description: ''
-                  originalName: jawsize
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!ChoiceSchema> &ref_23
@@ -1119,31 +1079,31 @@ schemas: !<!Schemas>
                   value: pink
                   language:
                     default:
-                      name: pink
+                      name: Pink
                       description: ''
                 - !<!ChoiceValue> 
                   value: gray
                   language:
                     default:
-                      name: gray
+                      name: Gray
                       description: ''
                 - !<!ChoiceValue> 
                   value: brown
                   language:
                     default:
-                      name: brown
+                      name: Brown
                       description: ''
                 - !<!ChoiceValue> 
                   value: RED
                   language:
                     default:
-                      name: upperRed
+                      name: UpperRed
                       description: Uppercase RED
                 - !<!ChoiceValue> 
                   value: red
                   language:
                     default:
-                      name: lowerRed
+                      name: LowerRed
                       description: Lowercase RED
                 type: choice
                 apiVersions:
@@ -1161,13 +1121,12 @@ schemas: !<!Schemas>
                 default:
                   name: color
                   description: Colors possible
-                  originalName: color
               protocol: !<!Protocols> {}
             extensions:
               x-ms-discriminator-value: goblin
             language: !<!Languages> 
               default:
-                name: goblinshark
+                name: Goblinshark
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -1185,7 +1144,7 @@ schemas: !<!Schemas>
               - *ref_8
             language: !<!Languages> 
               default:
-                name: cookiecuttershark
+                name: Cookiecuttershark
                 description: ''
                 namespace: Api20160229
             protocol: !<!Protocols> {}
@@ -1216,7 +1175,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeForage
+                name: TypeForage
                 description: ''
             protocol: !<!Protocols> {}
           required: false
@@ -1225,7 +1184,6 @@ schemas: !<!Schemas>
             default:
               name: age
               description: ''
-              originalName: age
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!DateTimeSchema> &ref_40
@@ -1236,7 +1194,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: shark-birthday
+                name: SharkBirthday
                 description: ''
             protocol: !<!Protocols> {}
           required: true
@@ -1245,11 +1203,10 @@ schemas: !<!Schemas>
             default:
               name: birthday
               description: ''
-              originalName: birthday
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: shark
+            name: Shark
             description: ''
             namespace: Api20160229
         protocol: !<!Protocols> {}
@@ -1281,7 +1238,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: Fish-species
+            name: FishSpecies
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -1290,7 +1247,6 @@ schemas: !<!Schemas>
         default:
           name: species
           description: ''
-          originalName: species
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!NumberSchema> &ref_55
@@ -1298,7 +1254,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForlength
+            name: TypeForlength
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -1307,7 +1263,6 @@ schemas: !<!Schemas>
         default:
           name: length
           description: ''
-          originalName: length
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_26
@@ -1318,8 +1273,8 @@ schemas: !<!Schemas>
         elementType: *ref_5
         language: !<!Languages> 
           default:
-            name: Fish-siblings
-            description: ''
+            name: FishSiblings
+            description: Array of Fish
         protocol: !<!Protocols> {}
       required: false
       serializedName: siblings
@@ -1327,7 +1282,6 @@ schemas: !<!Schemas>
         default:
           name: siblings
           description: ''
-          originalName: siblings
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1362,7 +1316,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: DotSalmon-location
+                name: DotSalmonLocation
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: location
@@ -1370,14 +1324,13 @@ schemas: !<!Schemas>
             default:
               name: location
               description: ''
-              originalName: location
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_31
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForiswild
+                name: TypeForiswild
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: iswild
@@ -1385,7 +1338,6 @@ schemas: !<!Schemas>
             default:
               name: iswild
               description: ''
-              originalName: iswild
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -1408,7 +1360,7 @@ schemas: !<!Schemas>
             version: '2016-02-29'
           language: !<!Languages> 
             default:
-              name: DotFish-fish.type
+              name: DotFishType
               description: ''
           protocol: !<!Protocols> {}
         isDiscriminator: true
@@ -1418,7 +1370,6 @@ schemas: !<!Schemas>
           default:
             name: fishType
             description: ''
-            originalName: fish.type
         protocol: !<!Protocols> {}
     properties:
     - *ref_16
@@ -1430,7 +1381,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: DotFish-species
+            name: DotFishSpecies
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -1439,7 +1390,6 @@ schemas: !<!Schemas>
         default:
           name: species
           description: ''
-          originalName: species
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1460,7 +1410,6 @@ schemas: !<!Schemas>
         default:
           name: sampleSalmon
           description: ''
-          originalName: sampleSalmon
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_27
@@ -1471,15 +1420,14 @@ schemas: !<!Schemas>
         elementType: *ref_15
         language: !<!Languages> 
           default:
-            name: DotFishMarket-salmons
-            description: ''
+            name: DotFishMarketSalmons
+            description: Array of DotSalmon
         protocol: !<!Protocols> {}
       serializedName: salmons
       language: !<!Languages> 
         default:
           name: salmons
           description: ''
-          originalName: salmons
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_14
@@ -1488,7 +1436,6 @@ schemas: !<!Schemas>
         default:
           name: sampleFish
           description: ''
-          originalName: sampleFish
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_28
@@ -1499,15 +1446,14 @@ schemas: !<!Schemas>
         elementType: *ref_14
         language: !<!Languages> 
           default:
-            name: DotFishMarket-fishes
-            description: ''
+            name: DotFishMarketFishes
+            description: Array of DotFish
         protocol: !<!Protocols> {}
       serializedName: fishes
       language: !<!Languages> 
         default:
           name: fishes
           description: ''
-          originalName: fishes
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1531,7 +1477,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: readonly-obj-id
+            name: ReadonlyObjId
             description: ''
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1540,7 +1486,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> &ref_165
       schema: !<!NumberSchema> &ref_56
@@ -1548,7 +1493,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForsize
+            name: TypeForsize
             description: ''
         protocol: !<!Protocols> {}
       serializedName: size
@@ -1556,11 +1501,10 @@ schemas: !<!Schemas>
         default:
           name: size
           description: ''
-          originalName: size
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: readonly-obj
+        name: ReadonlyObj
         description: ''
         namespace: Api20160229
     protocol: !<!Protocols> {}
@@ -1591,7 +1535,7 @@ schemas: !<!Schemas>
               version: '2016-02-29'
             language: !<!Languages> 
               default:
-                name: MyDerivedType-propD1
+                name: MyDerivedTypePropD1
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: propD1
@@ -1599,7 +1543,6 @@ schemas: !<!Schemas>
             default:
               name: propD1
               description: ''
-              originalName: propD1
           protocol: !<!Protocols> {}
         extensions:
           x-ms-discriminator-value: Kind1
@@ -1641,7 +1584,6 @@ schemas: !<!Schemas>
           default:
             name: kind
             description: ''
-            originalName: kind
         protocol: !<!Protocols> {}
     properties:
     - *ref_19
@@ -1653,7 +1595,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: MyBaseType-propB1
+            name: MyBaseTypePropB1
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -1662,7 +1604,6 @@ schemas: !<!Schemas>
         default:
           name: propB1
           description: ''
-          originalName: propB1
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_20
@@ -1672,7 +1613,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
         language: !<!Languages> 
           default:
-            name: MyBaseHelperType-propBH1
+            name: MyBaseHelperTypePropBh1
             description: ''
         protocol: !<!Protocols> {}
       flattenedNames:
@@ -1682,9 +1623,8 @@ schemas: !<!Schemas>
       serializedName: propBH1
       language: !<!Languages> 
         default:
-          name: propBH1
+          name: propBh1
           description: ''
-          originalName: propBH1
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1703,9 +1643,8 @@ schemas: !<!Schemas>
       serializedName: propBH1
       language: !<!Languages> 
         default:
-          name: propBH1
+          name: propBh1
           description: ''
-          originalName: propBH1
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -1753,7 +1692,7 @@ schemas: !<!Schemas>
     valueType: *ref_9
     language: !<!Languages> 
       default:
-        name: ApiVersion-2016-02-29
+        name: ApiVersion20160229
         description: Api Version (2016-02-29)
     protocol: !<!Protocols> {}
   - *ref_35
@@ -1890,7 +1829,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: 'Get complex type {id: 2, name: ''abc'', color: ''YELLOW''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1957,7 +1896,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: 'Please put {id: 2, name: ''abc'', color: ''Magenta''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2007,7 +1946,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: Get a basic complex type that is invalid for the local strong type
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2057,7 +1996,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get a basic complex type that is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2107,7 +2046,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get a basic complex type whose properties are null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2157,12 +2096,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotProvided
+        name: GetNotProvided
         description: Get a basic complex type while the server doesn't provide a response payload
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: basic
+      name: Basic
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -2215,7 +2154,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInt
+        name: GetInt
         description: Get complex types with integer properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2307,7 +2246,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putInt
+        name: PutInt
         description: Put complex types with integer properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2357,7 +2296,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLong
+        name: GetLong
         description: Get complex types with long properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2449,7 +2388,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putLong
+        name: PutLong
         description: Put complex types with long properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2499,7 +2438,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFloat
+        name: GetFloat
         description: Get complex types with float properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2591,7 +2530,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putFloat
+        name: PutFloat
         description: Put complex types with float properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2641,7 +2580,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDouble
+        name: GetDouble
         description: Get complex types with double properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2687,7 +2626,7 @@ operationGroups:
         targetProperty: *ref_107
         language: !<!Languages> 
           default:
-            name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
+            name: field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
             description: ''
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -2733,7 +2672,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDouble
+        name: PutDouble
         description: Put complex types with double properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2783,7 +2722,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBool
+        name: GetBool
         description: Get complex types with bool properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2817,7 +2756,7 @@ operationGroups:
         targetProperty: *ref_112
         language: !<!Languages> 
           default:
-            name: field_true
+            name: fieldTrue
             description: ''
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_115
@@ -2829,7 +2768,7 @@ operationGroups:
         targetProperty: *ref_113
         language: !<!Languages> 
           default:
-            name: field_false
+            name: fieldFalse
             description: ''
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -2875,7 +2814,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBool
+        name: PutBool
         description: Put complex types with bool properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2925,7 +2864,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getString
+        name: GetString
         description: Get complex types with string properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2991,7 +2930,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putString
+        name: PutString
         description: Put complex types with string properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3041,7 +2980,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDate
+        name: GetDate
         description: Get complex types with date properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3133,7 +3072,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDate
+        name: PutDate
         description: Put complex types with date properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3183,7 +3122,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTime
+        name: GetDateTime
         description: Get complex types with datetime properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3275,7 +3214,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateTime
+        name: PutDateTime
         description: Put complex types with datetime properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3325,7 +3264,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeRfc1123
+        name: GetDateTimeRfc1123
         description: Get complex types with datetimeRfc1123 properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3417,7 +3356,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateTimeRfc1123
+        name: PutDateTimeRfc1123
         description: Put complex types with datetimeRfc1123 properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3467,7 +3406,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDuration
+        name: GetDuration
         description: Get complex types with duration properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3546,7 +3485,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDuration
+        name: PutDuration
         description: Put complex types with duration properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3596,7 +3535,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getByte
+        name: GetByte
         description: Get complex types with byte properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3675,12 +3614,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putByte
+        name: PutByte
         description: Put complex types with byte properties
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: primitive
+      name: Primitive
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -3733,7 +3672,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types with array property
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3812,7 +3751,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types with array property
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3862,7 +3801,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get complex types with array property which is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3941,7 +3880,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmpty
+        name: PutEmpty
         description: Put complex types with array property which is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3991,12 +3930,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotProvided
+        name: GetNotProvided
         description: Get complex types with array property while server doesn't provide a response payload
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: array
+      name: Array
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4049,7 +3988,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types with dictionary property
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4128,7 +4067,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types with dictionary property
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4178,7 +4117,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get complex types with dictionary property which is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4257,7 +4196,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmpty
+        name: PutEmpty
         description: Put complex types with dictionary property which is empty
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4307,7 +4246,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get complex types with dictionary property which is null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4357,12 +4296,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotProvided
+        name: GetNotProvided
         description: Get complex types with dictionary property while server doesn't provide a response payload
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: dictionary
+      name: Dictionary
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4415,7 +4354,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types that extend others
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4481,12 +4420,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types that extend others
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: inheritance
+      name: Inheritance
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4539,7 +4478,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types that are polymorphic
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4638,7 +4577,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types that are polymorphic
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4688,7 +4627,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDotSyntax
+        name: GetDotSyntax
         description: 'Get complex types that are polymorphic, JSON key contains a dot'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4738,7 +4677,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComposedWithDiscriminator
+        name: GetComposedWithDiscriminator
         description: 'Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4788,7 +4727,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComposedWithoutDiscriminator
+        name: GetComposedWithoutDiscriminator
         description: 'Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4838,7 +4777,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplicated
+        name: GetComplicated
         description: 'Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4904,7 +4843,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putComplicated
+        name: PutComplicated
         description: 'Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4974,7 +4913,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMissingDiscriminator
+        name: PutMissingDiscriminator
         description: 'Put complex types that are polymorphic, omitting the discriminator'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5073,12 +5012,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValidMissingRequired
+        name: PutValidMissingRequired
         description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: polymorphism
+      name: Polymorphism
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -5131,7 +5070,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types that are polymorphic and have recursive references
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5230,12 +5169,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types that are polymorphic and have recursive references
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: polymorphicrecursive
+      name: Polymorphicrecursive
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -5288,7 +5227,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: Get complex types that have readonly properties
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5367,12 +5306,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putValid
+        name: PutValid
         description: Put complex types that have readonly properties
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: readonlyproperty
+      name: Readonlyproperty
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -5411,12 +5350,12 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getValid
+        name: GetValid
         description: ''
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: flattencomplex
+      name: Flattencomplex
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-date/namer.yaml
+++ b/modelerfour/test/scenarios/body-date/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_2
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -66,7 +64,7 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date
+          name: Date
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -82,7 +80,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: date
+        name: Date
         description: ''
     protocol: !<!Protocols> {}
   - *ref_0
@@ -93,7 +91,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_2
@@ -167,7 +165,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null date value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -217,7 +215,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalidDate
+        name: GetInvalidDate
         description: Get invalid date value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -267,7 +265,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getOverflowDate
+        name: GetOverflowDate
         description: Get overflow date value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -317,7 +315,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUnderflowDate
+        name: GetUnderflowDate
         description: Get underflow date value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -383,7 +381,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMaxDate
+        name: PutMaxDate
         description: Put max date value 9999-12-31
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -433,7 +431,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMaxDate
+        name: GetMaxDate
         description: Get max date value 9999-12-31
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -499,7 +497,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMinDate
+        name: PutMinDate
         description: Put min date value 0000-01-01
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -549,12 +547,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMinDate
+        name: GetMinDate
         description: Get min date value 0000-01-01
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: date
+      name: Date
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_2
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -67,7 +65,7 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -84,7 +82,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
     protocol: !<!Protocols> {}
   - *ref_0
@@ -95,7 +93,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_2
@@ -169,7 +167,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null datetime value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -219,7 +217,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: Get invalid datetime value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -269,7 +267,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getOverflow
+        name: GetOverflow
         description: Get overflow datetime value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -319,7 +317,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUnderflow
+        name: GetUnderflow
         description: Get underflow datetime value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -385,7 +383,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putUtcMaxDateTime
+        name: PutUtcMaxDateTime
         description: 'Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -435,7 +433,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUtcLowercaseMaxDateTime
+        name: GetUtcLowercaseMaxDateTime
         description: 'Get max datetime value fri, 31 dec 9999 23:59:59 gmt'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -485,7 +483,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUtcUppercaseMaxDateTime
+        name: GetUtcUppercaseMaxDateTime
         description: 'Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -551,7 +549,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putUtcMinDateTime
+        name: PutUtcMinDateTime
         description: 'Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -601,12 +599,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUtcMinDateTime
+        name: GetUtcMinDateTime
         description: 'Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: datetimerfc1123
+      name: Datetimerfc1123
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-datetime/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_3
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -67,7 +65,7 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -94,7 +92,7 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -111,7 +109,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
     protocol: !<!Protocols> {}
   - *ref_0
@@ -123,7 +121,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_3
@@ -197,7 +195,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null datetime value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -247,7 +245,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: Get invalid datetime value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -297,7 +295,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getOverflow
+        name: GetOverflow
         description: Get overflow datetime value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -347,7 +345,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUnderflow
+        name: GetUnderflow
         description: Get underflow datetime value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -413,7 +411,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putUtcMaxDateTime
+        name: PutUtcMaxDateTime
         description: 'Put max datetime value 9999-12-31T23:59:59.999Z'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -479,7 +477,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putUtcMaxDateTime7Digits
+        name: PutUtcMaxDateTime7Digits
         description: 'Put max datetime value 9999-12-31T23:59:59.9999999Z'
         summary: 'This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario'
     protocol: !<!Protocols> {}
@@ -530,7 +528,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUtcLowercaseMaxDateTime
+        name: GetUtcLowercaseMaxDateTime
         description: 'Get max datetime value 9999-12-31t23:59:59.999z'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -580,7 +578,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUtcUppercaseMaxDateTime
+        name: GetUtcUppercaseMaxDateTime
         description: 'Get max datetime value 9999-12-31T23:59:59.999Z'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -630,7 +628,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUtcUppercaseMaxDateTime7Digits
+        name: GetUtcUppercaseMaxDateTime7Digits
         description: 'Get max datetime value 9999-12-31T23:59:59.9999999Z'
         summary: 'This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario'
     protocol: !<!Protocols> {}
@@ -697,7 +695,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putLocalPositiveOffsetMaxDateTime
+        name: PutLocalPositiveOffsetMaxDateTime
         description: 'Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -747,7 +745,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLocalPositiveOffsetLowercaseMaxDateTime
+        name: GetLocalPositiveOffsetLowercaseMaxDateTime
         description: 'Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -797,7 +795,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLocalPositiveOffsetUppercaseMaxDateTime
+        name: GetLocalPositiveOffsetUppercaseMaxDateTime
         description: 'Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -863,7 +861,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putLocalNegativeOffsetMaxDateTime
+        name: PutLocalNegativeOffsetMaxDateTime
         description: 'Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -913,7 +911,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLocalNegativeOffsetUppercaseMaxDateTime
+        name: GetLocalNegativeOffsetUppercaseMaxDateTime
         description: 'Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -963,7 +961,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLocalNegativeOffsetLowercaseMaxDateTime
+        name: GetLocalNegativeOffsetLowercaseMaxDateTime
         description: 'Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1029,7 +1027,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putUtcMinDateTime
+        name: PutUtcMinDateTime
         description: 'Put min datetime value 0001-01-01T00:00:00Z'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1079,7 +1077,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUtcMinDateTime
+        name: GetUtcMinDateTime
         description: 'Get min datetime value 0001-01-01T00:00:00Z'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1145,7 +1143,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putLocalPositiveOffsetMinDateTime
+        name: PutLocalPositiveOffsetMinDateTime
         description: 'Put min datetime value 0001-01-01T00:00:00+14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1195,7 +1193,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLocalPositiveOffsetMinDateTime
+        name: GetLocalPositiveOffsetMinDateTime
         description: 'Get min datetime value 0001-01-01T00:00:00+14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1261,7 +1259,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putLocalNegativeOffsetMinDateTime
+        name: PutLocalNegativeOffsetMinDateTime
         description: 'Put min datetime value 0001-01-01T00:00:00-14:00'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1311,12 +1309,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLocalNegativeOffsetMinDateTime
+        name: GetLocalNegativeOffsetMinDateTime
         description: 'Get min datetime value 0001-01-01T00:00:00-14:00'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: datetime
+      name: Datetime
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-dictionary/namer.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_18
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -59,7 +57,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForinteger
+            name: TypeForinteger
             description: ''
         protocol: !<!Protocols> {}
       serializedName: integer
@@ -67,7 +65,6 @@ schemas: !<!Schemas>
         default:
           name: integer
           description: ''
-          originalName: integer
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_19
@@ -77,7 +74,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Widget-string
+            name: WidgetString
             description: ''
         protocol: !<!Protocols> {}
       serializedName: string
@@ -85,7 +82,6 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          originalName: string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -104,12 +100,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: integer
+          name: Integer
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfinteger
+        name: DictionaryOfInteger
         description: The null dictionary value
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_26
@@ -121,13 +117,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Dictionary of string
-        description: Dictionary of <paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties>
+        name: DictionaryOfString
+        description: Dictionary of String
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_28
     type: dictionary
@@ -138,12 +134,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: boolean
+          name: Boolean
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfboolean
+        name: DictionaryOfBoolean
         description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_31
@@ -156,12 +152,12 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: integer
+          name: Integer
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfinteger
+        name: DictionaryOfInteger
         description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_33
@@ -174,12 +170,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfnumber
+        name: DictionaryOfNumber
         description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_35
@@ -192,12 +188,12 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfnumber
+        name: DictionaryOfNumber
         description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_38
@@ -209,12 +205,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date
+          name: Date
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfdate
+        name: DictionaryOfDate
         description: 'The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_40
@@ -227,12 +223,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfdate-time
+        name: DictionaryOfDateTime
         description: 'The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_42
@@ -245,12 +241,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfdate-time
+        name: DictionaryOfDateTime
         description: 'The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_44
@@ -262,12 +258,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: duration
+          name: Duration
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfduration
+        name: DictionaryOfDuration
         description: 'The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_46
@@ -280,12 +276,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: byte-array
+          name: ByteArray
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfbyte-array
+        name: DictionaryOfByteArray
         description: 'The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_48
@@ -298,12 +294,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: byte-array
+          name: ByteArray
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfbyte-array
+        name: DictionaryOfByteArray
         description: 'The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_49
@@ -328,17 +324,17 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: get-200-application-json-additionalPropertiesItem
+            name: Get200ApplicationJsonAdditionalPropertiesItem
             description: ''
         protocol: !<!Protocols> {}
       language: !<!Languages> 
         default:
-          name: Array of get-200-application-json-additionalPropertiesItem
-          description: ''
+          name: ArrayOfGet200ApplicationJsonAdditionalPropertiesItem
+          description: Array of Get200ApplicationJsonAdditionalPropertiesItem
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfpaths·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
+        name: DictionaryOfpathsDictionaryArrayNullGetResponses200ContentApplicationJsonSchemaAdditionalproperties
         description: a null array
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_52
@@ -351,12 +347,12 @@ schemas: !<!Schemas>
       elementType: *ref_1
       language: !<!Languages> 
         default:
-          name: Array of string
-          description: ''
+          name: ArrayOfString
+          description: Array of String
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfpaths·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
+        name: DictionaryOfpathsDictionaryArrayEmptyGetResponses200ContentApplicationJsonSchemaAdditionalproperties
         description: 'An empty dictionary {}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_53
@@ -373,17 +369,17 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: put-content-schema-itemsItem
+            name: PutContentSchemaItemsItem
             description: ''
         protocol: !<!Protocols> {}
       language: !<!Languages> 
         default:
-          name: Array of put-content-schema-itemsItem
-          description: ''
+          name: ArrayOfPutContentSchemaItemsItem
+          description: Array of PutContentSchemaItemsItem
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: DictionaryOfpaths·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
+        name: DictionaryOfpathsDictionaryArrayValidPutRequestbodyContentApplicationJsonSchemaAdditionalproperties
         description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
     protocol: !<!Protocols> {}
   - !<!DictionarySchema> &ref_55
@@ -428,7 +424,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_18
@@ -506,7 +502,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null dictionary value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -556,7 +552,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: 'Get empty dictionary value {}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -622,7 +618,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmpty
+        name: PutEmpty
         description: 'Set dictionary value empty {}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -672,7 +668,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNullValue
+        name: GetNullValue
         description: Get Dictionary with null value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -722,7 +718,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNullKey
+        name: GetNullKey
         description: Get Dictionary with null key
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -772,7 +768,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmptyStringKey
+        name: GetEmptyStringKey
         description: Get Dictionary with key as empty string
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -822,7 +818,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: Get invalid Dictionary value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -872,7 +868,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanTfft
+        name: GetBooleanTfft
         description: 'Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -938,7 +934,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBooleanTfft
+        name: PutBooleanTfft
         description: 'Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -988,7 +984,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanInvalidNull
+        name: GetBooleanInvalidNull
         description: 'Get boolean dictionary value {"0": true, "1": null, "2": false }'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1038,7 +1034,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanInvalidString
+        name: GetBooleanInvalidString
         description: 'Get boolean dictionary value ''{"0": true, "1": "boolean", "2": false}'''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1088,7 +1084,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntegerValid
+        name: GetIntegerValid
         description: 'Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1154,7 +1150,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putIntegerValid
+        name: PutIntegerValid
         description: 'Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1204,7 +1200,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntInvalidNull
+        name: GetIntInvalidNull
         description: 'Get integer dictionary value {"0": 1, "1": null, "2": 0}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1254,7 +1250,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntInvalidString
+        name: GetIntInvalidString
         description: 'Get integer dictionary value {"0": 1, "1": "integer", "2": 0}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1304,7 +1300,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLongValid
+        name: GetLongValid
         description: 'Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1370,7 +1366,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putLongValid
+        name: PutLongValid
         description: 'Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1420,7 +1416,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLongInvalidNull
+        name: GetLongInvalidNull
         description: 'Get long dictionary value {"0": 1, "1": null, "2": 0}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1470,7 +1466,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLongInvalidString
+        name: GetLongInvalidString
         description: 'Get long dictionary value {"0": 1, "1": "integer", "2": 0}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1520,7 +1516,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFloatValid
+        name: GetFloatValid
         description: 'Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1586,7 +1582,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putFloatValid
+        name: PutFloatValid
         description: 'Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1636,7 +1632,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFloatInvalidNull
+        name: GetFloatInvalidNull
         description: 'Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1686,7 +1682,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getFloatInvalidString
+        name: GetFloatInvalidString
         description: 'Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1736,7 +1732,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDoubleValid
+        name: GetDoubleValid
         description: 'Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1802,7 +1798,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDoubleValid
+        name: PutDoubleValid
         description: 'Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1852,7 +1848,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDoubleInvalidNull
+        name: GetDoubleInvalidNull
         description: 'Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1902,7 +1898,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDoubleInvalidString
+        name: GetDoubleInvalidString
         description: 'Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1952,7 +1948,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getStringValid
+        name: GetStringValid
         description: 'Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2018,7 +2014,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putStringValid
+        name: PutStringValid
         description: 'Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2068,7 +2064,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getStringWithNull
+        name: GetStringWithNull
         description: 'Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2118,7 +2114,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getStringWithInvalid
+        name: GetStringWithInvalid
         description: 'Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2168,7 +2164,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateValid
+        name: GetDateValid
         description: 'Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2234,7 +2230,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateValid
+        name: PutDateValid
         description: 'Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2284,7 +2280,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateInvalidNull
+        name: GetDateInvalidNull
         description: 'Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2334,7 +2330,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateInvalidChars
+        name: GetDateInvalidChars
         description: 'Get date dictionary value {"0": "2011-03-22", "1": "date"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2384,7 +2380,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeValid
+        name: GetDateTimeValid
         description: 'Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2450,7 +2446,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateTimeValid
+        name: PutDateTimeValid
         description: 'Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2500,7 +2496,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeInvalidNull
+        name: GetDateTimeInvalidNull
         description: 'Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2550,7 +2546,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeInvalidChars
+        name: GetDateTimeInvalidChars
         description: 'Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2600,7 +2596,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDateTimeRfc1123Valid
+        name: GetDateTimeRfc1123Valid
         description: 'Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2666,7 +2662,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDateTimeRfc1123Valid
+        name: PutDateTimeRfc1123Valid
         description: 'Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2716,7 +2712,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDurationValid
+        name: GetDurationValid
         description: 'Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2782,7 +2778,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDurationValid
+        name: PutDurationValid
         description: 'Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2832,7 +2828,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getByteValid
+        name: GetByteValid
         description: 'Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2898,7 +2894,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putByteValid
+        name: PutByteValid
         description: 'Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2948,7 +2944,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getByteInvalidNull
+        name: GetByteInvalidNull
         description: 'Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2998,7 +2994,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBase64Url
+        name: GetBase64Url
         description: 'Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3048,7 +3044,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexNull
+        name: GetComplexNull
         description: Get dictionary of complex type null value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3098,7 +3094,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexEmpty
+        name: GetComplexEmpty
         description: 'Get empty dictionary of complex type {}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3148,7 +3144,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexItemNull
+        name: GetComplexItemNull
         description: 'Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3198,7 +3194,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexItemEmpty
+        name: GetComplexItemEmpty
         description: 'Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3248,7 +3244,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getComplexValid
+        name: GetComplexValid
         description: 'Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3314,7 +3310,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putComplexValid
+        name: PutComplexValid
         description: 'Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3364,7 +3360,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayNull
+        name: GetArrayNull
         description: Get a null array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3414,7 +3410,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayEmpty
+        name: GetArrayEmpty
         description: 'Get an empty dictionary {}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3464,7 +3460,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayItemNull
+        name: GetArrayItemNull
         description: 'Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3514,7 +3510,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayItemEmpty
+        name: GetArrayItemEmpty
         description: 'Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3564,7 +3560,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArrayValid
+        name: GetArrayValid
         description: 'Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3630,7 +3626,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putArrayValid
+        name: PutArrayValid
         description: 'Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3680,7 +3676,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryNull
+        name: GetDictionaryNull
         description: Get an dictionaries of dictionaries with value null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3730,7 +3726,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryEmpty
+        name: GetDictionaryEmpty
         description: 'Get an dictionaries of dictionaries of type <string, string> with value {}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3780,7 +3776,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryItemNull
+        name: GetDictionaryItemNull
         description: 'Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3830,7 +3826,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryItemEmpty
+        name: GetDictionaryItemEmpty
         description: 'Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3880,7 +3876,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionaryValid
+        name: GetDictionaryValid
         description: 'Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3946,12 +3942,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDictionaryValid
+        name: PutDictionaryValid
         description: 'Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: dictionary
+      name: Dictionary
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-duration/namer.yaml
+++ b/modelerfour/test/scenarios/body-duration/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_1
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -55,7 +53,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: duration
+        name: Duration
         description: ''
     protocol: !<!Protocols> {}
   numbers:
@@ -65,7 +63,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_1
@@ -139,7 +137,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null duration value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -205,7 +203,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putPositiveDuration
+        name: PutPositiveDuration
         description: Put a positive duration value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -255,7 +253,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getPositiveDuration
+        name: GetPositiveDuration
         description: Get a positive duration value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -305,12 +303,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: Get an invalid duration value
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: duration
+      name: Duration
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-file/namer.yaml
+++ b/modelerfour/test/scenarios/body-file/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_1
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -54,7 +52,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_1
@@ -233,7 +231,7 @@ operationGroups:
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: files
+      name: Files
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-integer/namer.yaml
+++ b/modelerfour/test/scenarios/body-integer/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_1
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -56,7 +54,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_0
@@ -68,7 +66,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_7
@@ -79,7 +77,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   strings:
@@ -87,7 +85,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_1
@@ -99,7 +97,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: unixtime
+        name: Unixtime
         description: 'date in seconds since 1970-01-01T00:00:00Z.'
     protocol: !<!Protocols> {}
 globalParameters:
@@ -172,7 +170,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null Int value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -222,7 +220,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalid
+        name: GetInvalid
         description: Get invalid Int value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -272,7 +270,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getOverflowInt32
+        name: GetOverflowInt32
         description: Get overflow Int32 value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -322,7 +320,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUnderflowInt32
+        name: GetUnderflowInt32
         description: Get underflow Int32 value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -372,7 +370,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getOverflowInt64
+        name: GetOverflowInt64
         description: Get overflow Int64 value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -422,7 +420,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUnderflowInt64
+        name: GetUnderflowInt64
         description: Get underflow Int64 value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -488,7 +486,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMax32
+        name: PutMax32
         description: Put max int32 value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -554,7 +552,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMax64
+        name: PutMax64
         description: Put max int64 value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -620,7 +618,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMin32
+        name: PutMin32
         description: Put min int32 value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -686,7 +684,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMin64
+        name: PutMin64
         description: Put min int64 value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -736,7 +734,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getUnixTime
+        name: GetUnixTime
         description: Get datetime encoded as Unix time value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -802,7 +800,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putUnixTimeDate
+        name: PutUnixTimeDate
         description: Put datetime encoded as Unix time
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -852,7 +850,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalidUnixTime
+        name: GetInvalidUnixTime
         description: Get invalid Unix time value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -902,12 +900,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNullUnixTime
+        name: GetNullUnixTime
         description: Get null Unix time value
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: int
+      name: Int
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-number.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_11
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -67,7 +65,7 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -94,7 +92,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -121,7 +119,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -148,7 +146,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -175,7 +173,7 @@ schemas: !<!Schemas>
       precision: 128
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -202,7 +200,7 @@ schemas: !<!Schemas>
       precision: 128
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -229,7 +227,7 @@ schemas: !<!Schemas>
       precision: 128
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -256,7 +254,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -283,7 +281,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -310,7 +308,7 @@ schemas: !<!Schemas>
       precision: 128
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -327,7 +325,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - *ref_0
@@ -339,7 +337,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_17
@@ -350,7 +348,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - *ref_1
@@ -365,7 +363,7 @@ schemas: !<!Schemas>
     precision: 128
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - *ref_5
@@ -379,7 +377,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_11
@@ -453,7 +451,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null Number value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -503,7 +501,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalidFloat
+        name: GetInvalidFloat
         description: Get invalid float Number value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -553,7 +551,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalidDouble
+        name: GetInvalidDouble
         description: Get invalid double Number value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -619,7 +617,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigFloat
+        name: PutBigFloat
         description: Put big float value 3.402823e+20
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -669,7 +667,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigFloat
+        name: GetBigFloat
         description: Get big float value 3.402823e+20
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -735,7 +733,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDouble
+        name: PutBigDouble
         description: Put big double value 2.5976931e+101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -785,7 +783,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDouble
+        name: GetBigDouble
         description: Get big double value 2.5976931e+101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -851,7 +849,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDoublePositiveDecimal
+        name: PutBigDoublePositiveDecimal
         description: Put big double value 99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -901,7 +899,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDoublePositiveDecimal
+        name: GetBigDoublePositiveDecimal
         description: Get big double value 99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -967,7 +965,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDoubleNegativeDecimal
+        name: PutBigDoubleNegativeDecimal
         description: Put big double value -99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1017,7 +1015,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDoubleNegativeDecimal
+        name: GetBigDoubleNegativeDecimal
         description: Get big double value -99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1083,7 +1081,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDecimal
+        name: PutBigDecimal
         description: Put big decimal value 2.5976931e+101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1133,7 +1131,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDecimal
+        name: GetBigDecimal
         description: Get big decimal value 2.5976931e+101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1199,7 +1197,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDecimalPositiveDecimal
+        name: PutBigDecimalPositiveDecimal
         description: Put big decimal value 99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1249,7 +1247,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDecimalPositiveDecimal
+        name: GetBigDecimalPositiveDecimal
         description: Get big decimal value 99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1315,7 +1313,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDecimalNegativeDecimal
+        name: PutBigDecimalNegativeDecimal
         description: Put big decimal value -99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1365,7 +1363,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDecimalNegativeDecimal
+        name: GetBigDecimalNegativeDecimal
         description: Get big decimal value -99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1431,7 +1429,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSmallFloat
+        name: PutSmallFloat
         description: Put small float value 3.402823e-20
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1481,7 +1479,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSmallFloat
+        name: GetSmallFloat
         description: Get big double value 3.402823e-20
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1547,7 +1545,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSmallDouble
+        name: PutSmallDouble
         description: Put small double value 2.5976931e-101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1597,7 +1595,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSmallDouble
+        name: GetSmallDouble
         description: Get big double value 2.5976931e-101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1663,7 +1661,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSmallDecimal
+        name: PutSmallDecimal
         description: Put small decimal value 2.5976931e-101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1713,12 +1711,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSmallDecimal
+        name: GetSmallDecimal
         description: Get small decimal value 2.5976931e-101
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: number
+      name: Number
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-number/namer.yaml
+++ b/modelerfour/test/scenarios/body-number/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_11
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -67,7 +65,7 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -94,7 +92,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -121,7 +119,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -148,7 +146,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -175,7 +173,7 @@ schemas: !<!Schemas>
       precision: 128
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -202,7 +200,7 @@ schemas: !<!Schemas>
       precision: 128
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -229,7 +227,7 @@ schemas: !<!Schemas>
       precision: 128
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -256,7 +254,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -283,7 +281,7 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -310,7 +308,7 @@ schemas: !<!Schemas>
       precision: 128
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -327,7 +325,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - *ref_0
@@ -339,7 +337,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_17
@@ -350,7 +348,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_18
@@ -361,7 +359,7 @@ schemas: !<!Schemas>
     precision: 128
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - *ref_1
@@ -379,7 +377,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_11
@@ -453,7 +451,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null Number value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -503,7 +501,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalidFloat
+        name: GetInvalidFloat
         description: Get invalid float Number value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -553,7 +551,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalidDouble
+        name: GetInvalidDouble
         description: Get invalid double Number value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -603,7 +601,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getInvalidDecimal
+        name: GetInvalidDecimal
         description: Get invalid decimal Number value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -669,7 +667,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigFloat
+        name: PutBigFloat
         description: Put big float value 3.402823e+20
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -719,7 +717,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigFloat
+        name: GetBigFloat
         description: Get big float value 3.402823e+20
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -785,7 +783,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDouble
+        name: PutBigDouble
         description: Put big double value 2.5976931e+101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -835,7 +833,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDouble
+        name: GetBigDouble
         description: Get big double value 2.5976931e+101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -900,7 +898,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDoublePositiveDecimal
+        name: PutBigDoublePositiveDecimal
         description: Put big double value 99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -950,7 +948,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDoublePositiveDecimal
+        name: GetBigDoublePositiveDecimal
         description: Get big double value 99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1015,7 +1013,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDoubleNegativeDecimal
+        name: PutBigDoubleNegativeDecimal
         description: Put big double value -99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1065,7 +1063,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDoubleNegativeDecimal
+        name: GetBigDoubleNegativeDecimal
         description: Get big double value -99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1131,7 +1129,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDecimal
+        name: PutBigDecimal
         description: Put big decimal value 2.5976931e+101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1181,7 +1179,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDecimal
+        name: GetBigDecimal
         description: Get big decimal value 2.5976931e+101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1246,7 +1244,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDecimalPositiveDecimal
+        name: PutBigDecimalPositiveDecimal
         description: Put big decimal value 99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1296,7 +1294,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDecimalPositiveDecimal
+        name: GetBigDecimalPositiveDecimal
         description: Get big decimal value 99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1361,7 +1359,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBigDecimalNegativeDecimal
+        name: PutBigDecimalNegativeDecimal
         description: Put big decimal value -99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1411,7 +1409,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBigDecimalNegativeDecimal
+        name: GetBigDecimalNegativeDecimal
         description: Get big decimal value -99999999.99
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1477,7 +1475,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSmallFloat
+        name: PutSmallFloat
         description: Put small float value 3.402823e-20
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1527,7 +1525,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSmallFloat
+        name: GetSmallFloat
         description: Get big double value 3.402823e-20
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1593,7 +1591,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSmallDouble
+        name: PutSmallDouble
         description: Put small double value 2.5976931e-101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1643,7 +1641,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSmallDouble
+        name: GetSmallDouble
         description: Get big double value 2.5976931e-101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1709,7 +1707,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSmallDecimal
+        name: PutSmallDecimal
         description: Put small decimal value 2.5976931e-101
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1759,12 +1757,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSmallDecimal
+        name: GetSmallDecimal
         description: Get small decimal value 2.5976931e-101
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: number
+      name: Number
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-string.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_3
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -69,7 +67,7 @@ schemas: !<!Schemas>
           type: string
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: simple string
           protocol: !<!Protocols> {}
         language: !<!Languages> 
@@ -81,9 +79,8 @@ schemas: !<!Schemas>
       serializedName: ColorConstant
       language: !<!Languages> 
         default:
-          name: ColorConstant
+          name: colorConstant
           description: Referenced Color Constant Description.
-          originalName: ColorConstant
       protocol: !<!Protocols> {}
     - !<!Property> &ref_20
       schema: !<!StringSchema> &ref_4
@@ -93,7 +90,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: RefColorConstant-field1
+            name: RefColorConstantField1
             description: Sample string.
         protocol: !<!Protocols> {}
       required: false
@@ -102,7 +99,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: Sample string.
-          originalName: field1
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -119,7 +115,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   constants:
@@ -137,7 +133,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant0
+        name: Constant1
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -154,7 +150,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant1
+        name: Constant2
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -171,7 +167,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant2
+        name: Constant3
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -188,7 +184,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant3
+        name: Constant4
         description: ''
     protocol: !<!Protocols> {}
   - *ref_1
@@ -201,19 +197,19 @@ schemas: !<!Schemas>
       value: red color
       language:
         default:
-          name: red color
+          name: RedColor
           description: ''
     - !<!ChoiceValue> 
       value: green-color
       language:
         default:
-          name: green-color
+          name: GreenColor
           description: ''
     - !<!ChoiceValue> 
       value: blue_color
       language:
         default:
-          name: blue_color
+          name: BlueColor
           description: ''
     type: sealed-choice
     apiVersions:
@@ -235,7 +231,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_4
@@ -309,7 +305,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null string value value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -374,7 +370,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNull
+        name: PutNull
         description: Set string value null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -424,7 +420,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get empty string value value ''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -490,7 +486,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmpty
+        name: PutEmpty
         description: Set string value empty ''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -540,7 +536,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMbcs
+        name: GetMbcs
         description: Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -606,7 +602,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMbcs
+        name: PutMbcs
         description: Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -656,7 +652,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getWhitespace
+        name: GetWhitespace
         description: Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -722,7 +718,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putWhitespace
+        name: PutWhitespace
         description: Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -772,7 +768,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotProvided
+        name: GetNotProvided
         description: Get String value when no string value is sent in response payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -822,7 +818,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBase64Encoded
+        name: GetBase64Encoded
         description: Get value that is base64 encoded
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -872,7 +868,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBase64UrlEncoded
+        name: GetBase64UrlEncoded
         description: Get value that is base64url encoded
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -938,7 +934,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBase64UrlEncoded
+        name: PutBase64UrlEncoded
         description: Put value that is base64url encoded
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -988,12 +984,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNullBase64UrlEncoded
+        name: GetNullBase64UrlEncoded
         description: Get null value that is expected to be base64url encoded
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: string
+      name: String
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1046,7 +1042,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotExpandable
+        name: GetNotExpandable
         description: 'Get enum value ''red color'' from enumeration of ''red color'', ''green-color'', ''blue_color''.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1112,7 +1108,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNotExpandable
+        name: PutNotExpandable
         description: 'Sends value ''red color'' from enumeration of ''red color'', ''green-color'', ''blue_color'''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1162,7 +1158,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getReferenced
+        name: GetReferenced
         description: 'Get enum value ''red color'' from enumeration of ''red color'', ''green-color'', ''blue_color''.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1228,7 +1224,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putReferenced
+        name: PutReferenced
         description: 'Sends value ''red color'' from enumeration of ''red color'', ''green-color'', ''blue_color'''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1278,7 +1274,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getReferencedConstant
+        name: GetReferencedConstant
         description: Get value 'green-color' from the constant.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1371,12 +1367,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putReferencedConstant
+        name: PutReferencedConstant
         description: Sends value 'green-color' from a constant
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: enum
+      name: Enum
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-string/namer.yaml
+++ b/modelerfour/test/scenarios/body-string/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_3
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -69,7 +67,7 @@ schemas: !<!Schemas>
           type: string
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: simple string
           protocol: !<!Protocols> {}
         language: !<!Languages> 
@@ -81,9 +79,8 @@ schemas: !<!Schemas>
       serializedName: ColorConstant
       language: !<!Languages> 
         default:
-          name: ColorConstant
+          name: colorConstant
           description: Referenced Color Constant Description.
-          originalName: ColorConstant
       protocol: !<!Protocols> {}
     - !<!Property> &ref_20
       schema: !<!StringSchema> &ref_4
@@ -93,7 +90,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: RefColorConstant-field1
+            name: RefColorConstantField1
             description: Sample string.
         protocol: !<!Protocols> {}
       required: false
@@ -102,7 +99,6 @@ schemas: !<!Schemas>
         default:
           name: field1
           description: Sample string.
-          originalName: field1
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -119,7 +115,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   constants:
@@ -137,7 +133,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant0
+        name: Constant1
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_8
@@ -154,7 +150,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant1
+        name: Constant2
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_9
@@ -171,7 +167,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant2
+        name: Constant3
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_10
@@ -188,7 +184,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant3
+        name: Constant4
         description: ''
     protocol: !<!Protocols> {}
   - *ref_1
@@ -201,19 +197,19 @@ schemas: !<!Schemas>
       value: red color
       language:
         default:
-          name: red color
+          name: RedColor
           description: ''
     - !<!ChoiceValue> 
       value: green-color
       language:
         default:
-          name: green-color
+          name: GreenColor
           description: ''
     - !<!ChoiceValue> 
       value: blue_color
       language:
         default:
-          name: blue_color
+          name: BlueColor
           description: ''
     type: sealed-choice
     apiVersions:
@@ -236,7 +232,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
 globalParameters:
@@ -309,7 +305,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNull
+        name: GetNull
         description: Get null string value value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -373,7 +369,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNull
+        name: PutNull
         description: Set string value null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -423,7 +419,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get empty string value value ''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -488,7 +484,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmpty
+        name: PutEmpty
         description: Set string value empty ''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -538,7 +534,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getMbcs
+        name: GetMbcs
         description: Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -603,7 +599,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putMbcs
+        name: PutMbcs
         description: Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -653,7 +649,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getWhitespace
+        name: GetWhitespace
         description: Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -718,7 +714,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putWhitespace
+        name: PutWhitespace
         description: Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -768,7 +764,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotProvided
+        name: GetNotProvided
         description: Get String value when no string value is sent in response payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -818,7 +814,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBase64Encoded
+        name: GetBase64Encoded
         description: Get value that is base64 encoded
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -868,7 +864,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBase64UrlEncoded
+        name: GetBase64UrlEncoded
         description: Get value that is base64url encoded
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -934,7 +930,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putBase64UrlEncoded
+        name: PutBase64UrlEncoded
         description: Put value that is base64url encoded
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -984,12 +980,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNullBase64UrlEncoded
+        name: GetNullBase64UrlEncoded
         description: Get null value that is expected to be base64url encoded
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: string
+      name: String
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1042,7 +1038,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNotExpandable
+        name: GetNotExpandable
         description: 'Get enum value ''red color'' from enumeration of ''red color'', ''green-color'', ''blue_color''.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1108,7 +1104,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNotExpandable
+        name: PutNotExpandable
         description: 'Sends value ''red color'' from enumeration of ''red color'', ''green-color'', ''blue_color'''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1158,7 +1154,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getReferenced
+        name: GetReferenced
         description: 'Get enum value ''red color'' from enumeration of ''red color'', ''green-color'', ''blue_color''.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1224,7 +1220,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putReferenced
+        name: PutReferenced
         description: 'Sends value ''red color'' from enumeration of ''red color'', ''green-color'', ''blue_color'''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1274,7 +1270,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getReferencedConstant
+        name: GetReferencedConstant
         description: Get value 'green-color' from the constant.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1367,12 +1363,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putReferencedConstant
+        name: PutReferencedConstant
         description: Sends value 'green-color' from a constant
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: enum
+      name: Enum
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
                 version: 2014-04-01-preview
               language: !<!Languages> 
                 default:
-                  name: Product-product_id
+                  name: ProductId
                   description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
               protocol: !<!Protocols> {}
             serializedName: product_id
@@ -35,7 +35,6 @@ schemas: !<!Schemas>
               default:
                 name: productId
                 description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
-                originalName: product_id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_10
@@ -45,7 +44,7 @@ schemas: !<!Schemas>
                 version: 2014-04-01-preview
               language: !<!Languages> 
                 default:
-                  name: Product-description
+                  name: ProductDescription
                   description: Description of product.
               protocol: !<!Protocols> {}
             serializedName: description
@@ -53,7 +52,6 @@ schemas: !<!Schemas>
               default:
                 name: description
                 description: Description of product.
-                originalName: description
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_11
@@ -63,7 +61,7 @@ schemas: !<!Schemas>
                 version: 2014-04-01-preview
               language: !<!Languages> 
                 default:
-                  name: Product-display_name
+                  name: ProductDisplayName
                   description: Display name of product.
               protocol: !<!Protocols> {}
             serializedName: display_name
@@ -71,7 +69,6 @@ schemas: !<!Schemas>
               default:
                 name: displayName
                 description: Display name of product.
-                originalName: display_name
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_12
@@ -82,7 +79,7 @@ schemas: !<!Schemas>
               defaultValue: '100'
               language: !<!Languages> 
                 default:
-                  name: Product-capacity
+                  name: ProductCapacity
                   description: 'Capacity of product. For example, 4 people.'
               protocol: !<!Protocols> {}
             serializedName: capacity
@@ -90,7 +87,6 @@ schemas: !<!Schemas>
               default:
                 name: capacity
                 description: 'Capacity of product. For example, 4 people.'
-                originalName: capacity
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_13
@@ -100,7 +96,7 @@ schemas: !<!Schemas>
                 version: 2014-04-01-preview
               language: !<!Languages> 
                 default:
-                  name: Product-image
+                  name: ProductImage
                   description: Image URL representing the product.
               protocol: !<!Protocols> {}
             serializedName: image
@@ -108,7 +104,6 @@ schemas: !<!Schemas>
               default:
                 name: image
                 description: Image URL representing the product.
-                originalName: image
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -118,7 +113,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CatalogArray-productArray
+            name: CatalogArrayProductArray
             description: Array of products
         protocol: !<!Protocols> {}
       serializedName: productArray
@@ -126,7 +121,6 @@ schemas: !<!Schemas>
         default:
           name: productArray
           description: Array of products
-          originalName: productArray
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -147,7 +141,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -155,7 +149,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_14
@@ -165,7 +158,7 @@ schemas: !<!Schemas>
           version: 2014-04-01-preview
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -173,7 +166,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -198,12 +190,12 @@ schemas: !<!Schemas>
           elementType: *ref_0
           language: !<!Languages> 
             default:
-              name: Array of Product
-              description: ''
+              name: ArrayOfProduct
+              description: Array of Product
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CatalogDictionaryOfArray-productDictionaryOfArray
+            name: CatalogDictionaryOfArrayProductDictionaryOfArray
             description: Dictionary of Array of product
         protocol: !<!Protocols> {}
       serializedName: productDictionaryOfArray
@@ -211,7 +203,6 @@ schemas: !<!Schemas>
         default:
           name: productDictionaryOfArray
           description: Dictionary of Array of product
-          originalName: productDictionaryOfArray
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -231,7 +222,7 @@ schemas: !<!Schemas>
         elementType: *ref_0
         language: !<!Languages> 
           default:
-            name: CatalogDictionary-productDictionary
+            name: CatalogDictionaryProductDictionary
             description: Dictionary of products
         protocol: !<!Protocols> {}
       serializedName: productDictionary
@@ -239,7 +230,6 @@ schemas: !<!Schemas>
         default:
           name: productDictionary
           description: Dictionary of products
-          originalName: productDictionary
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -264,12 +254,12 @@ schemas: !<!Schemas>
           elementType: *ref_0
           language: !<!Languages> 
             default:
-              name: CatalogArrayOfDictionary-productArrayOfDictionaryItem
+              name: CatalogArrayOfDictionaryProductArrayOfDictionaryItem
               description: Dictionary of <Product>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CatalogArrayOfDictionary-productArrayOfDictionary
+            name: CatalogArrayOfDictionaryProductArrayOfDictionary
             description: Array of dictionary of products
         protocol: !<!Protocols> {}
       serializedName: productArrayOfDictionary
@@ -277,7 +267,6 @@ schemas: !<!Schemas>
         default:
           name: productArrayOfDictionary
           description: Array of dictionary of products
-          originalName: productArrayOfDictionary
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -306,7 +295,7 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -325,7 +314,7 @@ schemas: !<!Schemas>
     valueType: *ref_7
     language: !<!Languages> 
       default:
-        name: ApiVersion-2014-04-01-preview
+        name: ApiVersion20140401Preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -339,7 +328,7 @@ schemas: !<!Schemas>
     valueType: *ref_7
     language: !<!Languages> 
       default:
-        name: ApiVersion-2014-04-01-preview
+        name: ApiVersion20140401Preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -353,7 +342,7 @@ schemas: !<!Schemas>
     valueType: *ref_7
     language: !<!Languages> 
       default:
-        name: ApiVersion-2014-04-01-preview
+        name: ApiVersion20140401Preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
   numbers:
@@ -367,7 +356,7 @@ schemas: !<!Schemas>
       version: 2014-04-01-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_9
@@ -487,7 +476,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: list
+        name: List
         description: 'The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.'
         summary: Product Types
     protocol: !<!Protocols> {}
@@ -598,7 +587,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: create
+        name: Create
         description: Resets products.
         summary: Create products
     protocol: !<!Protocols> {}
@@ -709,7 +698,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: update
+        name: Update
         description: Resets products.
         summary: Update products
     protocol: !<!Protocols> {}

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_1
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -54,7 +52,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_2
@@ -64,7 +62,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_6
@@ -75,7 +73,7 @@ schemas: !<!Schemas>
     defaultValue: v1
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_1
@@ -87,7 +85,7 @@ schemas: !<!Schemas>
     defaultValue: host
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
 globalParameters:
@@ -239,12 +237,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get a 200 to test a valid base uri
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: paths
+      name: Paths
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
@@ -32,7 +32,7 @@ schemas: !<!Schemas>
                   precision: 32
                   language: !<!Languages> 
                     default:
-                      name: typeForid
+                      name: TypeForid
                       description: ''
                   protocol: !<!Protocols> {}
                 serializedName: id
@@ -40,7 +40,6 @@ schemas: !<!Schemas>
                   default:
                     name: id
                     description: ''
-                    originalName: id
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_5
@@ -50,7 +49,7 @@ schemas: !<!Schemas>
                     version: 1.0.0
                   language: !<!Languages> 
                     default:
-                      name: Product-properties-name
+                      name: ProductPropertiesName
                       description: ''
                   protocol: !<!Protocols> {}
                 serializedName: name
@@ -58,11 +57,10 @@ schemas: !<!Schemas>
                   default:
                     name: name
                     description: ''
-                    originalName: name
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: Product-properties
+                  name: ProductProperties
                   description: ''
                   namespace: Api100
               protocol: !<!Protocols> {}
@@ -71,7 +69,6 @@ schemas: !<!Schemas>
               default:
                 name: properties
                 description: ''
-                originalName: properties
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -81,15 +78,14 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: ProductResult-values
-            description: ''
+            name: ProductResultValues
+            description: Array of Product
         protocol: !<!Protocols> {}
       serializedName: values
       language: !<!Languages> 
         default:
           name: values
           description: ''
-          originalName: values
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_6
@@ -99,7 +95,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ProductResult-nextLink
+            name: ProductResultNextLink
             description: ''
         protocol: !<!Protocols> {}
       serializedName: nextLink
@@ -107,7 +103,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: ''
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -129,7 +124,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -137,7 +132,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_7
@@ -147,7 +141,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -155,7 +149,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -173,7 +166,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_5
@@ -185,7 +178,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> 
@@ -196,7 +189,7 @@ schemas: !<!Schemas>
     defaultValue: host
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_7
@@ -294,7 +287,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getPagesPartialUrl
+        name: GetPagesPartialUrl
         description: 'A paging operation that combines custom url, paging and partial URL and expect to concat after host'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -364,7 +357,7 @@ operationGroups:
         operationName: Paging_getPagesPartialUrlOperationNext
     language: !<!Languages> 
       default:
-        name: getPagesPartialUrlOperation
+        name: GetPagesPartialUrlOperation
         description: 'A paging operation that combines custom url, paging and partial URL with next operation'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -449,7 +442,7 @@ operationGroups:
         operationName: Paging_getPagesPartialUrlOperationNext
     language: !<!Languages> 
       default:
-        name: getPagesPartialUrlOperationNext
+        name: GetPagesPartialUrlOperationNext
         description: 'A paging operation that combines custom url, paging and partial URL'
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_1
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -54,7 +52,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_1
@@ -66,7 +64,7 @@ schemas: !<!Schemas>
     defaultValue: host
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
 globalParameters:
@@ -159,12 +157,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmpty
+        name: GetEmpty
         description: Get a 200 to test a valid base uri
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: paths
+      name: Paths
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/datalake-storage/namer.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Filesystem-name
+                  name: FilesystemName
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: name
@@ -35,7 +35,6 @@ schemas: !<!Schemas>
               default:
                 name: name
                 description: ''
-                originalName: name
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_9
@@ -45,7 +44,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Filesystem-lastModified
+                  name: FilesystemLastModified
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: lastModified
@@ -53,7 +52,6 @@ schemas: !<!Schemas>
               default:
                 name: lastModified
                 description: ''
-                originalName: lastModified
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_10
@@ -63,7 +61,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Filesystem-eTag
+                  name: FilesystemETag
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: eTag
@@ -71,7 +69,6 @@ schemas: !<!Schemas>
               default:
                 name: eTag
                 description: ''
-                originalName: eTag
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -81,15 +78,14 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: FilesystemList-filesystems
-            description: ''
+            name: FilesystemListFilesystems
+            description: Array of Filesystem
         protocol: !<!Protocols> {}
       serializedName: filesystems
       language: !<!Languages> 
         default:
           name: filesystems
           description: ''
-          originalName: filesystems
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -119,7 +115,7 @@ schemas: !<!Schemas>
               version: '2019-10-31'
             language: !<!Languages> 
               default:
-                name: DataLakeStorageError-error-code
+                name: DataLakeStorageErrorCode
                 description: The service error code.
             protocol: !<!Protocols> {}
           serializedName: code
@@ -127,7 +123,6 @@ schemas: !<!Schemas>
             default:
               name: code
               description: The service error code.
-              originalName: code
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_12
@@ -137,7 +132,7 @@ schemas: !<!Schemas>
               version: '2019-10-31'
             language: !<!Languages> 
               default:
-                name: DataLakeStorageError-error-message
+                name: DataLakeStorageErrorMessage
                 description: The service error message.
             protocol: !<!Protocols> {}
           serializedName: message
@@ -145,11 +140,10 @@ schemas: !<!Schemas>
             default:
               name: message
               description: The service error message.
-              originalName: message
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: DataLakeStorageError-error
+            name: DataLakeStorageError
             description: The service error response object.
             namespace: Api20191031
         protocol: !<!Protocols> {}
@@ -158,7 +152,6 @@ schemas: !<!Schemas>
         default:
           name: error
           description: The service error response object.
-          originalName: error
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -193,7 +186,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Path-name
+                  name: PathName
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: name
@@ -201,7 +194,6 @@ schemas: !<!Schemas>
               default:
                 name: name
                 description: ''
-                originalName: name
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!BooleanSchema> &ref_5
@@ -209,7 +201,7 @@ schemas: !<!Schemas>
               defaultValue: false
               language: !<!Languages> 
                 default:
-                  name: typeForisDirectory
+                  name: TypeForisDirectory
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: isDirectory
@@ -217,7 +209,6 @@ schemas: !<!Schemas>
               default:
                 name: isDirectory
                 description: ''
-                originalName: isDirectory
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_14
@@ -227,7 +218,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Path-lastModified
+                  name: PathLastModified
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: lastModified
@@ -235,7 +226,6 @@ schemas: !<!Schemas>
               default:
                 name: lastModified
                 description: ''
-                originalName: lastModified
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_15
@@ -245,7 +235,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Path-eTag
+                  name: PathETag
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: eTag
@@ -253,7 +243,6 @@ schemas: !<!Schemas>
               default:
                 name: eTag
                 description: ''
-                originalName: eTag
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!NumberSchema> &ref_7
@@ -261,7 +250,7 @@ schemas: !<!Schemas>
               precision: 64
               language: !<!Languages> 
                 default:
-                  name: typeForcontentLength
+                  name: TypeForcontentLength
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: contentLength
@@ -269,7 +258,6 @@ schemas: !<!Schemas>
               default:
                 name: contentLength
                 description: ''
-                originalName: contentLength
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_16
@@ -279,7 +267,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Path-owner
+                  name: PathOwner
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: owner
@@ -287,7 +275,6 @@ schemas: !<!Schemas>
               default:
                 name: owner
                 description: ''
-                originalName: owner
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_17
@@ -297,7 +284,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Path-group
+                  name: PathGroup
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: group
@@ -305,7 +292,6 @@ schemas: !<!Schemas>
               default:
                 name: group
                 description: ''
-                originalName: group
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_18
@@ -315,7 +301,7 @@ schemas: !<!Schemas>
                 version: '2019-10-31'
               language: !<!Languages> 
                 default:
-                  name: Path-permissions
+                  name: PathPermissions
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: permissions
@@ -323,7 +309,6 @@ schemas: !<!Schemas>
               default:
                 name: permissions
                 description: ''
-                originalName: permissions
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -333,15 +318,14 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: PathList-paths
-            description: ''
+            name: PathListPaths
+            description: Array of Path
         protocol: !<!Protocols> {}
       serializedName: paths
       language: !<!Languages> 
         default:
           name: paths
           description: ''
-          originalName: paths
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -372,7 +356,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_103
@@ -382,7 +366,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - *ref_5
@@ -393,7 +377,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_192
@@ -403,7 +387,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_301
@@ -413,7 +397,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_358
@@ -423,7 +407,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_401
@@ -433,7 +417,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   constants:
@@ -449,7 +433,7 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -481,7 +465,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_27
@@ -493,7 +477,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_48
@@ -505,7 +489,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_102
@@ -517,7 +501,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_7
@@ -530,7 +514,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_188
@@ -541,7 +525,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -553,7 +537,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_193
@@ -565,7 +549,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_248
@@ -576,7 +560,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -588,7 +572,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_261
@@ -599,7 +583,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_323
@@ -610,7 +594,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -622,7 +606,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -634,7 +618,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Content-Length
     protocol: !<!Protocols> {}
@@ -645,13 +629,13 @@ schemas: !<!Schemas>
       value: directory
       language:
         default:
-          name: directory
+          name: Directory
           description: ''
     - !<!ChoiceValue> 
       value: file
       language:
         default:
-          name: file
+          name: File
           description: ''
     type: sealed-choice
     apiVersions:
@@ -669,13 +653,13 @@ schemas: !<!Schemas>
       value: legacy
       language:
         default:
-          name: legacy
+          name: Legacy
           description: ''
     - !<!ChoiceValue> 
       value: posix
       language:
         default:
-          name: posix
+          name: Posix
           description: ''
     type: sealed-choice
     apiVersions:
@@ -693,25 +677,25 @@ schemas: !<!Schemas>
       value: append
       language:
         default:
-          name: append
+          name: Append
           description: ''
     - !<!ChoiceValue> 
       value: flush
       language:
         default:
-          name: flush
+          name: Flush
           description: ''
     - !<!ChoiceValue> 
       value: setProperties
       language:
         default:
-          name: setProperties
+          name: SetProperties
           description: ''
     - !<!ChoiceValue> 
       value: setAccessControl
       language:
         default:
-          name: setAccessControl
+          name: SetAccessControl
           description: ''
     type: sealed-choice
     apiVersions:
@@ -729,31 +713,31 @@ schemas: !<!Schemas>
       value: acquire
       language:
         default:
-          name: acquire
+          name: Acquire
           description: ''
     - !<!ChoiceValue> 
       value: break
       language:
         default:
-          name: break
+          name: Break
           description: ''
     - !<!ChoiceValue> 
       value: change
       language:
         default:
-          name: change
+          name: Change
           description: ''
     - !<!ChoiceValue> 
       value: renew
       language:
         default:
-          name: renew
+          name: Renew
           description: ''
     - !<!ChoiceValue> 
       value: release
       language:
         default:
-          name: release
+          name: Release
           description: ''
     type: sealed-choice
     apiVersions:
@@ -771,19 +755,19 @@ schemas: !<!Schemas>
       value: getAccessControl
       language:
         default:
-          name: getAccessControl
+          name: GetAccessControl
           description: ''
     - !<!ChoiceValue> 
       value: getStatus
       language:
         default:
-          name: getStatus
+          name: GetStatus
           description: ''
     - !<!ChoiceValue> 
       value: checkAccess
       language:
         default:
-          name: checkAccess
+          name: CheckAccess
           description: ''
     type: sealed-choice
     apiVersions:
@@ -804,7 +788,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_24
@@ -814,7 +798,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_26
@@ -825,7 +809,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_28
@@ -835,7 +819,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_19
@@ -845,7 +829,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_37
@@ -855,7 +839,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -867,7 +851,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -878,7 +862,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -889,7 +873,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-continuation
     protocol: !<!Protocols> {}
@@ -900,7 +884,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -915,7 +899,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -926,7 +910,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -942,7 +926,7 @@ schemas: !<!Schemas>
     pattern: '^[$a-z0-9](?!.*--)[-a-z0-9]{1,61}[a-z0-9]$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_47
@@ -953,7 +937,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_49
@@ -963,7 +947,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_50
@@ -973,7 +957,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_56
@@ -983,7 +967,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -994,7 +978,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -1005,7 +989,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -1017,7 +1001,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -1028,7 +1012,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -1039,7 +1023,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-namespace-enabled
     protocol: !<!Protocols> {}
@@ -1050,7 +1034,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_63
@@ -1060,7 +1044,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_64
@@ -1070,7 +1054,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_72
@@ -1080,7 +1064,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -1091,7 +1075,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -1102,7 +1086,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -1114,7 +1098,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -1125,7 +1109,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -1136,7 +1120,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_101
@@ -1146,7 +1130,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_114
@@ -1156,7 +1140,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -1167,7 +1151,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -1178,7 +1162,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -1190,7 +1174,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -1201,7 +1185,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -1212,7 +1196,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-continuation
     protocol: !<!Protocols> {}
@@ -1229,7 +1213,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -1240,7 +1224,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -1251,7 +1235,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -1263,7 +1247,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -1274,7 +1258,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -1285,7 +1269,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-properties
     protocol: !<!Protocols> {}
@@ -1296,7 +1280,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-namespace-enabled
     protocol: !<!Protocols> {}
@@ -1307,7 +1291,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_89
@@ -1317,7 +1301,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_96
@@ -1328,7 +1312,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -1339,7 +1323,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -1350,7 +1334,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -1364,7 +1348,7 @@ schemas: !<!Schemas>
     pattern: '^[$a-z0-9](?!.*--)[-a-z0-9]{1,61}[a-z0-9]$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_121
@@ -1374,7 +1358,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_122
@@ -1385,7 +1369,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_124
@@ -1395,7 +1379,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_126
@@ -1405,7 +1389,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_128
@@ -1415,7 +1399,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_129
@@ -1425,7 +1409,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_130
@@ -1435,7 +1419,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_131
@@ -1445,7 +1429,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_132
@@ -1455,7 +1439,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_133
@@ -1465,7 +1449,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_134
@@ -1475,7 +1459,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_135
@@ -1485,7 +1469,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_136
@@ -1495,7 +1479,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_137
@@ -1505,7 +1489,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_138
@@ -1516,7 +1500,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_139
@@ -1527,7 +1511,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_140
@@ -1537,7 +1521,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_141
@@ -1547,7 +1531,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_142
@@ -1557,7 +1541,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_143
@@ -1567,7 +1551,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_144
@@ -1577,7 +1561,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_145
@@ -1587,7 +1571,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_146
@@ -1597,7 +1581,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_147
@@ -1607,7 +1591,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_148
@@ -1617,7 +1601,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_149
@@ -1627,7 +1611,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_150
@@ -1637,7 +1621,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_182
@@ -1647,7 +1631,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -1658,7 +1642,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -1669,7 +1653,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -1681,7 +1665,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -1692,7 +1676,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -1703,7 +1687,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-continuation
     protocol: !<!Protocols> {}
@@ -1714,7 +1698,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_195
@@ -1725,7 +1709,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_196
@@ -1735,7 +1719,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_197
@@ -1745,7 +1729,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_198
@@ -1755,7 +1739,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_199
@@ -1765,7 +1749,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_200
@@ -1775,7 +1759,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_201
@@ -1785,7 +1769,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_202
@@ -1795,7 +1779,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_203
@@ -1805,7 +1789,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_204
@@ -1815,7 +1799,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_205
@@ -1825,7 +1809,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_206
@@ -1835,7 +1819,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_207
@@ -1845,7 +1829,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_208
@@ -1855,7 +1839,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_209
@@ -1865,7 +1849,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_210
@@ -1875,7 +1859,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_240
@@ -1885,7 +1869,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -1896,7 +1880,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -1907,7 +1891,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -1918,7 +1902,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Accept-Ranges
     protocol: !<!Protocols> {}
@@ -1929,7 +1913,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Cache-Control
     protocol: !<!Protocols> {}
@@ -1940,7 +1924,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Disposition
     protocol: !<!Protocols> {}
@@ -1951,7 +1935,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Encoding
     protocol: !<!Protocols> {}
@@ -1962,7 +1946,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Language
     protocol: !<!Protocols> {}
@@ -1973,7 +1957,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Range
     protocol: !<!Protocols> {}
@@ -1984,7 +1968,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -1995,7 +1979,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -2006,7 +1990,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-properties
     protocol: !<!Protocols> {}
@@ -2018,7 +2002,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -2029,7 +2013,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -2040,7 +2024,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -2051,7 +2035,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -2063,7 +2047,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -2074,7 +2058,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -2086,7 +2070,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_263
@@ -2097,7 +2081,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_264
@@ -2107,7 +2091,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_265
@@ -2117,7 +2101,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_266
@@ -2127,7 +2111,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_267
@@ -2137,7 +2121,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_282
@@ -2147,7 +2131,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -2158,7 +2142,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -2169,7 +2153,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -2181,7 +2165,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -2192,7 +2176,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -2204,7 +2188,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-id
     protocol: !<!Protocols> {}
@@ -2215,7 +2199,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -2226,7 +2210,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -2237,7 +2221,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -2249,7 +2233,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -2260,7 +2244,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -2272,7 +2256,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-id
     protocol: !<!Protocols> {}
@@ -2283,7 +2267,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -2294,7 +2278,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -2306,7 +2290,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -2317,7 +2301,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -2328,7 +2312,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-time
     protocol: !<!Protocols> {}
@@ -2339,7 +2323,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_300
@@ -2350,7 +2334,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_302
@@ -2360,7 +2344,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_303
@@ -2370,7 +2354,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_304
@@ -2380,7 +2364,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_305
@@ -2390,7 +2374,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_318
@@ -2400,7 +2384,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Accept-Ranges
     protocol: !<!Protocols> {}
@@ -2411,7 +2395,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Cache-Control
     protocol: !<!Protocols> {}
@@ -2422,7 +2406,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Disposition
     protocol: !<!Protocols> {}
@@ -2433,7 +2417,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Encoding
     protocol: !<!Protocols> {}
@@ -2444,7 +2428,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Language
     protocol: !<!Protocols> {}
@@ -2455,7 +2439,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Range
     protocol: !<!Protocols> {}
@@ -2466,7 +2450,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -2477,7 +2461,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -2488,7 +2472,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -2499,7 +2483,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -2510,7 +2494,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -2522,7 +2506,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -2533,7 +2517,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -2544,7 +2528,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-resource-type
     protocol: !<!Protocols> {}
@@ -2555,7 +2539,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-properties
     protocol: !<!Protocols> {}
@@ -2566,7 +2550,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-duration
     protocol: !<!Protocols> {}
@@ -2577,7 +2561,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-state
     protocol: !<!Protocols> {}
@@ -2588,7 +2572,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-status
     protocol: !<!Protocols> {}
@@ -2599,7 +2583,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Accept-Ranges
     protocol: !<!Protocols> {}
@@ -2610,7 +2594,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Cache-Control
     protocol: !<!Protocols> {}
@@ -2621,7 +2605,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Disposition
     protocol: !<!Protocols> {}
@@ -2632,7 +2616,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Encoding
     protocol: !<!Protocols> {}
@@ -2643,7 +2627,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Language
     protocol: !<!Protocols> {}
@@ -2654,7 +2638,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Range
     protocol: !<!Protocols> {}
@@ -2665,7 +2649,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -2676,7 +2660,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -2687,7 +2671,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-content-md5
     protocol: !<!Protocols> {}
@@ -2698,7 +2682,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -2709,7 +2693,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -2720,7 +2704,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -2732,7 +2716,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -2743,7 +2727,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -2754,7 +2738,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-resource-type
     protocol: !<!Protocols> {}
@@ -2765,7 +2749,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-properties
     protocol: !<!Protocols> {}
@@ -2776,7 +2760,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-duration
     protocol: !<!Protocols> {}
@@ -2787,7 +2771,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-state
     protocol: !<!Protocols> {}
@@ -2798,7 +2782,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-status
     protocol: !<!Protocols> {}
@@ -2809,7 +2793,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_360
@@ -2820,7 +2804,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_361
@@ -2830,7 +2814,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_362
@@ -2840,7 +2824,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_363
@@ -2850,7 +2834,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_364
@@ -2860,7 +2844,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_378
@@ -2870,7 +2854,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Accept-Ranges
     protocol: !<!Protocols> {}
@@ -2881,7 +2865,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Cache-Control
     protocol: !<!Protocols> {}
@@ -2892,7 +2876,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Disposition
     protocol: !<!Protocols> {}
@@ -2903,7 +2887,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Encoding
     protocol: !<!Protocols> {}
@@ -2914,7 +2898,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Language
     protocol: !<!Protocols> {}
@@ -2925,7 +2909,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Range
     protocol: !<!Protocols> {}
@@ -2936,7 +2920,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-Type
     protocol: !<!Protocols> {}
@@ -2947,7 +2931,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Content-MD5
     protocol: !<!Protocols> {}
@@ -2958,7 +2942,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -2969,7 +2953,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: ETag
     protocol: !<!Protocols> {}
@@ -2980,7 +2964,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Last-Modified
     protocol: !<!Protocols> {}
@@ -2992,7 +2976,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -3003,7 +2987,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -3014,7 +2998,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-resource-type
     protocol: !<!Protocols> {}
@@ -3025,7 +3009,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-properties
     protocol: !<!Protocols> {}
@@ -3036,7 +3020,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-owner
     protocol: !<!Protocols> {}
@@ -3047,7 +3031,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-group
     protocol: !<!Protocols> {}
@@ -3058,7 +3042,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-permissions
     protocol: !<!Protocols> {}
@@ -3069,7 +3053,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-acl
     protocol: !<!Protocols> {}
@@ -3080,7 +3064,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-duration
     protocol: !<!Protocols> {}
@@ -3091,7 +3075,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-state
     protocol: !<!Protocols> {}
@@ -3102,7 +3086,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-lease-status
     protocol: !<!Protocols> {}
@@ -3113,7 +3097,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_403
@@ -3124,7 +3108,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_404
@@ -3134,7 +3118,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_405
@@ -3144,7 +3128,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_406
@@ -3154,7 +3138,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_407
@@ -3164,7 +3148,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_420
@@ -3174,7 +3158,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: Date
     protocol: !<!Protocols> {}
@@ -3186,7 +3170,7 @@ schemas: !<!Schemas>
     pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-request-id
     protocol: !<!Protocols> {}
@@ -3197,7 +3181,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-version
     protocol: !<!Protocols> {}
@@ -3208,7 +3192,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: x-ms-continuation
     protocol: !<!Protocols> {}
@@ -3219,7 +3203,7 @@ schemas: !<!Schemas>
       version: '2019-10-31'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> 
@@ -3230,7 +3214,7 @@ schemas: !<!Schemas>
     defaultValue: dfs.core.windows.net
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
 globalParameters:
@@ -3355,7 +3339,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -3377,7 +3361,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -3502,7 +3486,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -3524,7 +3508,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -3536,7 +3520,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-properties
+            name: xMSProperties
             description: >-
               User-defined properties to be stored with the filesystem, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string may only contain
               ASCII characters in the ISO-8859-1 character set.
@@ -3656,7 +3640,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -3678,7 +3662,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -3690,7 +3674,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-properties
+            name: xMSProperties
             description: >-
               Optional. User-defined properties to be stored with the filesystem, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string may
               only contain ASCII characters in the ISO-8859-1 character set.  If the filesystem exists, any properties not included in the list will be removed.  All properties are removed if the header is omitted.  To merge new and
@@ -3704,7 +3688,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Modified-Since
+            name: ifModifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has been modified since the specified date and time.
             serializedName: If-Modified-Since
         protocol: !<!Protocols> 
@@ -3715,7 +3699,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Unmodified-Since
+            name: ifUnmodifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
             serializedName: If-Unmodified-Since
         protocol: !<!Protocols> 
@@ -3834,7 +3818,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -3856,7 +3840,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -3977,7 +3961,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -3999,7 +3983,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -4011,7 +3995,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Modified-Since
+            name: ifModifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has been modified since the specified date and time.
             serializedName: If-Modified-Since
         protocol: !<!Protocols> 
@@ -4022,7 +4006,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Unmodified-Since
+            name: ifUnmodifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
             serializedName: If-Unmodified-Since
         protocol: !<!Protocols> 
@@ -4144,7 +4128,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -4166,7 +4150,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -4356,7 +4340,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -4378,7 +4362,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -4425,7 +4409,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: Cache-Control
+            name: cacheControl
             description: Optional.  The service stores this value and includes it in the "Cache-Control" response header for "Read File" operations for "Read File" operations.
             serializedName: Cache-Control
         protocol: !<!Protocols> 
@@ -4436,7 +4420,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: Content-Encoding
+            name: contentEncoding
             description: Optional.  Specifies which content encodings have been applied to the file. This value is returned to the client when the "Read File" operation is performed.
             serializedName: Content-Encoding
         protocol: !<!Protocols> 
@@ -4447,7 +4431,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: Content-Language
+            name: contentLanguage
             description: Optional.  Specifies the natural language used by the intended audience for the file.
             serializedName: Content-Language
         protocol: !<!Protocols> 
@@ -4458,7 +4442,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: Content-Disposition
+            name: contentDisposition
             description: Optional.  The service stores this value and includes it in the "Content-Disposition" response header for "Read File" operations.
             serializedName: Content-Disposition
         protocol: !<!Protocols> 
@@ -4469,7 +4453,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-cache-control
+            name: xMSCacheControl
             description: Optional.  The service stores this value and includes it in the "Cache-Control" response header for "Read File" operations.
             serializedName: x-ms-cache-control
         protocol: !<!Protocols> 
@@ -4480,7 +4464,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-type
+            name: xMSContentType
             description: Optional.  The service stores this value and includes it in the "Content-Type" response header for "Read File" operations.
             serializedName: x-ms-content-type
         protocol: !<!Protocols> 
@@ -4491,7 +4475,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-encoding
+            name: xMSContentEncoding
             description: Optional.  The service stores this value and includes it in the "Content-Encoding" response header for "Read File" operations.
             serializedName: x-ms-content-encoding
         protocol: !<!Protocols> 
@@ -4502,7 +4486,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-language
+            name: xMSContentLanguage
             description: Optional.  The service stores this value and includes it in the "Content-Language" response header for "Read File" operations.
             serializedName: x-ms-content-language
         protocol: !<!Protocols> 
@@ -4513,7 +4497,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-disposition
+            name: xMSContentDisposition
             description: Optional.  The service stores this value and includes it in the "Content-Disposition" response header for "Read File" operations.
             serializedName: x-ms-content-disposition
         protocol: !<!Protocols> 
@@ -4524,7 +4508,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-rename-source
+            name: xMSRenameSource
             description: >-
               An optional file or directory to be renamed.  The value must have the following format: "/{filesystem}/{path}".  If "x-ms-properties" is specified, the properties will overwrite the existing properties; otherwise, the existing
               properties will be preserved. This value must be a URL percent-encoded string. Note that the string may only contain ASCII characters in the ISO-8859-1 character set.
@@ -4537,7 +4521,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-lease-id
+            name: xMSLeaseId
             description: Optional.  A lease ID for the path specified in the URI.  The path to be overwritten must have an active lease and the lease ID must match.
             serializedName: x-ms-lease-id
         protocol: !<!Protocols> 
@@ -4548,7 +4532,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-source-lease-id
+            name: xMSSourceLeaseId
             description: Optional for rename operations.  A lease ID for the source path.  The source path must have an active lease and the lease ID must match.
             serializedName: x-ms-source-lease-id
         protocol: !<!Protocols> 
@@ -4559,7 +4543,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-properties
+            name: xMSProperties
             description: >-
               Optional.  User-defined properties to be stored with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string
               may only contain ASCII characters in the ISO-8859-1 character set.
@@ -4572,7 +4556,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-permissions
+            name: xMSPermissions
             description: >-
               Optional and only valid if Hierarchical Namespace is enabled for the account. Sets POSIX access permissions for the file owner, the file owning group, and others. Each class may be granted read, write, or execute permission. 
               The sticky bit is also supported.  Both symbolic (rwxrw-rw-) and 4-digit octal notation (e.g. 0766) are supported.
@@ -4585,7 +4569,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-umask
+            name: xMSUmask
             description: >-
               Optional and only valid if Hierarchical Namespace is enabled for the account. When creating a file or directory and the parent folder does not have a default ACL, the umask restricts the permissions of the file or directory to
               be created.  The resulting permission is given by p & ^u, where p is the permission and u is the umask.  For example, if p is 0777 and u is 0057, then the resulting permission is 0720.  The default permission is 0777 for a
@@ -4599,7 +4583,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Match
+            name: ifMatch
             description: Optional.  An ETag value. Specify this header to perform the operation only if the resource's ETag matches the value specified. The ETag must be specified in quotes.
             serializedName: If-Match
         protocol: !<!Protocols> 
@@ -4610,7 +4594,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-None-Match
+            name: ifNoneMatch
             description: Optional.  An ETag value or the special wildcard ("*") value. Specify this header to perform the operation only if the resource's ETag does not match the value specified. The ETag must be specified in quotes.
             serializedName: If-None-Match
         protocol: !<!Protocols> 
@@ -4621,7 +4605,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Modified-Since
+            name: ifModifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has been modified since the specified date and time.
             serializedName: If-Modified-Since
         protocol: !<!Protocols> 
@@ -4632,7 +4616,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Unmodified-Since
+            name: ifUnmodifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
             serializedName: If-Unmodified-Since
         protocol: !<!Protocols> 
@@ -4643,7 +4627,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-source-if-match
+            name: xMSSourceIfMatch
             description: Optional.  An ETag value. Specify this header to perform the rename operation only if the source's ETag matches the value specified. The ETag must be specified in quotes.
             serializedName: x-ms-source-if-match
         protocol: !<!Protocols> 
@@ -4654,7 +4638,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-source-if-none-match
+            name: xMSSourceIfNoneMatch
             description: Optional.  An ETag value or the special wildcard ("*") value. Specify this header to perform the rename operation only if the source's ETag does not match the value specified. The ETag must be specified in quotes.
             serializedName: x-ms-source-if-none-match
         protocol: !<!Protocols> 
@@ -4665,7 +4649,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-source-if-modified-since
+            name: xMSSourceIfModifiedSince
             description: Optional. A date and time value. Specify this header to perform the rename operation only if the source has been modified since the specified date and time.
             serializedName: x-ms-source-if-modified-since
         protocol: !<!Protocols> 
@@ -4676,7 +4660,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-source-if-unmodified-since
+            name: xMSSourceIfUnmodifiedSince
             description: Optional. A date and time value. Specify this header to perform the rename operation only if the source has not been modified since the specified date and time.
             serializedName: x-ms-source-if-unmodified-since
         protocol: !<!Protocols> 
@@ -4824,7 +4808,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -4846,7 +4830,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -4915,7 +4899,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: Content-Length
+            name: contentLength
             description: Required for "Append Data" and "Flush Data".  Must be 0 for "Flush Data".  Must be the length of the request content in bytes for "Append Data".
             serializedName: Content-Length
         protocol: !<!Protocols> 
@@ -4926,7 +4910,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: Content-MD5
+            name: contentMd5
             description: >-
               Optional. An MD5 hash of the request content. This header is valid on "Append" and "Flush" operations. This hash is used to verify the integrity of the request content during transport. When this header is specified, the
               storage service compares the hash of the content that has arrived with this header value. If the two hashes do not match, the operation will fail with error code 400 (Bad Request). Note that this MD5 hash is not stored with
@@ -4940,7 +4924,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-lease-id
+            name: xMSLeaseId
             description: The lease ID must be specified if there is an active lease.
             serializedName: x-ms-lease-id
         protocol: !<!Protocols> 
@@ -4951,7 +4935,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-cache-control
+            name: xMSCacheControl
             description: Optional and only valid for flush and set properties operations.  The service stores this value and includes it in the "Cache-Control" response header for "Read File" operations.
             serializedName: x-ms-cache-control
         protocol: !<!Protocols> 
@@ -4962,7 +4946,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-type
+            name: xMSContentType
             description: Optional and only valid for flush and set properties operations.  The service stores this value and includes it in the "Content-Type" response header for "Read File" operations.
             serializedName: x-ms-content-type
         protocol: !<!Protocols> 
@@ -4973,7 +4957,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-disposition
+            name: xMSContentDisposition
             description: Optional and only valid for flush and set properties operations.  The service stores this value and includes it in the "Content-Disposition" response header for "Read File" operations.
             serializedName: x-ms-content-disposition
         protocol: !<!Protocols> 
@@ -4984,7 +4968,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-encoding
+            name: xMSContentEncoding
             description: Optional and only valid for flush and set properties operations.  The service stores this value and includes it in the "Content-Encoding" response header for "Read File" operations.
             serializedName: x-ms-content-encoding
         protocol: !<!Protocols> 
@@ -4995,7 +4979,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-language
+            name: xMSContentLanguage
             description: Optional and only valid for flush and set properties operations.  The service stores this value and includes it in the "Content-Language" response header for "Read File" operations.
             serializedName: x-ms-content-language
         protocol: !<!Protocols> 
@@ -5006,7 +4990,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-content-md5
+            name: xMSContentMd5
             description: >-
               Optional and only valid for "Flush & Set Properties" operations.  The service stores this value and includes it in the "Content-Md5" response header for "Read & Get Properties" operations. If this property is not specified on
               the request, then the property will be cleared for the file. Subsequent calls to "Read & Get Properties" will not return this property unless it is explicitly set on that file again.
@@ -5019,7 +5003,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-properties
+            name: xMSProperties
             description: >-
               Optional.  User-defined properties to be stored with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string
               may only contain ASCII characters in the ISO-8859-1 character set. Valid only for the setProperties operation. If the file or directory exists, any properties not included in the list will be removed.  All properties are
@@ -5033,7 +5017,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-owner
+            name: xMSOwner
             description: Optional and valid only for the setAccessControl operation. Sets the owner of the file or directory.
             serializedName: x-ms-owner
         protocol: !<!Protocols> 
@@ -5044,7 +5028,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-group
+            name: xMSGroup
             description: Optional and valid only for the setAccessControl operation. Sets the owning group of the file or directory.
             serializedName: x-ms-group
         protocol: !<!Protocols> 
@@ -5055,7 +5039,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-permissions
+            name: xMSPermissions
             description: >-
               Optional and only valid if Hierarchical Namespace is enabled for the account. Sets POSIX access permissions for the file owner, the file owning group, and others. Each class may be granted read, write, or execute permission. 
               The sticky bit is also supported.  Both symbolic (rwxrw-rw-) and 4-digit octal notation (e.g. 0766) are supported. Invalid in conjunction with x-ms-acl.
@@ -5068,7 +5052,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-acl
+            name: xMSAcl
             description: >-
               Optional and valid only for the setAccessControl operation. Sets POSIX access control rights on files and directories. The value is a comma-separated list of access control entries that fully replaces the existing access
               control list (ACL).  Each access control entry (ACE) consists of a scope, a type, a user or group identifier, and permissions in the format "[scope:][type]:[id]:[permissions]". The scope must be "default" to indicate the ACE
@@ -5087,7 +5071,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Match
+            name: ifMatch
             description: >-
               Optional for Flush Data and Set Properties, but invalid for Append Data.  An ETag value. Specify this header to perform the operation only if the resource's ETag matches the value specified. The ETag must be specified in
               quotes.
@@ -5100,7 +5084,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-None-Match
+            name: ifNoneMatch
             description: >-
               Optional for Flush Data and Set Properties, but invalid for Append Data.  An ETag value or the special wildcard ("*") value. Specify this header to perform the operation only if the resource's ETag does not match the value
               specified. The ETag must be specified in quotes.
@@ -5113,7 +5097,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Modified-Since
+            name: ifModifiedSince
             description: 'Optional for Flush Data and Set Properties, but invalid for Append Data. A date and time value. Specify this header to perform the operation only if the resource has been modified since the specified date and time.'
             serializedName: If-Modified-Since
         protocol: !<!Protocols> 
@@ -5124,7 +5108,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Unmodified-Since
+            name: ifUnmodifiedSince
             description: 'Optional for Flush Data and Set Properties, but invalid for Append Data. A date and time value. Specify this header to perform the operation only if the resource has not been modified since the specified date and time.'
             serializedName: If-Unmodified-Since
         protocol: !<!Protocols> 
@@ -5335,7 +5319,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -5357,7 +5341,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -5370,7 +5354,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: x-ms-lease-action
+            name: xMSLeaseAction
             description: >-
               There are five lease actions: "acquire", "break", "change", "renew", and "release". Use "acquire" and specify the "x-ms-proposed-lease-id" and "x-ms-lease-duration" to acquire a new lease. Use "break" to break an existing
               lease. When a lease is broken, the lease break period is allowed to elapse, during which time no lease operation except break and release can be performed on the file. When a lease is successfully broken, the response
@@ -5385,7 +5369,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-lease-duration
+            name: xMSLeaseDuration
             description: 'The lease duration is required to acquire a lease, and specifies the duration of the lease in seconds.  The lease duration must be between 15 and 60 seconds or -1 for infinite lease.'
             serializedName: x-ms-lease-duration
         protocol: !<!Protocols> 
@@ -5396,7 +5380,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-lease-break-period
+            name: xMSLeaseBreakPeriod
             description: 'The lease break period duration is optional to break a lease, and  specifies the break period of the lease in seconds.  The lease break  duration must be between 0 and 60 seconds.'
             serializedName: x-ms-lease-break-period
         protocol: !<!Protocols> 
@@ -5407,7 +5391,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-lease-id
+            name: xMSLeaseId
             description: 'Required when "x-ms-lease-action" is "renew", "change" or "release". For the renew and release actions, this must match the current lease ID.'
             serializedName: x-ms-lease-id
         protocol: !<!Protocols> 
@@ -5418,7 +5402,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-proposed-lease-id
+            name: xMSProposedLeaseId
             description: Required when "x-ms-lease-action" is "acquire" or "change".  A lease will be acquired with this lease ID if the operation is successful.
             serializedName: x-ms-proposed-lease-id
         protocol: !<!Protocols> 
@@ -5429,7 +5413,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Match
+            name: ifMatch
             description: Optional.  An ETag value. Specify this header to perform the operation only if the resource's ETag matches the value specified. The ETag must be specified in quotes.
             serializedName: If-Match
         protocol: !<!Protocols> 
@@ -5440,7 +5424,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-None-Match
+            name: ifNoneMatch
             description: Optional.  An ETag value or the special wildcard ("*") value. Specify this header to perform the operation only if the resource's ETag does not match the value specified. The ETag must be specified in quotes.
             serializedName: If-None-Match
         protocol: !<!Protocols> 
@@ -5451,7 +5435,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Modified-Since
+            name: ifModifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has been modified since the specified date and time.
             serializedName: If-Modified-Since
         protocol: !<!Protocols> 
@@ -5462,7 +5446,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Unmodified-Since
+            name: ifUnmodifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
             serializedName: If-Unmodified-Since
         protocol: !<!Protocols> 
@@ -5642,7 +5626,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -5664,7 +5648,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -5676,7 +5660,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: Range
+            name: range
             description: The HTTP Range request header specifies one or more byte ranges of the resource to be retrieved.
             serializedName: Range
         protocol: !<!Protocols> 
@@ -5687,7 +5671,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-lease-id
+            name: xMSLeaseId
             description: >-
               Optional. If this header is specified, the operation will be performed only if both of the following conditions are met: i) the path's lease is currently active and ii) the lease ID specified in the request matches that of the
               path.
@@ -5700,7 +5684,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-range-get-content-md5
+            name: xMSRangeGetContentMd5
             description: >-
               Optional. When this header is set to "true" and specified together with the Range header, the service returns the MD5 hash for the range, as long as the range is less than or equal to 4MB in size. If this header is specified
               without the Range header, the service returns status code 400 (Bad Request). If this header is set to true when the range exceeds 4 MB in size, the service returns status code 400 (Bad Request).
@@ -5713,7 +5697,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Match
+            name: ifMatch
             description: Optional.  An ETag value. Specify this header to perform the operation only if the resource's ETag matches the value specified. The ETag must be specified in quotes.
             serializedName: If-Match
         protocol: !<!Protocols> 
@@ -5724,7 +5708,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-None-Match
+            name: ifNoneMatch
             description: Optional.  An ETag value or the special wildcard ("*") value. Specify this header to perform the operation only if the resource's ETag does not match the value specified. The ETag must be specified in quotes.
             serializedName: If-None-Match
         protocol: !<!Protocols> 
@@ -5735,7 +5719,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Modified-Since
+            name: ifModifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has been modified since the specified date and time.
             serializedName: If-Modified-Since
         protocol: !<!Protocols> 
@@ -5746,7 +5730,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Unmodified-Since
+            name: ifUnmodifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
             serializedName: If-Unmodified-Since
         protocol: !<!Protocols> 
@@ -5990,7 +5974,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -6012,7 +5996,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -6062,7 +6046,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-lease-id
+            name: xMSLeaseId
             description: >-
               Optional. If this header is specified, the operation will be performed only if both of the following conditions are met: i) the path's lease is currently active and ii) the lease ID specified in the request matches that of the
               path.
@@ -6075,7 +6059,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Match
+            name: ifMatch
             description: Optional.  An ETag value. Specify this header to perform the operation only if the resource's ETag matches the value specified. The ETag must be specified in quotes.
             serializedName: If-Match
         protocol: !<!Protocols> 
@@ -6086,7 +6070,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-None-Match
+            name: ifNoneMatch
             description: Optional.  An ETag value or the special wildcard ("*") value. Specify this header to perform the operation only if the resource's ETag does not match the value specified. The ETag must be specified in quotes.
             serializedName: If-None-Match
         protocol: !<!Protocols> 
@@ -6097,7 +6081,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Modified-Since
+            name: ifModifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has been modified since the specified date and time.
             serializedName: If-Modified-Since
         protocol: !<!Protocols> 
@@ -6108,7 +6092,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Unmodified-Since
+            name: ifUnmodifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
             serializedName: If-Unmodified-Since
         protocol: !<!Protocols> 
@@ -6286,7 +6270,7 @@ operationGroups:
           x-ms-client-request-id: true
         language: !<!Languages> 
           default:
-            name: x-ms-client-request-id
+            name: xMSClientRequestId
             description: A UUID recorded in the analytics logs for troubleshooting and correlation.
             serializedName: x-ms-client-request-id
         protocol: !<!Protocols> 
@@ -6308,7 +6292,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-date
+            name: xMSDate
             description: Specifies the Coordinated Universal Time (UTC) for the request.  This is required when using shared key authorization.
             serializedName: x-ms-date
         protocol: !<!Protocols> 
@@ -6344,7 +6328,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: x-ms-lease-id
+            name: xMSLeaseId
             description: The lease ID must be specified if there is an active lease.
             serializedName: x-ms-lease-id
         protocol: !<!Protocols> 
@@ -6355,7 +6339,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Match
+            name: ifMatch
             description: Optional.  An ETag value. Specify this header to perform the operation only if the resource's ETag matches the value specified. The ETag must be specified in quotes.
             serializedName: If-Match
         protocol: !<!Protocols> 
@@ -6366,7 +6350,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-None-Match
+            name: ifNoneMatch
             description: Optional.  An ETag value or the special wildcard ("*") value. Specify this header to perform the operation only if the resource's ETag does not match the value specified. The ETag must be specified in quotes.
             serializedName: If-None-Match
         protocol: !<!Protocols> 
@@ -6377,7 +6361,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Modified-Since
+            name: ifModifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has been modified since the specified date and time.
             serializedName: If-Modified-Since
         protocol: !<!Protocols> 
@@ -6388,7 +6372,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: If-Unmodified-Since
+            name: ifUnmodifiedSince
             description: Optional. A date and time value. Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
             serializedName: If-Unmodified-Since
         protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           version: '2016-07-07'
         language: !<!Languages> 
           default:
-            name: Pet-name
+            name: PetName
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -24,7 +24,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ChoiceSchema> &ref_1
@@ -79,7 +78,7 @@ schemas: !<!Schemas>
           type: string
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: simple string
           protocol: !<!Protocols> {}
         defaultValue: Friday
@@ -92,9 +91,8 @@ schemas: !<!Schemas>
       serializedName: DaysOfWeek
       language: !<!Languages> 
         default:
-          name: DaysOfWeek
+          name: daysOfWeek
           description: Type of Pet
-          originalName: DaysOfWeek
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ChoiceSchema> &ref_2
@@ -103,19 +101,19 @@ schemas: !<!Schemas>
           value: '1'
           language:
             default:
-              name: '1'
+              name: One
               description: one
         - !<!ChoiceValue> 
           value: '2'
           language:
             default:
-              name: '2'
+              name: Two
               description: two
         - !<!ChoiceValue> 
           value: '3'
           language:
             default:
-              name: '3'
+              name: Three
               description: three
         type: choice
         apiVersions:
@@ -131,9 +129,8 @@ schemas: !<!Schemas>
       serializedName: IntEnum
       language: !<!Languages> 
         default:
-          name: IntEnum
+          name: intEnum
           description: ''
-          originalName: IntEnum
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -153,7 +150,7 @@ schemas: !<!Schemas>
       version: '2016-07-07'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_3

--- a/modelerfour/test/scenarios/head-exceptions/namer.yaml
+++ b/modelerfour/test/scenarios/head-exceptions/namer.yaml
@@ -5,7 +5,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
 globalParameters:
@@ -70,7 +70,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head200
+        name: Head200
         description: Return 200 status code if successful
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -112,7 +112,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head204
+        name: Head204
         description: Return 204 status code if successful
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -154,12 +154,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head404
+        name: Head404
         description: Return 404 status code if successful
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: headException
+      name: HeadException
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/head/namer.yaml
+++ b/modelerfour/test/scenarios/head/namer.yaml
@@ -5,7 +5,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
 globalParameters:
@@ -79,7 +79,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head200
+        name: Head200
         description: Return 200 status code if successful
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -130,7 +130,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head204
+        name: Head204
         description: Return 204 status code if successful
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -181,12 +181,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head404
+        name: Head404
         description: Return 404 status code if successful
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpSuccess
+      name: HttpSuccess
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/header/namer.yaml
+++ b/modelerfour/test/scenarios/header/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_2
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -55,7 +53,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -68,7 +66,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -81,7 +79,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -93,7 +91,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -105,7 +103,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: date
+        name: Date
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -117,7 +115,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: duration
+        name: Duration
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -131,7 +129,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -143,7 +141,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -155,7 +153,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -167,7 +165,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -184,13 +182,13 @@ schemas: !<!Schemas>
       value: black
       language:
         default:
-          name: black
+          name: Black
           description: ''
     - !<!ChoiceValue> 
       value: GREY
       language:
         default:
-          name: GREY
+          name: Grey
           description: ''
     type: sealed-choice
     apiVersions:
@@ -200,7 +198,7 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -218,7 +216,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
         header: value
     protocol: !<!Protocols> {}
@@ -259,7 +257,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: User-Agent
+            name: userAgent
             description: 'Send a post request with header value "User-Agent": "overwrite"'
             serializedName: User-Agent
         protocol: !<!Protocols> 
@@ -302,7 +300,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramExistingKey
+        name: ParamExistingKey
         description: 'Send a post request with header value "User-Agent": "overwrite"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -352,7 +350,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseExistingKey
+        name: ResponseExistingKey
         description: 'Get a response with header value "User-Agent": "overwrite"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -368,7 +366,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: Content-Type
+            name: contentType
             description: 'Send a post request with header value "Content-Type": "text/html"'
             serializedName: Content-Type
         protocol: !<!Protocols> 
@@ -411,7 +409,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramProtectedKey
+        name: ParamProtectedKey
         description: 'Send a post request with header value "Content-Type": "text/html"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -461,7 +459,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseProtectedKey
+        name: ResponseProtectedKey
         description: 'Get a response with header value "Content-Type": "text/html"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -533,7 +531,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramInteger
+        name: ParamInteger
         description: 'Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2 '
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -596,7 +594,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseInteger
+        name: ResponseInteger
         description: 'Get a response with header value "value": 1 or -2'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -668,7 +666,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramLong
+        name: ParamLong
         description: 'Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2 '
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -731,7 +729,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseLong
+        name: ResponseLong
         description: 'Get a response with header value "value": 105 or -2'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -803,7 +801,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramFloat
+        name: ParamFloat
         description: 'Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -866,7 +864,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseFloat
+        name: ResponseFloat
         description: 'Get a response with header value "value": 0.07 or -3.0'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -938,7 +936,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramDouble
+        name: ParamDouble
         description: 'Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1001,7 +999,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseDouble
+        name: ResponseDouble
         description: 'Get a response with header value "value": 7e120 or -3.0'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1073,7 +1071,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramBool
+        name: ParamBool
         description: 'Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1136,7 +1134,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseBool
+        name: ResponseBool
         description: 'Get a response with header value "value": true or false'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1207,7 +1205,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramString
+        name: ParamString
         description: 'Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1270,7 +1268,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseString
+        name: ResponseString
         description: Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1342,7 +1340,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramDate
+        name: ParamDate
         description: 'Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1405,7 +1403,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseDate
+        name: ResponseDate
         description: Get a response with header values "2010-01-01" or "0001-01-01"
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1477,7 +1475,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramDatetime
+        name: ParamDatetime
         description: 'Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1540,7 +1538,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseDatetime
+        name: ResponseDatetime
         description: 'Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1611,7 +1609,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramDatetimeRfc1123
+        name: ParamDatetimeRfc1123
         description: 'Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1674,7 +1672,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseDatetimeRfc1123
+        name: ResponseDatetimeRfc1123
         description: 'Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1746,7 +1744,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramDuration
+        name: ParamDuration
         description: 'Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1809,7 +1807,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseDuration
+        name: ResponseDuration
         description: Get a response with header values "P123DT22H14M12.011S"
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1881,7 +1879,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramByte
+        name: ParamByte
         description: 'Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1944,7 +1942,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseByte
+        name: ResponseByte
         description: Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2015,7 +2013,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: paramEnum
+        name: ParamEnum
         description: 'Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2078,7 +2076,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: responseEnum
+        name: ResponseEnum
         description: Get a response with header values "GREY" or null
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2124,12 +2122,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: customRequestId
+        name: CustomRequestId
         description: Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: header
+      name: Header
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_5
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -73,7 +71,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: B-textStatusCode
+                name: BTextStatusCode
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: textStatusCode
@@ -81,7 +79,6 @@ schemas: !<!Schemas>
             default:
               name: textStatusCode
               description: ''
-              originalName: textStatusCode
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -100,7 +97,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: A-statusCode
+            name: AStatusCode
             description: ''
         protocol: !<!Protocols> {}
       serializedName: statusCode
@@ -108,7 +105,6 @@ schemas: !<!Schemas>
         default:
           name: statusCode
           description: ''
-          originalName: statusCode
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -131,7 +127,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: C-httpCode
+            name: CHttpCode
             description: ''
         protocol: !<!Protocols> {}
       serializedName: httpCode
@@ -139,7 +135,6 @@ schemas: !<!Schemas>
         default:
           name: httpCode
           description: ''
-          originalName: httpCode
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -161,7 +156,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: D-httpStatusCode
+            name: DHttpStatusCode
             description: ''
         protocol: !<!Protocols> {}
       serializedName: httpStatusCode
@@ -169,7 +164,6 @@ schemas: !<!Schemas>
         default:
           name: httpStatusCode
           description: ''
-          originalName: httpStatusCode
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -190,12 +184,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: get-300-application-json-itemsItem
+          name: Get300ApplicationJsonItemsItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfget-300-application-json-itemsItem
+        name: ArrayOfGet300ApplicationJsonItemsItem
         description: 'A list of location options for the request [''/http/success/get/200'']'
     protocol: !<!Protocols> {}
   booleans:
@@ -203,7 +197,7 @@ schemas: !<!Schemas>
     type: boolean
     language: !<!Languages> 
       default:
-        name: bool
+        name: Bool
         description: simple boolean
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_13
@@ -213,7 +207,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: Simple boolean value true
     protocol: !<!Protocols> {}
   constants:
@@ -249,7 +243,7 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -464,7 +458,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmptyError
+        name: GetEmptyError
         description: Get empty error form server
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -500,7 +494,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getNoModelError
+        name: GetNoModelError
         description: Get empty error form server
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -536,12 +530,12 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getNoModelEmpty
+        name: GetNoModelEmpty
         description: Get empty response from server
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpFailure
+      name: HttpFailure
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -590,7 +584,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head200
+        name: Head200
         description: Return 200 status code if successful
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -640,7 +634,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200
+        name: Get200
         description: Get 200 success
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -690,7 +684,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options200
+        name: Options200
         description: Options 200 success
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -755,7 +749,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put200
+        name: Put200
         description: Put boolean value true returning 200 success
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -820,7 +814,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch200
+        name: Patch200
         description: Patch true Boolean value in request returning 200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -885,7 +879,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post200
+        name: Post200
         description: Post bollean value true in request that returns a 200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -950,7 +944,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete200
+        name: Delete200
         description: Delete simple boolean value true returns 200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1015,7 +1009,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put201
+        name: Put201
         description: Put true Boolean value in request returns 201
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1080,7 +1074,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post201
+        name: Post201
         description: Post true Boolean value in request returns 201 (Created)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1145,7 +1139,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put202
+        name: Put202
         description: Put true Boolean value in request returns 202 (Accepted)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1210,7 +1204,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch202
+        name: Patch202
         description: Patch true Boolean value in request returns 202
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1275,7 +1269,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202
+        name: Post202
         description: Post true Boolean value in request returns 202 (Accepted)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1340,7 +1334,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete202
+        name: Delete202
         description: Delete true Boolean value in request returns 202 (accepted)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1386,7 +1380,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head204
+        name: Head204
         description: Return 204 status code if successful
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1451,7 +1445,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put204
+        name: Put204
         description: Put true Boolean value in request returns 204 (no content)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1516,7 +1510,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch204
+        name: Patch204
         description: Patch true Boolean value in request returns 204 (no content)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1581,7 +1575,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post204
+        name: Post204
         description: Post true Boolean value in request returns 204 (no content)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1646,7 +1640,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete204
+        name: Delete204
         description: Delete true Boolean value in request returns 204 (no content)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1701,12 +1695,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head404
+        name: Head404
         description: Return 404 status code
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpSuccess
+      name: HttpSuccess
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1768,7 +1762,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head300
+        name: Head300
         description: Return 300 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1831,7 +1825,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get300
+        name: Get300
         description: Return 300 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1890,7 +1884,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head301
+        name: Head301
         description: Return 301 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1949,7 +1943,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get301
+        name: Get301
         description: Return 301 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2018,7 +2012,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put301
+        name: Put301
         description: 'Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2077,7 +2071,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head302
+        name: Head302
         description: Return 302 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2136,7 +2130,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get302
+        name: Get302
         description: Return 302 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2205,7 +2199,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch302
+        name: Patch302
         description: 'Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2283,7 +2277,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post303
+        name: Post303
         description: 'Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2342,7 +2336,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head307
+        name: Head307
         description: 'Redirect with 307, resulting in a 200 success'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2401,7 +2395,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get307
+        name: Get307
         description: 'Redirect get with 307, resulting in a 200 success'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2460,7 +2454,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options307
+        name: Options307
         description: 'options redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2538,7 +2532,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put307
+        name: Put307
         description: 'Put redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2616,7 +2610,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch307
+        name: Patch307
         description: 'Patch redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2694,7 +2688,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post307
+        name: Post307
         description: 'Post redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2772,12 +2766,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete307
+        name: Delete307
         description: 'Delete redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpRedirects
+      name: HttpRedirects
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -2816,7 +2810,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head400
+        name: Head400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2852,7 +2846,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get400
+        name: Get400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2888,7 +2882,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options400
+        name: Options400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2943,7 +2937,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put400
+        name: Put400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2998,7 +2992,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch400
+        name: Patch400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3053,7 +3047,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post400
+        name: Post400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3108,7 +3102,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete400
+        name: Delete400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3144,7 +3138,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head401
+        name: Head401
         description: Return 401 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3180,7 +3174,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get402
+        name: Get402
         description: Return 402 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3216,7 +3210,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options403
+        name: Options403
         description: Return 403 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3252,7 +3246,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get403
+        name: Get403
         description: Return 403 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3307,7 +3301,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put404
+        name: Put404
         description: Return 404 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3362,7 +3356,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch405
+        name: Patch405
         description: Return 405 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3417,7 +3411,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post406
+        name: Post406
         description: Return 406 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3472,7 +3466,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete407
+        name: Delete407
         description: Return 407 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3527,7 +3521,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put409
+        name: Put409
         description: Return 409 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3563,7 +3557,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head410
+        name: Head410
         description: Return 410 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3599,7 +3593,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get411
+        name: Get411
         description: Return 411 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3635,7 +3629,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options412
+        name: Options412
         description: Return 412 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3671,7 +3665,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get412
+        name: Get412
         description: Return 412 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3726,7 +3720,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put413
+        name: Put413
         description: Return 413 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3781,7 +3775,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch414
+        name: Patch414
         description: Return 414 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3836,7 +3830,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post415
+        name: Post415
         description: Return 415 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3872,7 +3866,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get416
+        name: Get416
         description: Return 416 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3927,7 +3921,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete417
+        name: Delete417
         description: Return 417 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3963,12 +3957,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head429
+        name: Head429
         description: Return 429 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpClientFailure
+      name: HttpClientFailure
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4007,7 +4001,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head501
+        name: Head501
         description: Return 501 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4043,7 +4037,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get501
+        name: Get501
         description: Return 501 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4098,7 +4092,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post505
+        name: Post505
         description: Return 505 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4153,12 +4147,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete505
+        name: Delete505
         description: Return 505 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpServerFailure
+      name: HttpServerFailure
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4207,7 +4201,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head408
+        name: Head408
         description: 'Return 408 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4272,7 +4266,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put500
+        name: Put500
         description: 'Return 500 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4337,7 +4331,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch500
+        name: Patch500
         description: 'Return 500 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4383,7 +4377,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get502
+        name: Get502
         description: 'Return 502 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4433,7 +4427,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options502
+        name: Options502
         description: 'Return 502 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4498,7 +4492,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post503
+        name: Post503
         description: 'Return 503 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4563,7 +4557,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete503
+        name: Delete503
         description: 'Return 503 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4628,7 +4622,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put504
+        name: Put504
         description: 'Return 504 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4693,12 +4687,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch504
+        name: Patch504
         description: 'Return 504 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpRetry
+      name: HttpRetry
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4760,7 +4754,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError200Valid
+        name: Get200Model204NoModelDefaultError200Valid
         description: 'Send a 200 response with valid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4819,7 +4813,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError204Valid
+        name: Get200Model204NoModelDefaultError204Valid
         description: Send a 204 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4878,7 +4872,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError201Invalid
+        name: Get200Model204NoModelDefaultError201Invalid
         description: 'Send a 201 response with valid payload: {''statusCode'': ''201''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4937,7 +4931,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError202None
+        name: Get200Model204NoModelDefaultError202None
         description: 'Send a 202 response with no payload:'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4996,7 +4990,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError400Valid
+        name: Get200Model204NoModelDefaultError400Valid
         description: 'Send a 400 response with valid error payload: {''status'': 400, ''message'': ''client error''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5059,7 +5053,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model201ModelDefaultError200Valid
+        name: Get200Model201ModelDefaultError200Valid
         description: 'Send a 200 response with valid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5122,7 +5116,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model201ModelDefaultError201Valid
+        name: Get200Model201ModelDefaultError201Valid
         description: 'Send a 201 response with valid payload: {''statusCode'': ''201'', ''textStatusCode'': ''Created''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5185,7 +5179,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model201ModelDefaultError400Valid
+        name: Get200Model201ModelDefaultError400Valid
         description: 'Send a 400 response with valid payload: {''code'': ''400'', ''message'': ''client error''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5261,7 +5255,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200ModelA201ModelC404ModelDDefaultError200Valid
+        name: Get200ModelA201ModelC404ModelDDefaultError200Valid
         description: 'Send a 200 response with valid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5337,7 +5331,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200ModelA201ModelC404ModelDDefaultError201Valid
+        name: Get200ModelA201ModelC404ModelDDefaultError201Valid
         description: 'Send a 200 response with valid payload: {''httpCode'': ''201''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5413,7 +5407,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200ModelA201ModelC404ModelDDefaultError404Valid
+        name: Get200ModelA201ModelC404ModelDDefaultError404Valid
         description: 'Send a 200 response with valid payload: {''httpStatusCode'': ''404''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5489,7 +5483,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200ModelA201ModelC404ModelDDefaultError400Valid
+        name: Get200ModelA201ModelC404ModelDDefaultError400Valid
         description: 'Send a 400 response with valid payload: {''code'': ''400'', ''message'': ''client error''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5544,7 +5538,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultError202None
+        name: Get202None204NoneDefaultError202None
         description: Send a 202 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5599,7 +5593,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultError204None
+        name: Get202None204NoneDefaultError204None
         description: Send a 204 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5654,7 +5648,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultError400Valid
+        name: Get202None204NoneDefaultError400Valid
         description: 'Send a 400 response with valid payload: {''code'': ''400'', ''message'': ''client error''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5705,7 +5699,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultNone202Invalid
+        name: Get202None204NoneDefaultNone202Invalid
         description: 'Send a 202 response with an unexpected payload {''property'': ''value''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5756,7 +5750,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultNone204None
+        name: Get202None204NoneDefaultNone204None
         description: Send a 204 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5807,7 +5801,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultNone400None
+        name: Get202None204NoneDefaultNone400None
         description: Send a 400 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5858,7 +5852,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultNone400Invalid
+        name: Get202None204NoneDefaultNone400Invalid
         description: 'Send a 400 response with an unexpected payload {''property'': ''value''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5894,7 +5888,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultModelA200Valid
+        name: GetDefaultModelA200Valid
         description: 'Send a 200 response with valid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5930,7 +5924,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultModelA200None
+        name: GetDefaultModelA200None
         description: Send a 200 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5966,7 +5960,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultModelA400Valid
+        name: GetDefaultModelA400Valid
         description: 'Send a 400 response with valid payload: {''statusCode'': ''400''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6002,7 +5996,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultModelA400None
+        name: GetDefaultModelA400None
         description: Send a 400 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6034,7 +6028,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultNone200Invalid
+        name: GetDefaultNone200Invalid
         description: 'Send a 200 response with invalid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6066,7 +6060,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultNone200None
+        name: GetDefaultNone200None
         description: Send a 200 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6098,7 +6092,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultNone400Invalid
+        name: GetDefaultNone400Invalid
         description: 'Send a 400 response with valid payload: {''statusCode'': ''400''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6130,7 +6124,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultNone400None
+        name: GetDefaultNone400None
         description: Send a 400 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6166,7 +6160,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA200None
+        name: Get200ModelA200None
         description: 'Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6202,7 +6196,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA200Valid
+        name: Get200ModelA200Valid
         description: 'Send a 200 response with payload {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6238,7 +6232,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA200Invalid
+        name: Get200ModelA200Invalid
         description: 'Send a 200 response with invalid payload {''statusCodeInvalid'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6274,7 +6268,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA400None
+        name: Get200ModelA400None
         description: Send a 400 response with no payload client should treat as an http error with no error model
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6310,7 +6304,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA400Valid
+        name: Get200ModelA400Valid
         description: 'Send a 200 response with payload {''statusCode'': ''400''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6346,7 +6340,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA400Invalid
+        name: Get200ModelA400Invalid
         description: 'Send a 200 response with invalid payload {''statusCodeInvalid'': ''400''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6382,12 +6376,12 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA202Valid
+        name: Get200ModelA202Valid
         description: 'Send a 202 response with payload {''statusCode'': ''202''}'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: multipleResponses
+      name: MultipleResponses
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_5
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -73,7 +71,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: B-textStatusCode
+                name: BTextStatusCode
                 description: ''
             protocol: !<!Protocols> {}
           serializedName: textStatusCode
@@ -81,7 +79,6 @@ schemas: !<!Schemas>
             default:
               name: textStatusCode
               description: ''
-              originalName: textStatusCode
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -100,7 +97,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: A-statusCode
+            name: AStatusCode
             description: ''
         protocol: !<!Protocols> {}
       serializedName: statusCode
@@ -108,7 +105,6 @@ schemas: !<!Schemas>
         default:
           name: statusCode
           description: ''
-          originalName: statusCode
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -131,7 +127,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: C-httpCode
+            name: CHttpCode
             description: ''
         protocol: !<!Protocols> {}
       serializedName: httpCode
@@ -139,7 +135,6 @@ schemas: !<!Schemas>
         default:
           name: httpCode
           description: ''
-          originalName: httpCode
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -161,7 +156,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: D-httpStatusCode
+            name: DHttpStatusCode
             description: ''
         protocol: !<!Protocols> {}
       serializedName: httpStatusCode
@@ -169,7 +164,6 @@ schemas: !<!Schemas>
         default:
           name: httpStatusCode
           description: ''
-          originalName: httpStatusCode
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -190,12 +184,12 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: get-300-application-json-itemsItem
+          name: Get300ApplicationJsonItemsItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ArrayOfget-300-application-json-itemsItem
+        name: ArrayOfGet300ApplicationJsonItemsItem
         description: 'A list of location options for the request [''/http/success/get/200'']'
     protocol: !<!Protocols> {}
   booleans:
@@ -203,7 +197,7 @@ schemas: !<!Schemas>
     type: boolean
     language: !<!Languages> 
       default:
-        name: bool
+        name: Bool
         description: simple boolean
     protocol: !<!Protocols> {}
   constants:
@@ -239,7 +233,7 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
@@ -454,7 +448,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getEmptyError
+        name: GetEmptyError
         description: Get empty error form server
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -490,7 +484,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getNoModelError
+        name: GetNoModelError
         description: Get empty error form server
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -526,12 +520,12 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getNoModelEmpty
+        name: GetNoModelEmpty
         description: Get empty response from server
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpFailure
+      name: HttpFailure
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -580,7 +574,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head200
+        name: Head200
         description: Return 200 status code if successful
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -630,7 +624,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200
+        name: Get200
         description: Get 200 success
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -680,7 +674,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options200
+        name: Options200
         description: Options 200 success
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -744,7 +738,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put200
+        name: Put200
         description: Put boolean value true returning 200 success
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -808,7 +802,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch200
+        name: Patch200
         description: Patch true Boolean value in request returning 200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -872,7 +866,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post200
+        name: Post200
         description: Post bollean value true in request that returns a 200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -936,7 +930,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete200
+        name: Delete200
         description: Delete simple boolean value true returns 200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1000,7 +994,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put201
+        name: Put201
         description: Put true Boolean value in request returns 201
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1064,7 +1058,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post201
+        name: Post201
         description: Post true Boolean value in request returns 201 (Created)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1128,7 +1122,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put202
+        name: Put202
         description: Put true Boolean value in request returns 202 (Accepted)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1192,7 +1186,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch202
+        name: Patch202
         description: Patch true Boolean value in request returns 202
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1256,7 +1250,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202
+        name: Post202
         description: Post true Boolean value in request returns 202 (Accepted)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1320,7 +1314,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete202
+        name: Delete202
         description: Delete true Boolean value in request returns 202 (accepted)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1366,7 +1360,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head204
+        name: Head204
         description: Return 204 status code if successful
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1430,7 +1424,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put204
+        name: Put204
         description: Put true Boolean value in request returns 204 (no content)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1494,7 +1488,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch204
+        name: Patch204
         description: Patch true Boolean value in request returns 204 (no content)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1558,7 +1552,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post204
+        name: Post204
         description: Post true Boolean value in request returns 204 (no content)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1622,7 +1616,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete204
+        name: Delete204
         description: Delete true Boolean value in request returns 204 (no content)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1677,12 +1671,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head404
+        name: Head404
         description: Return 404 status code
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpSuccess
+      name: HttpSuccess
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -1744,7 +1738,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head300
+        name: Head300
         description: Return 300 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1807,7 +1801,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get300
+        name: Get300
         description: Return 300 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1866,7 +1860,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head301
+        name: Head301
         description: Return 301 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1925,7 +1919,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get301
+        name: Get301
         description: Return 301 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1993,7 +1987,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put301
+        name: Put301
         description: 'Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2052,7 +2046,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head302
+        name: Head302
         description: Return 302 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2111,7 +2105,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get302
+        name: Get302
         description: Return 302 status code and redirect to /http/success/200
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2179,7 +2173,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch302
+        name: Patch302
         description: 'Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2256,7 +2250,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post303
+        name: Post303
         description: 'Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2315,7 +2309,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head307
+        name: Head307
         description: 'Redirect with 307, resulting in a 200 success'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2374,7 +2368,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get307
+        name: Get307
         description: 'Redirect get with 307, resulting in a 200 success'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2433,7 +2427,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options307
+        name: Options307
         description: 'options redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2510,7 +2504,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put307
+        name: Put307
         description: 'Put redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2587,7 +2581,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch307
+        name: Patch307
         description: 'Patch redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2664,7 +2658,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post307
+        name: Post307
         description: 'Post redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2741,12 +2735,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete307
+        name: Delete307
         description: 'Delete redirected with 307, resulting in a 200 after redirect'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpRedirects
+      name: HttpRedirects
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -2785,7 +2779,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head400
+        name: Head400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2821,7 +2815,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get400
+        name: Get400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2857,7 +2851,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options400
+        name: Options400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2911,7 +2905,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put400
+        name: Put400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2965,7 +2959,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch400
+        name: Patch400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3019,7 +3013,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post400
+        name: Post400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3073,7 +3067,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete400
+        name: Delete400
         description: Return 400 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3109,7 +3103,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head401
+        name: Head401
         description: Return 401 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3145,7 +3139,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get402
+        name: Get402
         description: Return 402 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3181,7 +3175,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options403
+        name: Options403
         description: Return 403 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3217,7 +3211,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get403
+        name: Get403
         description: Return 403 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3271,7 +3265,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put404
+        name: Put404
         description: Return 404 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3325,7 +3319,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch405
+        name: Patch405
         description: Return 405 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3379,7 +3373,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post406
+        name: Post406
         description: Return 406 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3433,7 +3427,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete407
+        name: Delete407
         description: Return 407 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3487,7 +3481,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put409
+        name: Put409
         description: Return 409 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3523,7 +3517,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head410
+        name: Head410
         description: Return 410 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3559,7 +3553,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get411
+        name: Get411
         description: Return 411 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3595,7 +3589,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options412
+        name: Options412
         description: Return 412 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3631,7 +3625,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get412
+        name: Get412
         description: Return 412 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3685,7 +3679,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put413
+        name: Put413
         description: Return 413 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3739,7 +3733,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch414
+        name: Patch414
         description: Return 414 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3793,7 +3787,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post415
+        name: Post415
         description: Return 415 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3829,7 +3823,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get416
+        name: Get416
         description: Return 416 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3883,7 +3877,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete417
+        name: Delete417
         description: Return 417 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3919,12 +3913,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head429
+        name: Head429
         description: Return 429 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpClientFailure
+      name: HttpClientFailure
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -3963,7 +3957,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head501
+        name: Head501
         description: Return 501 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3999,7 +3993,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get501
+        name: Get501
         description: Return 501 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4053,7 +4047,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post505
+        name: Post505
         description: Return 505 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4107,12 +4101,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete505
+        name: Delete505
         description: Return 505 status code - should be represented in the client as an error
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpServerFailure
+      name: HttpServerFailure
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4161,7 +4155,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: head408
+        name: Head408
         description: 'Return 408 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4225,7 +4219,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put500
+        name: Put500
         description: 'Return 500 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4289,7 +4283,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch500
+        name: Patch500
         description: 'Return 500 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4335,7 +4329,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get502
+        name: Get502
         description: 'Return 502 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4385,7 +4379,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: options502
+        name: Options502
         description: 'Return 502 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4449,7 +4443,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post503
+        name: Post503
         description: 'Return 503 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4513,7 +4507,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: delete503
+        name: Delete503
         description: 'Return 503 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4577,7 +4571,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put504
+        name: Put504
         description: 'Return 504 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4641,12 +4635,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: patch504
+        name: Patch504
         description: 'Return 504 status code, then 200 after retry'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: httpRetry
+      name: HttpRetry
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4708,7 +4702,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError200Valid
+        name: Get200Model204NoModelDefaultError200Valid
         description: 'Send a 200 response with valid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4767,7 +4761,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError204Valid
+        name: Get200Model204NoModelDefaultError204Valid
         description: Send a 204 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4826,7 +4820,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError201Invalid
+        name: Get200Model204NoModelDefaultError201Invalid
         description: 'Send a 201 response with valid payload: {''statusCode'': ''201''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4885,7 +4879,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError202None
+        name: Get200Model204NoModelDefaultError202None
         description: 'Send a 202 response with no payload:'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4944,7 +4938,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model204NoModelDefaultError400Valid
+        name: Get200Model204NoModelDefaultError400Valid
         description: 'Send a 400 response with valid error payload: {''status'': 400, ''message'': ''client error''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5007,7 +5001,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model201ModelDefaultError200Valid
+        name: Get200Model201ModelDefaultError200Valid
         description: 'Send a 200 response with valid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5070,7 +5064,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model201ModelDefaultError201Valid
+        name: Get200Model201ModelDefaultError201Valid
         description: 'Send a 201 response with valid payload: {''statusCode'': ''201'', ''textStatusCode'': ''Created''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5133,7 +5127,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200Model201ModelDefaultError400Valid
+        name: Get200Model201ModelDefaultError400Valid
         description: 'Send a 400 response with valid payload: {''code'': ''400'', ''message'': ''client error''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5209,7 +5203,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200ModelA201ModelC404ModelDDefaultError200Valid
+        name: Get200ModelA201ModelC404ModelDDefaultError200Valid
         description: 'Send a 200 response with valid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5285,7 +5279,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200ModelA201ModelC404ModelDDefaultError201Valid
+        name: Get200ModelA201ModelC404ModelDDefaultError201Valid
         description: 'Send a 200 response with valid payload: {''httpCode'': ''201''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5361,7 +5355,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200ModelA201ModelC404ModelDDefaultError404Valid
+        name: Get200ModelA201ModelC404ModelDDefaultError404Valid
         description: 'Send a 200 response with valid payload: {''httpStatusCode'': ''404''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5437,7 +5431,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get200ModelA201ModelC404ModelDDefaultError400Valid
+        name: Get200ModelA201ModelC404ModelDDefaultError400Valid
         description: 'Send a 400 response with valid payload: {''code'': ''400'', ''message'': ''client error''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5492,7 +5486,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultError202None
+        name: Get202None204NoneDefaultError202None
         description: Send a 202 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5547,7 +5541,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultError204None
+        name: Get202None204NoneDefaultError204None
         description: Send a 204 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5602,7 +5596,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultError400Valid
+        name: Get202None204NoneDefaultError400Valid
         description: 'Send a 400 response with valid payload: {''code'': ''400'', ''message'': ''client error''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5653,7 +5647,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultNone202Invalid
+        name: Get202None204NoneDefaultNone202Invalid
         description: 'Send a 202 response with an unexpected payload {''property'': ''value''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5704,7 +5698,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultNone204None
+        name: Get202None204NoneDefaultNone204None
         description: Send a 204 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5755,7 +5749,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultNone400None
+        name: Get202None204NoneDefaultNone400None
         description: Send a 400 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5806,7 +5800,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: get202None204NoneDefaultNone400Invalid
+        name: Get202None204NoneDefaultNone400Invalid
         description: 'Send a 400 response with an unexpected payload {''property'': ''value''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5842,7 +5836,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getDefaultModelA200Valid
+        name: GetDefaultModelA200Valid
         description: 'Send a 200 response with valid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5878,7 +5872,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getDefaultModelA200None
+        name: GetDefaultModelA200None
         description: Send a 200 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5924,7 +5918,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultModelA400Valid
+        name: GetDefaultModelA400Valid
         description: 'Send a 400 response with valid payload: {''statusCode'': ''400''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5970,7 +5964,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultModelA400None
+        name: GetDefaultModelA400None
         description: Send a 400 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6002,7 +5996,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getDefaultNone200Invalid
+        name: GetDefaultNone200Invalid
         description: 'Send a 200 response with invalid payload: {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6034,7 +6028,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getDefaultNone200None
+        name: GetDefaultNone200None
         description: Send a 200 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6076,7 +6070,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultNone400Invalid
+        name: GetDefaultNone400Invalid
         description: 'Send a 400 response with valid payload: {''statusCode'': ''400''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6118,7 +6112,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDefaultNone400None
+        name: GetDefaultNone400None
         description: Send a 400 response with no payload
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6154,7 +6148,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA200None
+        name: Get200ModelA200None
         description: 'Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6190,7 +6184,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA200Valid
+        name: Get200ModelA200Valid
         description: 'Send a 200 response with payload {''statusCode'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6226,7 +6220,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA200Invalid
+        name: Get200ModelA200Invalid
         description: 'Send a 200 response with invalid payload {''statusCodeInvalid'': ''200''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6262,7 +6256,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA400None
+        name: Get200ModelA400None
         description: Send a 400 response with no payload client should treat as an http error with no error model
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6298,7 +6292,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA400Valid
+        name: Get200ModelA400Valid
         description: 'Send a 200 response with payload {''statusCode'': ''400''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6334,7 +6328,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA400Invalid
+        name: Get200ModelA400Invalid
         description: 'Send a 200 response with invalid payload {''statusCodeInvalid'': ''400''}'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -6370,12 +6364,12 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: get200ModelA202Valid
+        name: Get200ModelA202Valid
         description: 'Send a 202 response with payload {''statusCode'': ''202''}'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: multipleResponses
+      name: MultipleResponses
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -14,31 +14,31 @@ schemas: !<!Schemas>
           value: EC
           language:
             default:
-              name: EC
+              name: Ec
               description: Elliptic Curve.
         - !<!ChoiceValue> 
           value: EC-HSM
           language:
             default:
-              name: EC-HSM
+              name: EcHsm
               description: Elliptic Curve with a private key which is not exportable from the HSM.
         - !<!ChoiceValue> 
           value: RSA
           language:
             default:
-              name: RSA
+              name: Rsa
               description: 'RSA (https://tools.ietf.org/html/rfc3447)'
         - !<!ChoiceValue> 
           value: RSA-HSM
           language:
             default:
-              name: RSA-HSM
+              name: RsaHsm
               description: RSA with a private key which is not exportable from the HSM.
         - !<!ChoiceValue> 
           value: oct
           language:
             default:
-              name: oct
+              name: Oct
               description: Octet sequence (used to represent symmetric keys)
         type: choice
         apiVersions:
@@ -48,7 +48,7 @@ schemas: !<!Schemas>
           type: string
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: simple string
           protocol: !<!Protocols> {}
         language: !<!Languages> 
@@ -62,7 +62,6 @@ schemas: !<!Schemas>
         default:
           name: kty
           description: 'JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.'
-          originalName: kty
       protocol: !<!Protocols> {}
     - !<!Property> &ref_308
       schema: !<!NumberSchema> &ref_146
@@ -70,7 +69,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForkey_size
+            name: TypeForkeySize
             description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
         protocol: !<!Protocols> {}
       required: false
@@ -79,7 +78,6 @@ schemas: !<!Schemas>
         default:
           name: keySize
           description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-          originalName: key_size
       protocol: !<!Protocols> {}
     - !<!Property> &ref_309
       schema: !<!ArraySchema> &ref_75
@@ -93,37 +91,37 @@ schemas: !<!Schemas>
             value: encrypt
             language:
               default:
-                name: encrypt
+                name: Encrypt
                 description: ''
           - !<!ChoiceValue> 
             value: decrypt
             language:
               default:
-                name: decrypt
+                name: Decrypt
                 description: ''
           - !<!ChoiceValue> 
             value: sign
             language:
               default:
-                name: sign
+                name: Sign
                 description: ''
           - !<!ChoiceValue> 
             value: verify
             language:
               default:
-                name: verify
+                name: Verify
                 description: ''
           - !<!ChoiceValue> 
             value: wrapKey
             language:
               default:
-                name: wrapKey
+                name: WrapKey
                 description: ''
           - !<!ChoiceValue> 
             value: unwrapKey
             language:
               default:
-                name: unwrapKey
+                name: UnwrapKey
                 description: ''
           type: choice
           apiVersions:
@@ -137,8 +135,8 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: KeyCreateParameters-key_ops
-            description: ''
+            name: KeyCreateParametersKeyOps
+            description: Array of JsonWebKeyOperation
         protocol: !<!Protocols> {}
       required: false
       serializedName: key_ops
@@ -146,7 +144,6 @@ schemas: !<!Schemas>
         default:
           name: keyOps
           description: ''
-          originalName: key_ops
       protocol: !<!Protocols> {}
     - !<!Property> &ref_310
       schema: !<!ObjectSchema> &ref_1
@@ -188,7 +185,7 @@ schemas: !<!Schemas>
                       value: Recoverable+Purgeable
                       language:
                         default:
-                          name: Recoverable+Purgeable
+                          name: RecoverablePurgeable
                           description: ''
                     - !<!ChoiceValue> 
                       value: Recoverable
@@ -200,7 +197,7 @@ schemas: !<!Schemas>
                       value: Recoverable+ProtectedSubscription
                       language:
                         default:
-                          name: Recoverable+ProtectedSubscription
+                          name: RecoverableProtectedSubscription
                           description: ''
                     type: choice
                     apiVersions:
@@ -222,7 +219,6 @@ schemas: !<!Schemas>
                       description: >-
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
-                      originalName: recoveryLevel
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
@@ -251,7 +247,6 @@ schemas: !<!Schemas>
                       description: >-
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
-                      originalName: recoveryLevel
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
@@ -269,7 +264,7 @@ schemas: !<!Schemas>
                 type: boolean
                 language: !<!Languages> 
                   default:
-                    name: typeForenabled
+                    name: TypeForenabled
                     description: Determines whether the object is enabled.
                 protocol: !<!Protocols> {}
               serializedName: enabled
@@ -277,7 +272,6 @@ schemas: !<!Schemas>
                 default:
                   name: enabled
                   description: Determines whether the object is enabled.
-                  originalName: enabled
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!UnixTimeSchema> &ref_272
@@ -290,9 +284,8 @@ schemas: !<!Schemas>
               serializedName: nbf
               language: !<!Languages> 
                 default:
-                  name: NotBefore
+                  name: notBefore
                   description: Not before date in UTC.
-                  originalName: NotBefore
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!UnixTimeSchema> &ref_273
@@ -305,16 +298,15 @@ schemas: !<!Schemas>
               serializedName: exp
               language: !<!Languages> 
                 default:
-                  name: Expires
+                  name: expires
                   description: Expiry date in UTC.
-                  originalName: Expires
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!UnixTimeSchema> &ref_274
                 type: unixtime
                 language: !<!Languages> 
                   default:
-                    name: typeForcreated
+                    name: TypeForcreated
                     description: Creation time in UTC.
                 protocol: !<!Protocols> {}
               readOnly: true
@@ -323,14 +315,13 @@ schemas: !<!Schemas>
                 default:
                   name: created
                   description: Creation time in UTC.
-                  originalName: created
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!UnixTimeSchema> &ref_275
                 type: unixtime
                 language: !<!Languages> 
                   default:
-                    name: typeForupdated
+                    name: TypeForupdated
                     description: Last updated time in UTC.
                 protocol: !<!Protocols> {}
               readOnly: true
@@ -339,7 +330,6 @@ schemas: !<!Schemas>
                 default:
                   name: updated
                   description: Last updated time in UTC.
-                  originalName: updated
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -360,7 +350,6 @@ schemas: !<!Schemas>
               description: >-
                 Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the
                 end of the retention interval.
-              originalName: recoveryLevel
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -374,7 +363,6 @@ schemas: !<!Schemas>
         default:
           name: keyAttributes
           description: The attributes of a key managed by the key vault service.
-          originalName: keyAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_311
       schema: !<!DictionarySchema> &ref_50
@@ -386,12 +374,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: KeyCreateParameters-tags
+            name: KeyCreateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       required: false
@@ -400,7 +388,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     - !<!Property> &ref_312
       schema: !<!ChoiceSchema> &ref_9
@@ -409,25 +396,25 @@ schemas: !<!Schemas>
           value: P-256
           language:
             default:
-              name: P-256
+              name: P256
               description: 'The NIST P-256 elliptic curve, AKA SECG curve SECP256R1.'
         - !<!ChoiceValue> 
           value: P-384
           language:
             default:
-              name: P-384
+              name: P384
               description: 'The NIST P-384 elliptic curve, AKA SECG curve SECP384R1.'
         - !<!ChoiceValue> 
           value: P-521
           language:
             default:
-              name: P-521
+              name: P521
               description: 'The NIST P-521 elliptic curve, AKA SECG curve SECP521R1.'
         - !<!ChoiceValue> 
           value: P-256K
           language:
             default:
-              name: P-256K
+              name: P256K
               description: The SECG SECP256K1 elliptic curve.
         type: choice
         apiVersions:
@@ -445,7 +432,6 @@ schemas: !<!Schemas>
         default:
           name: curve
           description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
-          originalName: curve
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -481,7 +467,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: DeletedKeyBundle-recoveryId
+                name: DeletedKeyBundleRecoveryId
                 description: 'The url of the recovery object, used to identify and recover the deleted key.'
             protocol: !<!Protocols> {}
           serializedName: recoveryId
@@ -489,14 +475,13 @@ schemas: !<!Schemas>
             default:
               name: recoveryId
               description: 'The url of the recovery object, used to identify and recover the deleted key.'
-              originalName: recoveryId
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_276
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeForscheduledPurgeDate
+                name: TypeForscheduledPurgeDate
                 description: 'The time when the key is scheduled to be purged, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -505,14 +490,13 @@ schemas: !<!Schemas>
             default:
               name: scheduledPurgeDate
               description: 'The time when the key is scheduled to be purged, in UTC'
-              originalName: scheduledPurgeDate
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_277
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeFordeletedDate
+                name: TypeFordeletedDate
                 description: 'The time when the key was deleted, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -521,7 +505,6 @@ schemas: !<!Schemas>
             default:
               name: deletedDate
               description: 'The time when the key was deleted, in UTC'
-              originalName: deletedDate
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -547,7 +530,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-kid
+                name: JsonWebKeyKid
                 description: Key identifier.
             protocol: !<!Protocols> {}
           serializedName: kid
@@ -555,7 +538,6 @@ schemas: !<!Schemas>
             default:
               name: kid
               description: Key identifier.
-              originalName: kid
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_8
@@ -564,7 +546,6 @@ schemas: !<!Schemas>
             default:
               name: kty
               description: 'JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.'
-              originalName: kty
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ArraySchema> &ref_76
@@ -579,20 +560,19 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: JsonWebKey-key_opsItem
+                  name: JsonWebKeyOpsItem
                   description: Supported key operations.
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: JsonWebKey-key_ops
-                description: ''
+                name: JsonWebKeyOps
+                description: Array of JsonWebKeyOpsItem
             protocol: !<!Protocols> {}
           serializedName: key_ops
           language: !<!Languages> 
             default:
               name: keyOps
               description: ''
-              originalName: key_ops
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_116
@@ -603,7 +583,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-n
+                name: JsonWebKeyN
                 description: RSA modulus.
             protocol: !<!Protocols> {}
           serializedName: 'n'
@@ -611,7 +591,6 @@ schemas: !<!Schemas>
             default:
               name: 'n'
               description: RSA modulus.
-              originalName: 'n'
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_117
@@ -622,7 +601,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-e
+                name: JsonWebKeyE
                 description: RSA public exponent.
             protocol: !<!Protocols> {}
           serializedName: e
@@ -630,7 +609,6 @@ schemas: !<!Schemas>
             default:
               name: e
               description: RSA public exponent.
-              originalName: e
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_118
@@ -641,7 +619,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-d
+                name: JsonWebKeyD
                 description: 'RSA private exponent, or the D component of an EC private key.'
             protocol: !<!Protocols> {}
           serializedName: d
@@ -649,7 +627,6 @@ schemas: !<!Schemas>
             default:
               name: d
               description: 'RSA private exponent, or the D component of an EC private key.'
-              originalName: d
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_119
@@ -660,15 +637,14 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: DP
+                name: Dp
                 description: RSA private key parameter.
             protocol: !<!Protocols> {}
           serializedName: dp
           language: !<!Languages> 
             default:
-              name: DP
+              name: dp
               description: RSA private key parameter.
-              originalName: DP
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_120
@@ -679,15 +655,14 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: DQ
+                name: Dq
                 description: RSA private key parameter.
             protocol: !<!Protocols> {}
           serializedName: dq
           language: !<!Languages> 
             default:
-              name: DQ
+              name: dq
               description: RSA private key parameter.
-              originalName: DQ
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_121
@@ -698,15 +673,14 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: QI
+                name: Qi
                 description: RSA private key parameter.
             protocol: !<!Protocols> {}
           serializedName: qi
           language: !<!Languages> 
             default:
-              name: QI
+              name: qi
               description: RSA private key parameter.
-              originalName: QI
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_122
@@ -717,7 +691,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-p
+                name: JsonWebKeyP
                 description: RSA secret prime.
             protocol: !<!Protocols> {}
           serializedName: p
@@ -725,7 +699,6 @@ schemas: !<!Schemas>
             default:
               name: p
               description: RSA secret prime.
-              originalName: p
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_123
@@ -736,7 +709,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-q
+                name: JsonWebKeyQ
                 description: 'RSA secret prime, with p < q.'
             protocol: !<!Protocols> {}
           serializedName: q
@@ -744,7 +717,6 @@ schemas: !<!Schemas>
             default:
               name: q
               description: 'RSA secret prime, with p < q.'
-              originalName: q
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_124
@@ -755,7 +727,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-k
+                name: JsonWebKeyK
                 description: Symmetric key.
             protocol: !<!Protocols> {}
           serializedName: k
@@ -763,7 +735,6 @@ schemas: !<!Schemas>
             default:
               name: k
               description: Symmetric key.
-              originalName: k
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_125
@@ -774,7 +745,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: t
+                name: T
                 description: 'HSM Token, used with ''Bring Your Own Key''.'
             protocol: !<!Protocols> {}
           serializedName: key_hsm
@@ -782,7 +753,6 @@ schemas: !<!Schemas>
             default:
               name: t
               description: 'HSM Token, used with ''Bring Your Own Key''.'
-              originalName: t
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_9
@@ -791,7 +761,6 @@ schemas: !<!Schemas>
             default:
               name: crv
               description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
-              originalName: crv
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_126
@@ -802,7 +771,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-x
+                name: JsonWebKeyX
                 description: X component of an EC public key.
             protocol: !<!Protocols> {}
           serializedName: x
@@ -810,7 +779,6 @@ schemas: !<!Schemas>
             default:
               name: x
               description: X component of an EC public key.
-              originalName: x
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ByteArraySchema> &ref_127
@@ -821,7 +789,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: JsonWebKey-y
+                name: JsonWebKeyY
                 description: Y component of an EC public key.
             protocol: !<!Protocols> {}
           serializedName: 'y'
@@ -829,7 +797,6 @@ schemas: !<!Schemas>
             default:
               name: 'y'
               description: Y component of an EC public key.
-              originalName: 'y'
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -842,7 +809,6 @@ schemas: !<!Schemas>
         default:
           name: key
           description: 'As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18'
-          originalName: key
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_1
@@ -851,7 +817,6 @@ schemas: !<!Schemas>
         default:
           name: attributes
           description: The attributes of a key managed by the key vault service.
-          originalName: attributes
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_51
@@ -863,12 +828,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: KeyBundle-tags
+            name: KeyBundleTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -876,14 +841,13 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_99
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeFormanaged
+            name: TypeFormanaged
             description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
         protocol: !<!Protocols> {}
       readOnly: true
@@ -892,7 +856,6 @@ schemas: !<!Schemas>
         default:
           name: managed
           description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
-          originalName: managed
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -922,7 +885,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: Error-code
+                name: ErrorCode
                 description: The error code.
             protocol: !<!Protocols> {}
           readOnly: true
@@ -931,7 +894,6 @@ schemas: !<!Schemas>
             default:
               name: code
               description: The error code.
-              originalName: code
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_157
@@ -941,7 +903,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: Error-message
+                name: ErrorMessage
                 description: The error message.
             protocol: !<!Protocols> {}
           readOnly: true
@@ -950,7 +912,6 @@ schemas: !<!Schemas>
             default:
               name: message
               description: The error message.
-              originalName: message
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_11
@@ -960,7 +921,6 @@ schemas: !<!Schemas>
             default:
               name: innerError
               description: The key vault server error.
-              originalName: innerError
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -974,7 +934,6 @@ schemas: !<!Schemas>
         default:
           name: error
           description: The key vault server error.
-          originalName: error
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -994,16 +953,15 @@ schemas: !<!Schemas>
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForHsm
+            name: TypeForHsm
             description: Whether to import as a hardware key (HSM) or software key.
         protocol: !<!Protocols> {}
       required: false
       serializedName: Hsm
       language: !<!Languages> 
         default:
-          name: Hsm
+          name: hsm
           description: Whether to import as a hardware key (HSM) or software key.
-          originalName: Hsm
       protocol: !<!Protocols> {}
     - !<!Property> &ref_326
       schema: *ref_10
@@ -1013,7 +971,6 @@ schemas: !<!Schemas>
         default:
           name: key
           description: 'As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18'
-          originalName: key
       protocol: !<!Protocols> {}
     - !<!Property> &ref_327
       schema: *ref_1
@@ -1023,7 +980,6 @@ schemas: !<!Schemas>
         default:
           name: keyAttributes
           description: The attributes of a key managed by the key vault service.
-          originalName: keyAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_328
       schema: !<!DictionarySchema> &ref_52
@@ -1035,12 +991,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: KeyImportParameters-tags
+            name: KeyImportParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       required: false
@@ -1049,7 +1005,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1073,7 +1028,7 @@ schemas: !<!Schemas>
         elementType: *ref_12
         language: !<!Languages> 
           default:
-            name: KeyUpdateParameters-key_ops
+            name: KeyUpdateParametersKeyOps
             description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
         protocol: !<!Protocols> {}
       serializedName: key_ops
@@ -1081,7 +1036,6 @@ schemas: !<!Schemas>
         default:
           name: keyOps
           description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
-          originalName: key_ops
       protocol: !<!Protocols> {}
     - !<!Property> &ref_343
       schema: *ref_1
@@ -1090,7 +1044,6 @@ schemas: !<!Schemas>
         default:
           name: keyAttributes
           description: The attributes of a key managed by the key vault service.
-          originalName: keyAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_344
       schema: !<!DictionarySchema> &ref_53
@@ -1102,12 +1055,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: KeyUpdateParameters-tags
+            name: KeyUpdateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -1115,7 +1068,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1161,7 +1113,7 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: DeletedKeyItem-recoveryId
+                      name: DeletedKeyItemRecoveryId
                       description: 'The url of the recovery object, used to identify and recover the deleted key.'
                   protocol: !<!Protocols> {}
                 serializedName: recoveryId
@@ -1169,14 +1121,13 @@ schemas: !<!Schemas>
                   default:
                     name: recoveryId
                     description: 'The url of the recovery object, used to identify and recover the deleted key.'
-                    originalName: recoveryId
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_278
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForscheduledPurgeDate
+                      name: TypeForscheduledPurgeDate
                       description: 'The time when the key is scheduled to be purged, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -1185,14 +1136,13 @@ schemas: !<!Schemas>
                   default:
                     name: scheduledPurgeDate
                     description: 'The time when the key is scheduled to be purged, in UTC'
-                    originalName: scheduledPurgeDate
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_279
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeFordeletedDate
+                      name: TypeFordeletedDate
                       description: 'The time when the key was deleted, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -1201,7 +1151,6 @@ schemas: !<!Schemas>
                   default:
                     name: deletedDate
                     description: 'The time when the key was deleted, in UTC'
-                    originalName: deletedDate
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -1220,7 +1169,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: KeyItem-kid
+                  name: KeyItemKid
                   description: Key identifier.
               protocol: !<!Protocols> {}
             serializedName: kid
@@ -1228,7 +1177,6 @@ schemas: !<!Schemas>
               default:
                 name: kid
                 description: Key identifier.
-                originalName: kid
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: *ref_1
@@ -1237,7 +1185,6 @@ schemas: !<!Schemas>
               default:
                 name: attributes
                 description: The attributes of a key managed by the key vault service.
-                originalName: attributes
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_54
@@ -1249,12 +1196,12 @@ schemas: !<!Schemas>
                   version: 7.0-preview
                 language: !<!Languages> 
                   default:
-                    name: string
+                    name: String
                     description: ''
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: KeyItem-tags
+                  name: KeyItemTags
                   description: Application specific metadata in the form of key-value pairs.
               protocol: !<!Protocols> {}
             serializedName: tags
@@ -1262,14 +1209,13 @@ schemas: !<!Schemas>
               default:
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
-                originalName: tags
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!BooleanSchema> &ref_101
               type: boolean
               language: !<!Languages> 
                 default:
-                  name: typeFormanaged
+                  name: TypeFormanaged
                   description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
               protocol: !<!Protocols> {}
             readOnly: true
@@ -1278,7 +1224,6 @@ schemas: !<!Schemas>
               default:
                 name: managed
                 description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
-                originalName: managed
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -1288,7 +1233,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: KeyListResult-value
+            name: KeyListResultValue
             description: A response message containing a list of keys in the key vault along with a link to the next page of keys.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1297,7 +1242,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of keys in the key vault along with a link to the next page of keys.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_163
@@ -1307,7 +1251,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: KeyListResult-nextLink
+            name: KeyListResultNextLink
             description: The URL to get the next set of keys.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1316,7 +1260,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of keys.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1340,7 +1283,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: BackupKeyResult-value
+            name: BackupKeyResultValue
             description: The backup blob containing the backed up key.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1349,7 +1292,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: The backup blob containing the backed up key.
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1372,7 +1314,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: keyBundleBackup
+            name: KeyBundleBackup
             description: The backup blob associated with a key bundle.
         protocol: !<!Protocols> {}
       required: true
@@ -1381,7 +1323,6 @@ schemas: !<!Schemas>
         default:
           name: keyBundleBackup
           description: The backup blob associated with a key bundle.
-          originalName: keyBundleBackup
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1402,19 +1343,19 @@ schemas: !<!Schemas>
           value: RSA-OAEP
           language:
             default:
-              name: RSA-OAEP
+              name: RsaOaep
               description: ''
         - !<!ChoiceValue> 
           value: RSA-OAEP-256
           language:
             default:
-              name: RSA-OAEP-256
+              name: RsaOaep256
               description: ''
         - !<!ChoiceValue> 
           value: RSA1_5
           language:
             default:
-              name: RSA1_5
+              name: Rsa15
               description: ''
         type: choice
         apiVersions:
@@ -1432,7 +1373,6 @@ schemas: !<!Schemas>
         default:
           name: algorithm
           description: algorithm identifier
-          originalName: algorithm
       protocol: !<!Protocols> {}
     - !<!Property> &ref_379
       schema: !<!ByteArraySchema> &ref_130
@@ -1443,7 +1383,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: KeyOperationsParameters-value
+            name: KeyOperationsParametersValue
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -1452,7 +1392,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1474,7 +1413,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: KeyOperationResult-kid
+            name: KeyOperationResultKid
             description: Key identifier
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1483,7 +1422,6 @@ schemas: !<!Schemas>
         default:
           name: kid
           description: Key identifier
-          originalName: kid
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ByteArraySchema> &ref_131
@@ -1494,7 +1432,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: result
+            name: Result
             description: ''
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1503,7 +1441,6 @@ schemas: !<!Schemas>
         default:
           name: result
           description: ''
-          originalName: result
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1524,67 +1461,67 @@ schemas: !<!Schemas>
           value: PS256
           language:
             default:
-              name: PS256
+              name: Ps256
               description: 'RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in https://tools.ietf.org/html/rfc7518'
         - !<!ChoiceValue> 
           value: PS384
           language:
             default:
-              name: PS384
+              name: Ps384
               description: 'RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in https://tools.ietf.org/html/rfc7518'
         - !<!ChoiceValue> 
           value: PS512
           language:
             default:
-              name: PS512
+              name: Ps512
               description: 'RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in https://tools.ietf.org/html/rfc7518'
         - !<!ChoiceValue> 
           value: RS256
           language:
             default:
-              name: RS256
+              name: Rs256
               description: 'RSASSA-PKCS1-v1_5 using SHA-256, as described in https://tools.ietf.org/html/rfc7518'
         - !<!ChoiceValue> 
           value: RS384
           language:
             default:
-              name: RS384
+              name: Rs384
               description: 'RSASSA-PKCS1-v1_5 using SHA-384, as described in https://tools.ietf.org/html/rfc7518'
         - !<!ChoiceValue> 
           value: RS512
           language:
             default:
-              name: RS512
+              name: Rs512
               description: 'RSASSA-PKCS1-v1_5 using SHA-512, as described in https://tools.ietf.org/html/rfc7518'
         - !<!ChoiceValue> 
           value: RSNULL
           language:
             default:
-              name: RSNULL
+              name: Rsnull
               description: Reserved
         - !<!ChoiceValue> 
           value: ES256
           language:
             default:
-              name: ES256
+              name: Es256
               description: 'ECDSA using P-256 and SHA-256, as described in https://tools.ietf.org/html/rfc7518.'
         - !<!ChoiceValue> 
           value: ES384
           language:
             default:
-              name: ES384
+              name: Es384
               description: 'ECDSA using P-384 and SHA-384, as described in https://tools.ietf.org/html/rfc7518'
         - !<!ChoiceValue> 
           value: ES512
           language:
             default:
-              name: ES512
+              name: Es512
               description: 'ECDSA using P-521 and SHA-512, as described in https://tools.ietf.org/html/rfc7518'
         - !<!ChoiceValue> 
           value: ES256K
           language:
             default:
-              name: ES256K
+              name: Es256K
               description: 'ECDSA using P-256K and SHA-256, as described in https://tools.ietf.org/html/rfc7518'
         type: choice
         apiVersions:
@@ -1602,7 +1539,6 @@ schemas: !<!Schemas>
         default:
           name: algorithm
           description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
-          originalName: algorithm
       protocol: !<!Protocols> {}
     - !<!Property> &ref_399
       schema: !<!ByteArraySchema> &ref_132
@@ -1613,7 +1549,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: KeySignParameters-value
+            name: KeySignParametersValue
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -1622,7 +1558,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1644,7 +1579,6 @@ schemas: !<!Schemas>
         default:
           name: algorithm
           description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
-          originalName: algorithm
       protocol: !<!Protocols> {}
     - !<!Property> &ref_410
       schema: !<!ByteArraySchema> &ref_133
@@ -1655,7 +1589,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: KeyVerifyParameters-digest
+            name: KeyVerifyParametersDigest
             description: The digest used for signing.
         protocol: !<!Protocols> {}
       required: true
@@ -1664,7 +1598,6 @@ schemas: !<!Schemas>
         default:
           name: digest
           description: The digest used for signing.
-          originalName: digest
       protocol: !<!Protocols> {}
     - !<!Property> &ref_411
       schema: !<!ByteArraySchema> &ref_134
@@ -1675,7 +1608,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: signature
+            name: Signature
             description: The signature to be verified.
         protocol: !<!Protocols> {}
       required: true
@@ -1684,7 +1617,6 @@ schemas: !<!Schemas>
         default:
           name: signature
           description: The signature to be verified.
-          originalName: signature
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1703,7 +1635,7 @@ schemas: !<!Schemas>
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForvalue
+            name: TypeForvalue
             description: 'True if the signature is verified, otherwise false.'
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1712,7 +1644,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: 'True if the signature is verified, otherwise false.'
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1735,7 +1666,7 @@ schemas: !<!Schemas>
         elementType: *ref_14
         language: !<!Languages> 
           default:
-            name: DeletedKeyListResult-value
+            name: DeletedKeyListResultValue
             description: A response message containing a list of deleted keys in the vault along with a link to the next page of deleted keys
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1744,7 +1675,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of deleted keys in the vault along with a link to the next page of deleted keys
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_166
@@ -1754,7 +1684,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: DeletedKeyListResult-nextLink
+            name: DeletedKeyListResultNextLink
             description: The URL to get the next set of deleted keys.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -1763,7 +1693,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of deleted keys.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1786,7 +1715,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SecretSetParameters-value
+            name: SecretSetParametersValue
             description: The value of the secret.
         protocol: !<!Protocols> {}
       required: true
@@ -1795,7 +1724,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: The value of the secret.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> &ref_452
       schema: !<!DictionarySchema> &ref_55
@@ -1807,12 +1735,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SecretSetParameters-tags
+            name: SecretSetParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       required: false
@@ -1821,7 +1749,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     - !<!Property> &ref_453
       schema: !<!StringSchema> &ref_169
@@ -1831,7 +1758,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SecretSetParameters-contentType
+            name: SecretSetParametersContentType
             description: Type of the secret value such as a password.
         protocol: !<!Protocols> {}
       required: false
@@ -1840,7 +1767,6 @@ schemas: !<!Schemas>
         default:
           name: contentType
           description: Type of the secret value such as a password.
-          originalName: contentType
       protocol: !<!Protocols> {}
     - !<!Property> &ref_454
       schema: *ref_4
@@ -1850,7 +1776,6 @@ schemas: !<!Schemas>
         default:
           name: secretAttributes
           description: The secret management attributes.
-          originalName: secretAttributes
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1885,7 +1810,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: DeletedSecretBundle-recoveryId
+                name: DeletedSecretBundleRecoveryId
                 description: 'The url of the recovery object, used to identify and recover the deleted secret.'
             protocol: !<!Protocols> {}
           serializedName: recoveryId
@@ -1893,14 +1818,13 @@ schemas: !<!Schemas>
             default:
               name: recoveryId
               description: 'The url of the recovery object, used to identify and recover the deleted secret.'
-              originalName: recoveryId
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_280
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeForscheduledPurgeDate
+                name: TypeForscheduledPurgeDate
                 description: 'The time when the secret is scheduled to be purged, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -1909,14 +1833,13 @@ schemas: !<!Schemas>
             default:
               name: scheduledPurgeDate
               description: 'The time when the secret is scheduled to be purged, in UTC'
-              originalName: scheduledPurgeDate
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_281
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeFordeletedDate
+                name: TypeFordeletedDate
                 description: 'The time when the secret was deleted, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -1925,7 +1848,6 @@ schemas: !<!Schemas>
             default:
               name: deletedDate
               description: 'The time when the secret was deleted, in UTC'
-              originalName: deletedDate
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -1944,7 +1866,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SecretBundle-value
+            name: SecretBundleValue
             description: The secret value.
         protocol: !<!Protocols> {}
       serializedName: value
@@ -1952,7 +1874,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: The secret value.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_171
@@ -1962,7 +1883,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SecretBundle-id
+            name: SecretBundleId
             description: The secret id.
         protocol: !<!Protocols> {}
       serializedName: id
@@ -1970,7 +1891,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: The secret id.
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_172
@@ -1980,7 +1900,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SecretBundle-contentType
+            name: SecretBundleContentType
             description: The content type of the secret.
         protocol: !<!Protocols> {}
       serializedName: contentType
@@ -1988,7 +1908,6 @@ schemas: !<!Schemas>
         default:
           name: contentType
           description: The content type of the secret.
-          originalName: contentType
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_4
@@ -1997,7 +1916,6 @@ schemas: !<!Schemas>
         default:
           name: attributes
           description: The secret management attributes.
-          originalName: attributes
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_56
@@ -2009,12 +1927,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SecretBundle-tags
+            name: SecretBundleTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -2022,7 +1940,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_174
@@ -2032,7 +1949,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SecretBundle-kid
+            name: SecretBundleKid
             description: 'If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV certificate.'
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2041,14 +1958,13 @@ schemas: !<!Schemas>
         default:
           name: kid
           description: 'If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV certificate.'
-          originalName: kid
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_103
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeFormanaged
+            name: TypeFormanaged
             description: 'True if the secret''s lifetime is managed by key vault. If this is a secret backing a certificate, then managed will be true.'
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2057,7 +1973,6 @@ schemas: !<!Schemas>
         default:
           name: managed
           description: 'True if the secret''s lifetime is managed by key vault. If this is a secret backing a certificate, then managed will be true.'
-          originalName: managed
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2080,7 +1995,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SecretUpdateParameters-contentType
+            name: SecretUpdateParametersContentType
             description: Type of the secret value such as a password.
         protocol: !<!Protocols> {}
       serializedName: contentType
@@ -2088,7 +2003,6 @@ schemas: !<!Schemas>
         default:
           name: contentType
           description: Type of the secret value such as a password.
-          originalName: contentType
       protocol: !<!Protocols> {}
     - !<!Property> &ref_469
       schema: *ref_4
@@ -2097,7 +2011,6 @@ schemas: !<!Schemas>
         default:
           name: secretAttributes
           description: The secret management attributes.
-          originalName: secretAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_470
       schema: !<!DictionarySchema> &ref_57
@@ -2109,12 +2022,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SecretUpdateParameters-tags
+            name: SecretUpdateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -2122,7 +2035,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2168,7 +2080,7 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: DeletedSecretItem-recoveryId
+                      name: DeletedSecretItemRecoveryId
                       description: 'The url of the recovery object, used to identify and recover the deleted secret.'
                   protocol: !<!Protocols> {}
                 serializedName: recoveryId
@@ -2176,14 +2088,13 @@ schemas: !<!Schemas>
                   default:
                     name: recoveryId
                     description: 'The url of the recovery object, used to identify and recover the deleted secret.'
-                    originalName: recoveryId
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_282
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForscheduledPurgeDate
+                      name: TypeForscheduledPurgeDate
                       description: 'The time when the secret is scheduled to be purged, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -2192,14 +2103,13 @@ schemas: !<!Schemas>
                   default:
                     name: scheduledPurgeDate
                     description: 'The time when the secret is scheduled to be purged, in UTC'
-                    originalName: scheduledPurgeDate
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_283
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeFordeletedDate
+                      name: TypeFordeletedDate
                       description: 'The time when the secret was deleted, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -2208,7 +2118,6 @@ schemas: !<!Schemas>
                   default:
                     name: deletedDate
                     description: 'The time when the secret was deleted, in UTC'
-                    originalName: deletedDate
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -2227,7 +2136,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: SecretItem-id
+                  name: SecretItemId
                   description: Secret identifier.
               protocol: !<!Protocols> {}
             serializedName: id
@@ -2235,7 +2144,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: Secret identifier.
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: *ref_4
@@ -2244,7 +2152,6 @@ schemas: !<!Schemas>
               default:
                 name: attributes
                 description: The secret management attributes.
-                originalName: attributes
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_58
@@ -2256,12 +2163,12 @@ schemas: !<!Schemas>
                   version: 7.0-preview
                 language: !<!Languages> 
                   default:
-                    name: string
+                    name: String
                     description: ''
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: SecretItem-tags
+                  name: SecretItemTags
                   description: Application specific metadata in the form of key-value pairs.
               protocol: !<!Protocols> {}
             serializedName: tags
@@ -2269,7 +2176,6 @@ schemas: !<!Schemas>
               default:
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
-                originalName: tags
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_180
@@ -2279,7 +2185,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: SecretItem-contentType
+                  name: SecretItemContentType
                   description: Type of the secret value such as a password.
               protocol: !<!Protocols> {}
             serializedName: contentType
@@ -2287,14 +2193,13 @@ schemas: !<!Schemas>
               default:
                 name: contentType
                 description: Type of the secret value such as a password.
-                originalName: contentType
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!BooleanSchema> &ref_104
               type: boolean
               language: !<!Languages> 
                 default:
-                  name: typeFormanaged
+                  name: TypeFormanaged
                   description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
               protocol: !<!Protocols> {}
             readOnly: true
@@ -2303,7 +2208,6 @@ schemas: !<!Schemas>
               default:
                 name: managed
                 description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
-                originalName: managed
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -2313,7 +2217,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SecretListResult-value
+            name: SecretListResultValue
             description: A response message containing a list of secrets in the key vault along with a link to the next page of secrets.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2322,7 +2226,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of secrets in the key vault along with a link to the next page of secrets.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_181
@@ -2332,7 +2235,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SecretListResult-nextLink
+            name: SecretListResultNextLink
             description: The URL to get the next set of secrets.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2341,7 +2244,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of secrets.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2365,7 +2267,7 @@ schemas: !<!Schemas>
         elementType: *ref_19
         language: !<!Languages> 
           default:
-            name: DeletedSecretListResult-value
+            name: DeletedSecretListResultValue
             description: A response message containing a list of the deleted secrets in the vault along with a link to the next page of deleted secrets
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2374,7 +2276,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of the deleted secrets in the vault along with a link to the next page of deleted secrets
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_183
@@ -2384,7 +2285,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: DeletedSecretListResult-nextLink
+            name: DeletedSecretListResultNextLink
             description: The URL to get the next set of deleted secrets.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2393,7 +2294,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of deleted secrets.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2417,7 +2317,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: BackupSecretResult-value
+            name: BackupSecretResultValue
             description: The backup blob containing the backed up secret.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2426,7 +2326,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: The backup blob containing the backed up secret.
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2449,7 +2348,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: secretBundleBackup
+            name: SecretBundleBackup
             description: The backup blob associated with a secret bundle.
         protocol: !<!Protocols> {}
       required: true
@@ -2458,7 +2357,6 @@ schemas: !<!Schemas>
         default:
           name: secretBundleBackup
           description: The backup blob associated with a secret bundle.
-          originalName: secretBundleBackup
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2504,7 +2402,7 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: DeletedCertificateItem-recoveryId
+                      name: DeletedCertificateItemRecoveryId
                       description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
                   protocol: !<!Protocols> {}
                 serializedName: recoveryId
@@ -2512,14 +2410,13 @@ schemas: !<!Schemas>
                   default:
                     name: recoveryId
                     description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
-                    originalName: recoveryId
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_288
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForscheduledPurgeDate
+                      name: TypeForscheduledPurgeDate
                       description: 'The time when the certificate is scheduled to be purged, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -2528,14 +2425,13 @@ schemas: !<!Schemas>
                   default:
                     name: scheduledPurgeDate
                     description: 'The time when the certificate is scheduled to be purged, in UTC'
-                    originalName: scheduledPurgeDate
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_289
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeFordeletedDate
+                      name: TypeFordeletedDate
                       description: 'The time when the certificate was deleted, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -2544,7 +2440,6 @@ schemas: !<!Schemas>
                   default:
                     name: deletedDate
                     description: 'The time when the certificate was deleted, in UTC'
-                    originalName: deletedDate
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -2563,7 +2458,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: CertificateItem-id
+                  name: CertificateItemId
                   description: Certificate identifier.
               protocol: !<!Protocols> {}
             serializedName: id
@@ -2571,7 +2466,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: Certificate identifier.
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: *ref_5
@@ -2580,7 +2474,6 @@ schemas: !<!Schemas>
               default:
                 name: attributes
                 description: The certificate management attributes.
-                originalName: attributes
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_59
@@ -2592,12 +2485,12 @@ schemas: !<!Schemas>
                   version: 7.0-preview
                 language: !<!Languages> 
                   default:
-                    name: string
+                    name: String
                     description: ''
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: CertificateItem-tags
+                  name: CertificateItemTags
                   description: Application specific metadata in the form of key-value pairs.
               protocol: !<!Protocols> {}
             serializedName: tags
@@ -2605,7 +2498,6 @@ schemas: !<!Schemas>
               default:
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
-                originalName: tags
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ByteArraySchema> &ref_137
@@ -2622,9 +2514,8 @@ schemas: !<!Schemas>
             serializedName: x5t
             language: !<!Languages> 
               default:
-                name: X509Thumbprint
+                name: x509Thumbprint
                 description: Thumbprint of the certificate.
-                originalName: X509Thumbprint
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -2634,7 +2525,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CertificateListResult-value
+            name: CertificateListResultValue
             description: A response message containing a list of certificates in the key vault along with a link to the next page of certificates.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2643,7 +2534,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of certificates in the key vault along with a link to the next page of certificates.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_186
@@ -2653,7 +2543,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateListResult-nextLink
+            name: CertificateListResultNextLink
             description: The URL to get the next set of certificates.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2662,7 +2552,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of certificates.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2698,7 +2587,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: DeletedCertificateBundle-recoveryId
+                name: DeletedCertificateBundleRecoveryId
                 description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
             protocol: !<!Protocols> {}
           serializedName: recoveryId
@@ -2706,14 +2595,13 @@ schemas: !<!Schemas>
             default:
               name: recoveryId
               description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
-              originalName: recoveryId
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_284
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeForscheduledPurgeDate
+                name: TypeForscheduledPurgeDate
                 description: 'The time when the certificate is scheduled to be purged, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -2722,14 +2610,13 @@ schemas: !<!Schemas>
             default:
               name: scheduledPurgeDate
               description: 'The time when the certificate is scheduled to be purged, in UTC'
-              originalName: scheduledPurgeDate
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_285
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeFordeletedDate
+                name: TypeFordeletedDate
                 description: 'The time when the certificate was deleted, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -2738,7 +2625,6 @@ schemas: !<!Schemas>
             default:
               name: deletedDate
               description: 'The time when the certificate was deleted, in UTC'
-              originalName: deletedDate
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -2757,7 +2643,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateBundle-id
+            name: CertificateBundleId
             description: The certificate id.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2766,7 +2652,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: The certificate id.
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_188
@@ -2776,7 +2661,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateBundle-kid
+            name: CertificateBundleKid
             description: The key id.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2785,7 +2670,6 @@ schemas: !<!Schemas>
         default:
           name: kid
           description: The key id.
-          originalName: kid
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_189
@@ -2795,7 +2679,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateBundle-sid
+            name: CertificateBundleSid
             description: The secret id.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -2804,7 +2688,6 @@ schemas: !<!Schemas>
         default:
           name: sid
           description: The secret id.
-          originalName: sid
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ByteArraySchema> &ref_138
@@ -2822,9 +2705,8 @@ schemas: !<!Schemas>
       serializedName: x5t
       language: !<!Languages> 
         default:
-          name: X509Thumbprint
+          name: x509Thumbprint
           description: Thumbprint of the certificate.
-          originalName: X509Thumbprint
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_24
@@ -2841,7 +2723,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: CertificatePolicy-id
+                name: CertificatePolicyId
                 description: The certificate id.
             protocol: !<!Protocols> {}
           readOnly: true
@@ -2850,7 +2732,6 @@ schemas: !<!Schemas>
             default:
               name: id
               description: The certificate id.
-              originalName: id
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ObjectSchema> &ref_25
@@ -2864,7 +2745,7 @@ schemas: !<!Schemas>
                 type: boolean
                 language: !<!Languages> 
                   default:
-                    name: typeForexportable
+                    name: TypeForexportable
                     description: Indicates if the private key can be exported.
                 protocol: !<!Protocols> {}
               serializedName: exportable
@@ -2872,7 +2753,6 @@ schemas: !<!Schemas>
                 default:
                   name: exportable
                   description: Indicates if the private key can be exported.
-                  originalName: exportable
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: *ref_8
@@ -2881,7 +2761,6 @@ schemas: !<!Schemas>
                 default:
                   name: keyType
                   description: 'JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.'
-                  originalName: keyType
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!NumberSchema> &ref_147
@@ -2889,7 +2768,7 @@ schemas: !<!Schemas>
                 precision: 32
                 language: !<!Languages> 
                   default:
-                    name: typeForkey_size
+                    name: TypeForkeySize
                     description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
                 protocol: !<!Protocols> {}
               serializedName: key_size
@@ -2897,14 +2776,13 @@ schemas: !<!Schemas>
                 default:
                   name: keySize
                   description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-                  originalName: key_size
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!BooleanSchema> &ref_106
                 type: boolean
                 language: !<!Languages> 
                   default:
-                    name: typeForreuse_key
+                    name: TypeForreuseKey
                     description: Indicates if the same key pair will be used on certificate renewal.
                 protocol: !<!Protocols> {}
               serializedName: reuse_key
@@ -2912,7 +2790,6 @@ schemas: !<!Schemas>
                 default:
                   name: reuseKey
                   description: Indicates if the same key pair will be used on certificate renewal.
-                  originalName: reuse_key
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: *ref_9
@@ -2921,7 +2798,6 @@ schemas: !<!Schemas>
                 default:
                   name: curve
                   description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
-                  originalName: curve
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -2932,9 +2808,8 @@ schemas: !<!Schemas>
           serializedName: key_props
           language: !<!Languages> 
             default:
-              name: KeyProperties
+              name: keyProperties
               description: Properties of the key pair backing a certificate.
-              originalName: KeyProperties
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ObjectSchema> &ref_26
@@ -2951,7 +2826,7 @@ schemas: !<!Schemas>
                   version: 7.0-preview
                 language: !<!Languages> 
                   default:
-                    name: SecretProperties-contentType
+                    name: SecretPropertiesContentType
                     description: The media type (MIME type).
                 protocol: !<!Protocols> {}
               serializedName: contentType
@@ -2959,7 +2834,6 @@ schemas: !<!Schemas>
                 default:
                   name: contentType
                   description: The media type (MIME type).
-                  originalName: contentType
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -2970,9 +2844,8 @@ schemas: !<!Schemas>
           serializedName: secret_props
           language: !<!Languages> 
             default:
-              name: SecretProperties
+              name: secretProperties
               description: Properties of the key backing a certificate.
-              originalName: SecretProperties
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ObjectSchema> &ref_27
@@ -2989,7 +2862,7 @@ schemas: !<!Schemas>
                   version: 7.0-preview
                 language: !<!Languages> 
                   default:
-                    name: X509CertificateProperties-subject
+                    name: X509CertificatePropertiesSubject
                     description: The subject name. Should be a valid X509 distinguished Name.
                 protocol: !<!Protocols> {}
               serializedName: subject
@@ -2997,7 +2870,6 @@ schemas: !<!Schemas>
                 default:
                   name: subject
                   description: The subject name. Should be a valid X509 distinguished Name.
-                  originalName: subject
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!ArraySchema> &ref_83
@@ -3012,12 +2884,12 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: X509CertificateProperties-ekusItem
+                      name: X509CertificatePropertiesEkusItem
                       description: ''
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
-                    name: X509CertificateProperties-ekus
+                    name: X509CertificatePropertiesEkus
                     description: The enhanced key usage.
                 protocol: !<!Protocols> {}
               serializedName: ekus
@@ -3025,7 +2897,6 @@ schemas: !<!Schemas>
                 default:
                   name: ekus
                   description: The enhanced key usage.
-                  originalName: ekus
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!ObjectSchema> &ref_28
@@ -3047,12 +2918,12 @@ schemas: !<!Schemas>
                         version: 7.0-preview
                       language: !<!Languages> 
                         default:
-                          name: SubjectAlternativeNames-emailsItem
+                          name: SubjectAlternativeNamesEmailsItem
                           description: ''
                       protocol: !<!Protocols> {}
                     language: !<!Languages> 
                       default:
-                        name: SubjectAlternativeNames-emails
+                        name: SubjectAlternativeNamesEmails
                         description: Email addresses.
                     protocol: !<!Protocols> {}
                   serializedName: emails
@@ -3060,7 +2931,6 @@ schemas: !<!Schemas>
                     default:
                       name: emails
                       description: Email addresses.
-                      originalName: emails
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_85
@@ -3075,12 +2945,12 @@ schemas: !<!Schemas>
                         version: 7.0-preview
                       language: !<!Languages> 
                         default:
-                          name: SubjectAlternativeNames-dns_namesItem
+                          name: SubjectAlternativeNamesDnsNamesItem
                           description: ''
                       protocol: !<!Protocols> {}
                     language: !<!Languages> 
                       default:
-                        name: SubjectAlternativeNames-dns_names
+                        name: SubjectAlternativeNamesDnsNames
                         description: Domain names.
                     protocol: !<!Protocols> {}
                   serializedName: dns_names
@@ -3088,7 +2958,6 @@ schemas: !<!Schemas>
                     default:
                       name: dnsNames
                       description: Domain names.
-                      originalName: dns_names
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_86
@@ -3103,12 +2972,12 @@ schemas: !<!Schemas>
                         version: 7.0-preview
                       language: !<!Languages> 
                         default:
-                          name: SubjectAlternativeNames-upnsItem
+                          name: SubjectAlternativeNamesUpnsItem
                           description: ''
                       protocol: !<!Protocols> {}
                     language: !<!Languages> 
                       default:
-                        name: SubjectAlternativeNames-upns
+                        name: SubjectAlternativeNamesUpns
                         description: User principal names.
                     protocol: !<!Protocols> {}
                   serializedName: upns
@@ -3116,7 +2985,6 @@ schemas: !<!Schemas>
                     default:
                       name: upns
                       description: User principal names.
-                      originalName: upns
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
@@ -3127,9 +2995,8 @@ schemas: !<!Schemas>
               serializedName: sans
               language: !<!Languages> 
                 default:
-                  name: SubjectAlternativeNames
+                  name: subjectAlternativeNames
                   description: The subject alternate names of a X509 object.
-                  originalName: SubjectAlternativeNames
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!ArraySchema> &ref_87
@@ -3143,55 +3010,55 @@ schemas: !<!Schemas>
                     value: digitalSignature
                     language:
                       default:
-                        name: digitalSignature
+                        name: DigitalSignature
                         description: ''
                   - !<!ChoiceValue> 
                     value: nonRepudiation
                     language:
                       default:
-                        name: nonRepudiation
+                        name: NonRepudiation
                         description: ''
                   - !<!ChoiceValue> 
                     value: keyEncipherment
                     language:
                       default:
-                        name: keyEncipherment
+                        name: KeyEncipherment
                         description: ''
                   - !<!ChoiceValue> 
                     value: dataEncipherment
                     language:
                       default:
-                        name: dataEncipherment
+                        name: DataEncipherment
                         description: ''
                   - !<!ChoiceValue> 
                     value: keyAgreement
                     language:
                       default:
-                        name: keyAgreement
+                        name: KeyAgreement
                         description: ''
                   - !<!ChoiceValue> 
                     value: keyCertSign
                     language:
                       default:
-                        name: keyCertSign
+                        name: KeyCertSign
                         description: ''
                   - !<!ChoiceValue> 
                     value: cRLSign
                     language:
                       default:
-                        name: cRLSign
+                        name: CRlSign
                         description: ''
                   - !<!ChoiceValue> 
                     value: encipherOnly
                     language:
                       default:
-                        name: encipherOnly
+                        name: EncipherOnly
                         description: ''
                   - !<!ChoiceValue> 
                     value: decipherOnly
                     language:
                       default:
-                        name: decipherOnly
+                        name: DecipherOnly
                         description: ''
                   type: choice
                   apiVersions:
@@ -3205,7 +3072,7 @@ schemas: !<!Schemas>
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
-                    name: X509CertificateProperties-key_usage
+                    name: X509CertificatePropertiesKeyUsage
                     description: List of key usages.
                 protocol: !<!Protocols> {}
               serializedName: key_usage
@@ -3213,7 +3080,6 @@ schemas: !<!Schemas>
                 default:
                   name: keyUsage
                   description: List of key usages.
-                  originalName: key_usage
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!NumberSchema> &ref_148
@@ -3228,9 +3094,8 @@ schemas: !<!Schemas>
               serializedName: validity_months
               language: !<!Languages> 
                 default:
-                  name: ValidityInMonths
+                  name: validityInMonths
                   description: The duration that the certificate is valid in months.
-                  originalName: ValidityInMonths
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -3241,9 +3106,8 @@ schemas: !<!Schemas>
           serializedName: x509_props
           language: !<!Languages> 
             default:
-              name: X509CertificateProperties
+              name: x509CertificateProperties
               description: Properties of the X509 component of a certificate.
-              originalName: X509CertificateProperties
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ArraySchema> &ref_88
@@ -3272,7 +3136,7 @@ schemas: !<!Schemas>
                       precision: 32
                       language: !<!Languages> 
                         default:
-                          name: typeForlifetime_percentage
+                          name: TypeForlifetimePercentage
                           description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
                       protocol: !<!Protocols> {}
                     serializedName: lifetime_percentage
@@ -3280,7 +3144,6 @@ schemas: !<!Schemas>
                       default:
                         name: lifetimePercentage
                         description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
-                        originalName: lifetime_percentage
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!NumberSchema> &ref_150
@@ -3288,7 +3151,7 @@ schemas: !<!Schemas>
                       precision: 32
                       language: !<!Languages> 
                         default:
-                          name: typeFordays_before_expiry
+                          name: TypeFordaysBeforeExpiry
                           description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
                       protocol: !<!Protocols> {}
                     serializedName: days_before_expiry
@@ -3296,7 +3159,6 @@ schemas: !<!Schemas>
                       default:
                         name: daysBeforeExpiry
                         description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
-                        originalName: days_before_expiry
                     protocol: !<!Protocols> {}
                   language: !<!Languages> 
                     default:
@@ -3309,7 +3171,6 @@ schemas: !<!Schemas>
                   default:
                     name: trigger
                     description: A condition to be satisfied for an action to be executed.
-                    originalName: trigger
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_31
@@ -3348,7 +3209,6 @@ schemas: !<!Schemas>
                       default:
                         name: actionType
                         description: The type of the action.
-                        originalName: action_type
                     protocol: !<!Protocols> {}
                   language: !<!Languages> 
                     default:
@@ -3361,7 +3221,6 @@ schemas: !<!Schemas>
                   default:
                     name: action
                     description: The action that will be executed.
-                    originalName: action
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -3371,7 +3230,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: CertificatePolicy-lifetime_actions
+                name: CertificatePolicyLifetimeActions
                 description: Actions that will be performed by Key Vault over the lifetime of a certificate.
             protocol: !<!Protocols> {}
           serializedName: lifetime_actions
@@ -3379,7 +3238,6 @@ schemas: !<!Schemas>
             default:
               name: lifetimeActions
               description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-              originalName: lifetime_actions
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ObjectSchema> &ref_32
@@ -3396,7 +3254,7 @@ schemas: !<!Schemas>
                   version: 7.0-preview
                 language: !<!Languages> 
                   default:
-                    name: IssuerParameters-name
+                    name: IssuerParametersName
                     description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
                 protocol: !<!Protocols> {}
               serializedName: name
@@ -3404,7 +3262,6 @@ schemas: !<!Schemas>
                 default:
                   name: name
                   description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
-                  originalName: name
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!StringSchema> &ref_198
@@ -3420,9 +3277,8 @@ schemas: !<!Schemas>
               serializedName: cty
               language: !<!Languages> 
                 default:
-                  name: CertificateType
+                  name: certificateType
                   description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
-                  originalName: CertificateType
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!BooleanSchema> &ref_107
@@ -3435,9 +3291,8 @@ schemas: !<!Schemas>
               serializedName: cert_transparency
               language: !<!Languages> 
                 default:
-                  name: CertificateTransparency
+                  name: certificateTransparency
                   description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
-                  originalName: CertificateTransparency
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -3448,9 +3303,8 @@ schemas: !<!Schemas>
           serializedName: issuer
           language: !<!Languages> 
             default:
-              name: IssuerParameters
+              name: issuerParameters
               description: Parameters for the issuer of the X509 component of a certificate.
-              originalName: IssuerParameters
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_5
@@ -3459,7 +3313,6 @@ schemas: !<!Schemas>
             default:
               name: attributes
               description: The certificate management attributes.
-              originalName: attributes
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -3473,7 +3326,6 @@ schemas: !<!Schemas>
         default:
           name: policy
           description: Management policy for a certificate.
-          originalName: policy
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ByteArraySchema> &ref_139
@@ -3484,7 +3336,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateBundle-cer
+            name: CertificateBundleCer
             description: CER contents of x509 certificate.
         protocol: !<!Protocols> {}
       serializedName: cer
@@ -3492,7 +3344,6 @@ schemas: !<!Schemas>
         default:
           name: cer
           description: CER contents of x509 certificate.
-          originalName: cer
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_199
@@ -3502,7 +3353,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateBundle-contentType
+            name: CertificateBundleContentType
             description: The content type of the secret.
         protocol: !<!Protocols> {}
       serializedName: contentType
@@ -3510,7 +3361,6 @@ schemas: !<!Schemas>
         default:
           name: contentType
           description: The content type of the secret.
-          originalName: contentType
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_5
@@ -3519,7 +3369,6 @@ schemas: !<!Schemas>
         default:
           name: attributes
           description: The certificate management attributes.
-          originalName: attributes
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_60
@@ -3531,12 +3380,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CertificateBundle-tags
+            name: CertificateBundleTags
             description: Application specific metadata in the form of key-value pairs
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -3544,7 +3393,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -3576,7 +3424,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: Contacts-id
+            name: ContactsId
             description: Identifier for the contacts collection.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -3585,7 +3433,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Identifier for the contacts collection.
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> &ref_524
       schema: !<!ArraySchema> &ref_89
@@ -3613,9 +3460,8 @@ schemas: !<!Schemas>
             serializedName: email
             language: !<!Languages> 
               default:
-                name: EmailAddress
+                name: emailAddress
                 description: Email address.
-                originalName: EmailAddress
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_204
@@ -3625,7 +3471,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: Contact-name
+                  name: ContactName
                   description: Name.
               protocol: !<!Protocols> {}
             serializedName: name
@@ -3633,7 +3479,6 @@ schemas: !<!Schemas>
               default:
                 name: name
                 description: Name.
-                originalName: name
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_205
@@ -3643,7 +3488,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: Contact-phone
+                  name: ContactPhone
                   description: Phone number.
               protocol: !<!Protocols> {}
             serializedName: phone
@@ -3651,7 +3496,6 @@ schemas: !<!Schemas>
               default:
                 name: phone
                 description: Phone number.
-                originalName: phone
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -3667,9 +3511,8 @@ schemas: !<!Schemas>
       serializedName: contacts
       language: !<!Languages> 
         default:
-          name: ContactList
+          name: contactList
           description: The contact list for the vault certificates.
-          originalName: ContactList
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -3704,7 +3547,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: CertificateIssuerItem-id
+                  name: CertificateIssuerItemId
                   description: Certificate Identifier.
               protocol: !<!Protocols> {}
             serializedName: id
@@ -3712,7 +3555,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: Certificate Identifier.
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_207
@@ -3722,7 +3564,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: CertificateIssuerItem-provider
+                  name: CertificateIssuerItemProvider
                   description: The issuer provider.
               protocol: !<!Protocols> {}
             serializedName: provider
@@ -3730,7 +3572,6 @@ schemas: !<!Schemas>
               default:
                 name: provider
                 description: The issuer provider.
-                originalName: provider
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -3740,7 +3581,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CertificateIssuerListResult-value
+            name: CertificateIssuerListResultValue
             description: A response message containing a list of certificate issuers in the key vault along with a link to the next page of certificate issuers.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -3749,7 +3590,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of certificate issuers in the key vault along with a link to the next page of certificate issuers.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_208
@@ -3759,7 +3599,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateIssuerListResult-nextLink
+            name: CertificateIssuerListResultNextLink
             description: The URL to get the next set of certificate issuers.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -3768,7 +3608,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of certificate issuers.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -3791,7 +3630,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateIssuerSetParameters-provider
+            name: CertificateIssuerSetParametersProvider
             description: The issuer provider.
         protocol: !<!Protocols> {}
       required: true
@@ -3800,7 +3639,6 @@ schemas: !<!Schemas>
         default:
           name: provider
           description: The issuer provider.
-          originalName: provider
       protocol: !<!Protocols> {}
     - !<!Property> &ref_537
       schema: !<!ObjectSchema> &ref_35
@@ -3817,7 +3655,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: IssuerCredentials-account_id
+                name: IssuerCredentialsAccountId
                 description: The user name/account name/account id.
             protocol: !<!Protocols> {}
           serializedName: account_id
@@ -3825,7 +3663,6 @@ schemas: !<!Schemas>
             default:
               name: accountId
               description: The user name/account name/account id.
-              originalName: account_id
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_211
@@ -3841,9 +3678,8 @@ schemas: !<!Schemas>
           serializedName: pwd
           language: !<!Languages> 
             default:
-              name: Password
+              name: password
               description: The password/secret/account key.
-              originalName: Password
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -3857,7 +3693,6 @@ schemas: !<!Schemas>
         default:
           name: credentials
           description: The credentials to be used for the certificate issuer.
-          originalName: credentials
       protocol: !<!Protocols> {}
     - !<!Property> &ref_538
       schema: !<!ObjectSchema> &ref_36
@@ -3874,7 +3709,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: OrganizationDetails-id
+                name: OrganizationDetailsId
                 description: Id of the organization.
             protocol: !<!Protocols> {}
           serializedName: id
@@ -3882,7 +3717,6 @@ schemas: !<!Schemas>
             default:
               name: id
               description: Id of the organization.
-              originalName: id
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ArraySchema> &ref_91
@@ -3904,7 +3738,7 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: AdministratorDetails-first_name
+                      name: AdministratorDetailsFirstName
                       description: First name.
                   protocol: !<!Protocols> {}
                 serializedName: first_name
@@ -3912,7 +3746,6 @@ schemas: !<!Schemas>
                   default:
                     name: firstName
                     description: First name.
-                    originalName: first_name
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_214
@@ -3922,7 +3755,7 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: AdministratorDetails-last_name
+                      name: AdministratorDetailsLastName
                       description: Last name.
                   protocol: !<!Protocols> {}
                 serializedName: last_name
@@ -3930,7 +3763,6 @@ schemas: !<!Schemas>
                   default:
                     name: lastName
                     description: Last name.
-                    originalName: last_name
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_215
@@ -3946,9 +3778,8 @@ schemas: !<!Schemas>
                 serializedName: email
                 language: !<!Languages> 
                   default:
-                    name: EmailAddress
+                    name: emailAddress
                     description: Email address.
-                    originalName: EmailAddress
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_216
@@ -3958,7 +3789,7 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: AdministratorDetails-phone
+                      name: AdministratorDetailsPhone
                       description: Phone number.
                   protocol: !<!Protocols> {}
                 serializedName: phone
@@ -3966,7 +3797,6 @@ schemas: !<!Schemas>
                   default:
                     name: phone
                     description: Phone number.
-                    originalName: phone
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -3976,7 +3806,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: OrganizationDetails-admin_details
+                name: OrganizationDetailsAdminDetails
                 description: Details of the organization administrator.
             protocol: !<!Protocols> {}
           serializedName: admin_details
@@ -3984,7 +3814,6 @@ schemas: !<!Schemas>
             default:
               name: adminDetails
               description: Details of the organization administrator.
-              originalName: admin_details
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -3996,9 +3825,8 @@ schemas: !<!Schemas>
       serializedName: org_details
       language: !<!Languages> 
         default:
-          name: OrganizationDetails
+          name: organizationDetails
           description: Details of the organization of the certificate issuer.
-          originalName: OrganizationDetails
       protocol: !<!Protocols> {}
     - !<!Property> &ref_539
       schema: !<!ObjectSchema> &ref_38
@@ -4012,7 +3840,7 @@ schemas: !<!Schemas>
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForenabled
+                name: TypeForenabled
                 description: Determines whether the issuer is enabled.
             protocol: !<!Protocols> {}
           serializedName: enabled
@@ -4020,14 +3848,13 @@ schemas: !<!Schemas>
             default:
               name: enabled
               description: Determines whether the issuer is enabled.
-              originalName: enabled
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_286
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeForcreated
+                name: TypeForcreated
                 description: Creation time in UTC.
             protocol: !<!Protocols> {}
           readOnly: true
@@ -4036,14 +3863,13 @@ schemas: !<!Schemas>
             default:
               name: created
               description: Creation time in UTC.
-              originalName: created
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_287
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeForupdated
+                name: TypeForupdated
                 description: Last updated time in UTC.
             protocol: !<!Protocols> {}
           readOnly: true
@@ -4052,7 +3878,6 @@ schemas: !<!Schemas>
             default:
               name: updated
               description: Last updated time in UTC.
-              originalName: updated
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -4066,7 +3891,6 @@ schemas: !<!Schemas>
         default:
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
-          originalName: attributes
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4092,7 +3916,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: IssuerBundle-id
+            name: IssuerBundleId
             description: Identifier for the issuer object.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -4101,7 +3925,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Identifier for the issuer object.
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_218
@@ -4111,7 +3934,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: IssuerBundle-provider
+            name: IssuerBundleProvider
             description: The issuer provider.
         protocol: !<!Protocols> {}
       serializedName: provider
@@ -4119,7 +3942,6 @@ schemas: !<!Schemas>
         default:
           name: provider
           description: The issuer provider.
-          originalName: provider
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_35
@@ -4128,16 +3950,14 @@ schemas: !<!Schemas>
         default:
           name: credentials
           description: The credentials to be used for the certificate issuer.
-          originalName: credentials
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_36
       serializedName: org_details
       language: !<!Languages> 
         default:
-          name: OrganizationDetails
+          name: organizationDetails
           description: Details of the organization of the certificate issuer.
-          originalName: OrganizationDetails
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_38
@@ -4146,7 +3966,6 @@ schemas: !<!Schemas>
         default:
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
-          originalName: attributes
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4168,7 +3987,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateIssuerUpdateParameters-provider
+            name: CertificateIssuerUpdateParametersProvider
             description: The issuer provider.
         protocol: !<!Protocols> {}
       serializedName: provider
@@ -4176,7 +3995,6 @@ schemas: !<!Schemas>
         default:
           name: provider
           description: The issuer provider.
-          originalName: provider
       protocol: !<!Protocols> {}
     - !<!Property> &ref_551
       schema: *ref_35
@@ -4185,16 +4003,14 @@ schemas: !<!Schemas>
         default:
           name: credentials
           description: The credentials to be used for the certificate issuer.
-          originalName: credentials
       protocol: !<!Protocols> {}
     - !<!Property> &ref_552
       schema: *ref_36
       serializedName: org_details
       language: !<!Languages> 
         default:
-          name: OrganizationDetails
+          name: organizationDetails
           description: Details of the organization of the certificate issuer.
-          originalName: OrganizationDetails
       protocol: !<!Protocols> {}
     - !<!Property> &ref_553
       schema: *ref_38
@@ -4203,7 +4019,6 @@ schemas: !<!Schemas>
         default:
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
-          originalName: attributes
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4222,18 +4037,16 @@ schemas: !<!Schemas>
       serializedName: policy
       language: !<!Languages> 
         default:
-          name: CertificatePolicy
+          name: certificatePolicy
           description: Management policy for a certificate.
-          originalName: CertificatePolicy
       protocol: !<!Protocols> {}
     - !<!Property> &ref_570
       schema: *ref_5
       serializedName: attributes
       language: !<!Languages> 
         default:
-          name: CertificateAttributes
+          name: certificateAttributes
           description: The certificate management attributes.
-          originalName: CertificateAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_571
       schema: !<!DictionarySchema> &ref_61
@@ -4245,12 +4058,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CertificateCreateParameters-tags
+            name: CertificateCreateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -4258,7 +4071,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4280,7 +4092,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateOperation-id
+            name: CertificateOperationId
             description: The certificate id.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -4289,16 +4101,14 @@ schemas: !<!Schemas>
         default:
           name: id
           description: The certificate id.
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_32
       serializedName: issuer
       language: !<!Languages> 
         default:
-          name: IssuerParameters
+          name: issuerParameters
           description: Parameters for the issuer of the X509 component of a certificate.
-          originalName: IssuerParameters
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ByteArraySchema> &ref_140
@@ -4309,7 +4119,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateOperation-csr
+            name: CertificateOperationCsr
             description: The certificate signing request (CSR) that is being used in the certificate operation.
         protocol: !<!Protocols> {}
       serializedName: csr
@@ -4317,14 +4127,13 @@ schemas: !<!Schemas>
         default:
           name: csr
           description: The certificate signing request (CSR) that is being used in the certificate operation.
-          originalName: csr
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_109
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForcancellation_requested
+            name: TypeForcancellationRequested
             description: Indicates if cancellation was requested on the certificate operation.
         protocol: !<!Protocols> {}
       serializedName: cancellation_requested
@@ -4332,7 +4141,6 @@ schemas: !<!Schemas>
         default:
           name: cancellationRequested
           description: Indicates if cancellation was requested on the certificate operation.
-          originalName: cancellation_requested
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_222
@@ -4342,7 +4150,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateOperation-status
+            name: CertificateOperationStatus
             description: Status of the certificate operation.
         protocol: !<!Protocols> {}
       serializedName: status
@@ -4350,7 +4158,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: Status of the certificate operation.
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_223
@@ -4360,7 +4167,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateOperation-status_details
+            name: CertificateOperationStatusDetails
             description: The status details of the certificate operation.
         protocol: !<!Protocols> {}
       serializedName: status_details
@@ -4368,7 +4175,6 @@ schemas: !<!Schemas>
         default:
           name: statusDetails
           description: The status details of the certificate operation.
-          originalName: status_details
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_11
@@ -4377,7 +4183,6 @@ schemas: !<!Schemas>
         default:
           name: error
           description: The key vault server error.
-          originalName: error
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_224
@@ -4387,7 +4192,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateOperation-target
+            name: CertificateOperationTarget
             description: Location which contains the result of the certificate operation.
         protocol: !<!Protocols> {}
       serializedName: target
@@ -4395,7 +4200,6 @@ schemas: !<!Schemas>
         default:
           name: target
           description: Location which contains the result of the certificate operation.
-          originalName: target
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_225
@@ -4405,7 +4209,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: CertificateOperation-request_id
+            name: CertificateOperationRequestId
             description: Identifier for the certificate operation.
         protocol: !<!Protocols> {}
       serializedName: request_id
@@ -4413,7 +4217,6 @@ schemas: !<!Schemas>
         default:
           name: requestId
           description: Identifier for the certificate operation.
-          originalName: request_id
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4435,7 +4238,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: base64EncodedCertificate
+            name: Base64EncodedCertificate
             description: Base64 encoded representation of the certificate object to import. This certificate needs to contain the private key.
         protocol: !<!Protocols> {}
       required: true
@@ -4444,7 +4247,6 @@ schemas: !<!Schemas>
         default:
           name: base64EncodedCertificate
           description: Base64 encoded representation of the certificate object to import. This certificate needs to contain the private key.
-          originalName: base64EncodedCertificate
       protocol: !<!Protocols> {}
     - !<!Property> &ref_582
       schema: !<!StringSchema> &ref_227
@@ -4454,7 +4256,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: password
+            name: Password
             description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
         protocol: !<!Protocols> {}
       required: false
@@ -4463,7 +4265,6 @@ schemas: !<!Schemas>
         default:
           name: password
           description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
-          originalName: password
       protocol: !<!Protocols> {}
     - !<!Property> &ref_583
       schema: *ref_24
@@ -4471,9 +4272,8 @@ schemas: !<!Schemas>
       serializedName: policy
       language: !<!Languages> 
         default:
-          name: CertificatePolicy
+          name: certificatePolicy
           description: Management policy for a certificate.
-          originalName: CertificatePolicy
       protocol: !<!Protocols> {}
     - !<!Property> &ref_584
       schema: *ref_5
@@ -4481,9 +4281,8 @@ schemas: !<!Schemas>
       serializedName: attributes
       language: !<!Languages> 
         default:
-          name: CertificateAttributes
+          name: certificateAttributes
           description: The certificate management attributes.
-          originalName: CertificateAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_585
       schema: !<!DictionarySchema> &ref_62
@@ -4495,12 +4294,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CertificateImportParameters-tags
+            name: CertificateImportParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       required: false
@@ -4509,7 +4308,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4528,18 +4326,16 @@ schemas: !<!Schemas>
       serializedName: policy
       language: !<!Languages> 
         default:
-          name: CertificatePolicy
+          name: certificatePolicy
           description: Management policy for a certificate.
-          originalName: CertificatePolicy
       protocol: !<!Protocols> {}
     - !<!Property> &ref_610
       schema: *ref_5
       serializedName: attributes
       language: !<!Languages> 
         default:
-          name: CertificateAttributes
+          name: certificateAttributes
           description: The certificate management attributes.
-          originalName: CertificateAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_611
       schema: !<!DictionarySchema> &ref_63
@@ -4551,12 +4347,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CertificateUpdateParameters-tags
+            name: CertificateUpdateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -4564,7 +4360,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4583,7 +4378,7 @@ schemas: !<!Schemas>
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForcancellation_requested
+            name: TypeForcancellationRequested
             description: Indicates if cancellation was requested on the certificate operation.
         protocol: !<!Protocols> {}
       required: true
@@ -4592,7 +4387,6 @@ schemas: !<!Schemas>
         default:
           name: cancellationRequested
           description: Indicates if cancellation was requested on the certificate operation.
-          originalName: cancellation_requested
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4620,12 +4414,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: CertificateMergeParameters-x5cItem
+              name: CertificateMergeParametersX5CItem
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: x509Certificates
+            name: X509Certificates
             description: The certificate or the certificate chain to merge.
         protocol: !<!Protocols> {}
       required: true
@@ -4634,7 +4428,6 @@ schemas: !<!Schemas>
         default:
           name: x509Certificates
           description: The certificate or the certificate chain to merge.
-          originalName: x509Certificates
       protocol: !<!Protocols> {}
     - !<!Property> &ref_640
       schema: *ref_5
@@ -4642,9 +4435,8 @@ schemas: !<!Schemas>
       serializedName: attributes
       language: !<!Languages> 
         default:
-          name: CertificateAttributes
+          name: certificateAttributes
           description: The certificate management attributes.
-          originalName: CertificateAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_641
       schema: !<!DictionarySchema> &ref_64
@@ -4656,12 +4448,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: CertificateMergeParameters-tags
+            name: CertificateMergeParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       required: false
@@ -4670,7 +4462,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4693,7 +4484,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: BackupCertificateResult-value
+            name: BackupCertificateResultValue
             description: The backup blob containing the backed up certificate.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -4702,7 +4493,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: The backup blob containing the backed up certificate.
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4725,7 +4515,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: certificateBundleBackup
+            name: CertificateBundleBackup
             description: The backup blob associated with a certificate bundle.
         protocol: !<!Protocols> {}
       required: true
@@ -4734,7 +4524,6 @@ schemas: !<!Schemas>
         default:
           name: certificateBundleBackup
           description: The backup blob associated with a certificate bundle.
-          originalName: certificateBundleBackup
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4757,7 +4546,7 @@ schemas: !<!Schemas>
         elementType: *ref_21
         language: !<!Languages> 
           default:
-            name: DeletedCertificateListResult-value
+            name: DeletedCertificateListResultValue
             description: A response message containing a list of deleted certificates in the vault along with a link to the next page of deleted certificates
         protocol: !<!Protocols> {}
       readOnly: true
@@ -4766,7 +4555,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of deleted certificates in the vault along with a link to the next page of deleted certificates
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_232
@@ -4776,7 +4564,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: DeletedCertificateListResult-nextLink
+            name: DeletedCertificateListResultNextLink
             description: The URL to get the next set of deleted certificates.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -4785,7 +4573,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of deleted certificates.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -4832,7 +4619,7 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: DeletedStorageAccountItem-recoveryId
+                      name: DeletedStorageAccountItemRecoveryId
                       description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
                   protocol: !<!Protocols> {}
                 serializedName: recoveryId
@@ -4840,14 +4627,13 @@ schemas: !<!Schemas>
                   default:
                     name: recoveryId
                     description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
-                    originalName: recoveryId
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_292
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForscheduledPurgeDate
+                      name: TypeForscheduledPurgeDate
                       description: 'The time when the storage account is scheduled to be purged, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -4856,14 +4642,13 @@ schemas: !<!Schemas>
                   default:
                     name: scheduledPurgeDate
                     description: 'The time when the storage account is scheduled to be purged, in UTC'
-                    originalName: scheduledPurgeDate
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_293
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeFordeletedDate
+                      name: TypeFordeletedDate
                       description: 'The time when the storage account was deleted, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -4872,7 +4657,6 @@ schemas: !<!Schemas>
                   default:
                     name: deletedDate
                     description: 'The time when the storage account was deleted, in UTC'
-                    originalName: deletedDate
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -4891,7 +4675,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: StorageAccountItem-id
+                  name: StorageAccountItemId
                   description: Storage identifier.
               protocol: !<!Protocols> {}
             readOnly: true
@@ -4900,7 +4684,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: Storage identifier.
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_234
@@ -4910,7 +4693,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: StorageAccountItem-resourceId
+                  name: StorageAccountItemResourceId
                   description: Storage account resource Id.
               protocol: !<!Protocols> {}
             readOnly: true
@@ -4919,7 +4702,6 @@ schemas: !<!Schemas>
               default:
                 name: resourceId
                 description: Storage account resource Id.
-                originalName: resourceId
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_41
@@ -4933,7 +4715,7 @@ schemas: !<!Schemas>
                   type: boolean
                   language: !<!Languages> 
                     default:
-                      name: typeForenabled
+                      name: TypeForenabled
                       description: the enabled state of the object.
                   protocol: !<!Protocols> {}
                 serializedName: enabled
@@ -4941,14 +4723,13 @@ schemas: !<!Schemas>
                   default:
                     name: enabled
                     description: the enabled state of the object.
-                    originalName: enabled
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_290
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForcreated
+                      name: TypeForcreated
                       description: Creation time in UTC.
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -4957,14 +4738,13 @@ schemas: !<!Schemas>
                   default:
                     name: created
                     description: Creation time in UTC.
-                    originalName: created
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_291
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForupdated
+                      name: TypeForupdated
                       description: Last updated time in UTC.
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -4973,7 +4753,6 @@ schemas: !<!Schemas>
                   default:
                     name: updated
                     description: Last updated time in UTC.
-                    originalName: updated
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_3
@@ -4985,7 +4764,6 @@ schemas: !<!Schemas>
                     description: >-
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
-                    originalName: recoveryLevel
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -4999,7 +4777,6 @@ schemas: !<!Schemas>
               default:
                 name: attributes
                 description: The storage account management attributes.
-                originalName: attributes
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_65
@@ -5011,12 +4788,12 @@ schemas: !<!Schemas>
                   version: 7.0-preview
                 language: !<!Languages> 
                   default:
-                    name: string
+                    name: String
                     description: ''
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: StorageAccountItem-tags
+                  name: StorageAccountItemTags
                   description: Application specific metadata in the form of key-value pairs.
               protocol: !<!Protocols> {}
             readOnly: true
@@ -5025,7 +4802,6 @@ schemas: !<!Schemas>
               default:
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
-                originalName: tags
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -5035,7 +4811,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: StorageListResult-value
+            name: StorageListResultValue
             description: A response message containing a list of storage accounts in the key vault along with a link to the next page of storage accounts.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5044,7 +4820,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of storage accounts in the key vault along with a link to the next page of storage accounts.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_236
@@ -5054,7 +4829,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageListResult-nextLink
+            name: StorageListResultNextLink
             description: The URL to get the next set of storage accounts.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5063,7 +4838,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of storage accounts.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5088,7 +4862,7 @@ schemas: !<!Schemas>
         elementType: *ref_40
         language: !<!Languages> 
           default:
-            name: DeletedStorageListResult-value
+            name: DeletedStorageListResultValue
             description: A response message containing a list of the deleted storage accounts in the vault along with a link to the next page of deleted storage accounts
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5097,7 +4871,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of the deleted storage accounts in the vault along with a link to the next page of deleted storage accounts
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_238
@@ -5107,7 +4880,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: DeletedStorageListResult-nextLink
+            name: DeletedStorageListResultNextLink
             description: The URL to get the next set of deleted storage accounts.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5116,7 +4889,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of deleted storage accounts.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5151,7 +4923,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: DeletedStorageBundle-recoveryId
+                name: DeletedStorageBundleRecoveryId
                 description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
             protocol: !<!Protocols> {}
           serializedName: recoveryId
@@ -5159,14 +4931,13 @@ schemas: !<!Schemas>
             default:
               name: recoveryId
               description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
-              originalName: recoveryId
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_294
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeForscheduledPurgeDate
+                name: TypeForscheduledPurgeDate
                 description: 'The time when the storage account is scheduled to be purged, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -5175,14 +4946,13 @@ schemas: !<!Schemas>
             default:
               name: scheduledPurgeDate
               description: 'The time when the storage account is scheduled to be purged, in UTC'
-              originalName: scheduledPurgeDate
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_295
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeFordeletedDate
+                name: TypeFordeletedDate
                 description: 'The time when the storage account was deleted, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -5191,7 +4961,6 @@ schemas: !<!Schemas>
             default:
               name: deletedDate
               description: 'The time when the storage account was deleted, in UTC'
-              originalName: deletedDate
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -5210,7 +4979,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageBundle-id
+            name: StorageBundleId
             description: The storage account id.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5219,7 +4988,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: The storage account id.
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_240
@@ -5229,7 +4997,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageBundle-resourceId
+            name: StorageBundleResourceId
             description: The storage account resource id.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5238,7 +5006,6 @@ schemas: !<!Schemas>
         default:
           name: resourceId
           description: The storage account resource id.
-          originalName: resourceId
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_241
@@ -5248,7 +5015,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageBundle-activeKeyName
+            name: StorageBundleActiveKeyName
             description: The current active storage account key name.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5257,14 +5024,13 @@ schemas: !<!Schemas>
         default:
           name: activeKeyName
           description: The current active storage account key name.
-          originalName: activeKeyName
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!BooleanSchema> &ref_112
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForautoRegenerateKey
+            name: TypeForautoRegenerateKey
             description: whether keyvault should manage the storage account for the user.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5273,7 +5039,6 @@ schemas: !<!Schemas>
         default:
           name: autoRegenerateKey
           description: whether keyvault should manage the storage account for the user.
-          originalName: autoRegenerateKey
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_242
@@ -5283,7 +5048,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageBundle-regenerationPeriod
+            name: StorageBundleRegenerationPeriod
             description: The key regeneration time duration specified in ISO-8601 format.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5292,7 +5057,6 @@ schemas: !<!Schemas>
         default:
           name: regenerationPeriod
           description: The key regeneration time duration specified in ISO-8601 format.
-          originalName: regenerationPeriod
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_41
@@ -5302,7 +5066,6 @@ schemas: !<!Schemas>
         default:
           name: attributes
           description: The storage account management attributes.
-          originalName: attributes
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_66
@@ -5314,12 +5077,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: StorageBundle-tags
+            name: StorageBundleTags
             description: Application specific metadata in the form of key-value pairs
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5328,7 +5091,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5352,7 +5114,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: BackupStorageResult-value
+            name: BackupStorageResultValue
             description: The backup blob containing the backed up storage account.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5361,7 +5123,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: The backup blob containing the backed up storage account.
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5384,7 +5145,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: storageBundleBackup
+            name: StorageBundleBackup
             description: The backup blob associated with a storage account.
         protocol: !<!Protocols> {}
       required: true
@@ -5393,7 +5154,6 @@ schemas: !<!Schemas>
         default:
           name: storageBundleBackup
           description: The backup blob associated with a storage account.
-          originalName: storageBundleBackup
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5415,7 +5175,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountCreateParameters-resourceId
+            name: StorageAccountCreateParametersResourceId
             description: Storage account resource id.
         protocol: !<!Protocols> {}
       required: true
@@ -5424,7 +5184,6 @@ schemas: !<!Schemas>
         default:
           name: resourceId
           description: Storage account resource id.
-          originalName: resourceId
       protocol: !<!Protocols> {}
     - !<!Property> &ref_707
       schema: !<!StringSchema> &ref_246
@@ -5434,7 +5193,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountCreateParameters-activeKeyName
+            name: StorageAccountCreateParametersActiveKeyName
             description: Current active storage account key name.
         protocol: !<!Protocols> {}
       required: true
@@ -5443,14 +5202,13 @@ schemas: !<!Schemas>
         default:
           name: activeKeyName
           description: Current active storage account key name.
-          originalName: activeKeyName
       protocol: !<!Protocols> {}
     - !<!Property> &ref_708
       schema: !<!BooleanSchema> &ref_113
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForautoRegenerateKey
+            name: TypeForautoRegenerateKey
             description: whether keyvault should manage the storage account for the user.
         protocol: !<!Protocols> {}
       required: true
@@ -5459,7 +5217,6 @@ schemas: !<!Schemas>
         default:
           name: autoRegenerateKey
           description: whether keyvault should manage the storage account for the user.
-          originalName: autoRegenerateKey
       protocol: !<!Protocols> {}
     - !<!Property> &ref_709
       schema: !<!StringSchema> &ref_247
@@ -5469,7 +5226,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountCreateParameters-regenerationPeriod
+            name: StorageAccountCreateParametersRegenerationPeriod
             description: The key regeneration time duration specified in ISO-8601 format.
         protocol: !<!Protocols> {}
       required: false
@@ -5478,7 +5235,6 @@ schemas: !<!Schemas>
         default:
           name: regenerationPeriod
           description: The key regeneration time duration specified in ISO-8601 format.
-          originalName: regenerationPeriod
       protocol: !<!Protocols> {}
     - !<!Property> &ref_710
       schema: *ref_41
@@ -5486,9 +5242,8 @@ schemas: !<!Schemas>
       serializedName: attributes
       language: !<!Languages> 
         default:
-          name: StorageAccountAttributes
+          name: storageAccountAttributes
           description: The storage account management attributes.
-          originalName: StorageAccountAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_711
       schema: !<!DictionarySchema> &ref_67
@@ -5500,12 +5255,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: StorageAccountCreateParameters-tags
+            name: StorageAccountCreateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       required: false
@@ -5514,7 +5269,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5536,7 +5290,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountUpdateParameters-activeKeyName
+            name: StorageAccountUpdateParametersActiveKeyName
             description: The current active storage account key name.
         protocol: !<!Protocols> {}
       serializedName: activeKeyName
@@ -5544,14 +5298,13 @@ schemas: !<!Schemas>
         default:
           name: activeKeyName
           description: The current active storage account key name.
-          originalName: activeKeyName
       protocol: !<!Protocols> {}
     - !<!Property> &ref_724
       schema: !<!BooleanSchema> &ref_114
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeForautoRegenerateKey
+            name: TypeForautoRegenerateKey
             description: whether keyvault should manage the storage account for the user.
         protocol: !<!Protocols> {}
       serializedName: autoRegenerateKey
@@ -5559,7 +5312,6 @@ schemas: !<!Schemas>
         default:
           name: autoRegenerateKey
           description: whether keyvault should manage the storage account for the user.
-          originalName: autoRegenerateKey
       protocol: !<!Protocols> {}
     - !<!Property> &ref_725
       schema: !<!StringSchema> &ref_250
@@ -5569,7 +5321,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountUpdateParameters-regenerationPeriod
+            name: StorageAccountUpdateParametersRegenerationPeriod
             description: The key regeneration time duration specified in ISO-8601 format.
         protocol: !<!Protocols> {}
       serializedName: regenerationPeriod
@@ -5577,16 +5329,14 @@ schemas: !<!Schemas>
         default:
           name: regenerationPeriod
           description: The key regeneration time duration specified in ISO-8601 format.
-          originalName: regenerationPeriod
       protocol: !<!Protocols> {}
     - !<!Property> &ref_726
       schema: *ref_41
       serializedName: attributes
       language: !<!Languages> 
         default:
-          name: StorageAccountAttributes
+          name: storageAccountAttributes
           description: The storage account management attributes.
-          originalName: StorageAccountAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_727
       schema: !<!DictionarySchema> &ref_68
@@ -5598,12 +5348,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: StorageAccountUpdateParameters-tags
+            name: StorageAccountUpdateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -5611,7 +5361,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5633,7 +5382,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountRegenerteKeyParameters-keyName
+            name: StorageAccountRegenerteKeyParametersKeyName
             description: The storage account key name.
         protocol: !<!Protocols> {}
       required: true
@@ -5642,7 +5391,6 @@ schemas: !<!Schemas>
         default:
           name: keyName
           description: The storage account key name.
-          originalName: keyName
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5688,7 +5436,7 @@ schemas: !<!Schemas>
                     version: 7.0-preview
                   language: !<!Languages> 
                     default:
-                      name: DeletedSasDefinitionItem-recoveryId
+                      name: DeletedSasDefinitionItemRecoveryId
                       description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
                   protocol: !<!Protocols> {}
                 serializedName: recoveryId
@@ -5696,14 +5444,13 @@ schemas: !<!Schemas>
                   default:
                     name: recoveryId
                     description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
-                    originalName: recoveryId
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_298
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForscheduledPurgeDate
+                      name: TypeForscheduledPurgeDate
                       description: 'The time when the SAS definition is scheduled to be purged, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -5712,14 +5459,13 @@ schemas: !<!Schemas>
                   default:
                     name: scheduledPurgeDate
                     description: 'The time when the SAS definition is scheduled to be purged, in UTC'
-                    originalName: scheduledPurgeDate
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_299
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeFordeletedDate
+                      name: TypeFordeletedDate
                       description: 'The time when the SAS definition was deleted, in UTC'
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -5728,7 +5474,6 @@ schemas: !<!Schemas>
                   default:
                     name: deletedDate
                     description: 'The time when the SAS definition was deleted, in UTC'
-                    originalName: deletedDate
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -5747,7 +5492,7 @@ schemas: !<!Schemas>
                 version: 7.0-preview
               language: !<!Languages> 
                 default:
-                  name: SasDefinitionItem-id
+                  name: SasDefinitionItemId
                   description: The storage SAS identifier.
               protocol: !<!Protocols> {}
             readOnly: true
@@ -5756,7 +5501,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: The storage SAS identifier.
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_254
@@ -5773,9 +5517,8 @@ schemas: !<!Schemas>
             serializedName: sid
             language: !<!Languages> 
               default:
-                name: SecretId
+                name: secretId
                 description: The storage account SAS definition secret id.
-                originalName: SecretId
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_46
@@ -5789,7 +5532,7 @@ schemas: !<!Schemas>
                   type: boolean
                   language: !<!Languages> 
                     default:
-                      name: typeForenabled
+                      name: TypeForenabled
                       description: the enabled state of the object.
                   protocol: !<!Protocols> {}
                 serializedName: enabled
@@ -5797,14 +5540,13 @@ schemas: !<!Schemas>
                   default:
                     name: enabled
                     description: the enabled state of the object.
-                    originalName: enabled
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_296
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForcreated
+                      name: TypeForcreated
                       description: Creation time in UTC.
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -5813,14 +5555,13 @@ schemas: !<!Schemas>
                   default:
                     name: created
                     description: Creation time in UTC.
-                    originalName: created
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!UnixTimeSchema> &ref_297
                   type: unixtime
                   language: !<!Languages> 
                     default:
-                      name: typeForupdated
+                      name: TypeForupdated
                       description: Last updated time in UTC.
                   protocol: !<!Protocols> {}
                 readOnly: true
@@ -5829,7 +5570,6 @@ schemas: !<!Schemas>
                   default:
                     name: updated
                     description: Last updated time in UTC.
-                    originalName: updated
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_3
@@ -5841,7 +5581,6 @@ schemas: !<!Schemas>
                     description: >-
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
-                    originalName: recoveryLevel
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -5855,7 +5594,6 @@ schemas: !<!Schemas>
               default:
                 name: attributes
                 description: The SAS definition management attributes.
-                originalName: attributes
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_69
@@ -5867,12 +5605,12 @@ schemas: !<!Schemas>
                   version: 7.0-preview
                 language: !<!Languages> 
                   default:
-                    name: string
+                    name: String
                     description: ''
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: SasDefinitionItem-tags
+                  name: SasDefinitionItemTags
                   description: Application specific metadata in the form of key-value pairs.
               protocol: !<!Protocols> {}
             readOnly: true
@@ -5881,7 +5619,6 @@ schemas: !<!Schemas>
               default:
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
-                originalName: tags
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -5891,7 +5628,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SasDefinitionListResult-value
+            name: SasDefinitionListResultValue
             description: A response message containing a list of SAS definitions along with a link to the next page of SAS definitions.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5900,7 +5637,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of SAS definitions along with a link to the next page of SAS definitions.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_256
@@ -5910,7 +5646,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SasDefinitionListResult-nextLink
+            name: SasDefinitionListResultNextLink
             description: The URL to get the next set of SAS definitions.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5919,7 +5655,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of SAS definitions.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -5944,7 +5679,7 @@ schemas: !<!Schemas>
         elementType: *ref_45
         language: !<!Languages> 
           default:
-            name: DeletedSasDefinitionListResult-value
+            name: DeletedSasDefinitionListResultValue
             description: A response message containing a list of the deleted SAS definitions in the vault along with a link to the next page of deleted sas definitions
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5953,7 +5688,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: A response message containing a list of the deleted SAS definitions in the vault along with a link to the next page of deleted sas definitions
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_258
@@ -5963,7 +5697,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: DeletedSasDefinitionListResult-nextLink
+            name: DeletedSasDefinitionListResultNextLink
             description: The URL to get the next set of deleted SAS definitions.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -5972,7 +5706,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: The URL to get the next set of deleted SAS definitions.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -6007,7 +5740,7 @@ schemas: !<!Schemas>
               version: 7.0-preview
             language: !<!Languages> 
               default:
-                name: DeletedSasDefinitionBundle-recoveryId
+                name: DeletedSasDefinitionBundleRecoveryId
                 description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
             protocol: !<!Protocols> {}
           serializedName: recoveryId
@@ -6015,14 +5748,13 @@ schemas: !<!Schemas>
             default:
               name: recoveryId
               description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
-              originalName: recoveryId
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_300
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeForscheduledPurgeDate
+                name: TypeForscheduledPurgeDate
                 description: 'The time when the SAS definition is scheduled to be purged, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -6031,14 +5763,13 @@ schemas: !<!Schemas>
             default:
               name: scheduledPurgeDate
               description: 'The time when the SAS definition is scheduled to be purged, in UTC'
-              originalName: scheduledPurgeDate
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!UnixTimeSchema> &ref_301
             type: unixtime
             language: !<!Languages> 
               default:
-                name: typeFordeletedDate
+                name: TypeFordeletedDate
                 description: 'The time when the SAS definition was deleted, in UTC'
             protocol: !<!Protocols> {}
           readOnly: true
@@ -6047,7 +5778,6 @@ schemas: !<!Schemas>
             default:
               name: deletedDate
               description: 'The time when the SAS definition was deleted, in UTC'
-              originalName: deletedDate
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -6066,7 +5796,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SasDefinitionBundle-id
+            name: SasDefinitionBundleId
             description: The SAS definition id.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -6075,7 +5805,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: The SAS definition id.
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_260
@@ -6092,9 +5821,8 @@ schemas: !<!Schemas>
       serializedName: sid
       language: !<!Languages> 
         default:
-          name: SecretId
+          name: secretId
           description: Storage account SAS definition secret id.
-          originalName: SecretId
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_261
@@ -6104,7 +5832,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SasDefinitionBundle-templateUri
+            name: SasDefinitionBundleTemplateUri
             description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -6113,7 +5841,6 @@ schemas: !<!Schemas>
         default:
           name: templateUri
           description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-          originalName: templateUri
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ChoiceSchema> &ref_49
@@ -6122,13 +5849,13 @@ schemas: !<!Schemas>
           value: account
           language:
             default:
-              name: account
+              name: Account
               description: ''
         - !<!ChoiceValue> 
           value: service
           language:
             default:
-              name: service
+              name: Service
               description: ''
         type: choice
         apiVersions:
@@ -6146,7 +5873,6 @@ schemas: !<!Schemas>
         default:
           name: sasType
           description: The type of SAS token the SAS definition will create.
-          originalName: sasType
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_262
@@ -6156,7 +5882,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SasDefinitionBundle-validityPeriod
+            name: SasDefinitionBundleValidityPeriod
             description: The validity period of SAS tokens created according to the SAS definition.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -6165,7 +5891,6 @@ schemas: !<!Schemas>
         default:
           name: validityPeriod
           description: The validity period of SAS tokens created according to the SAS definition.
-          originalName: validityPeriod
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_46
@@ -6175,7 +5900,6 @@ schemas: !<!Schemas>
         default:
           name: attributes
           description: The SAS definition management attributes.
-          originalName: attributes
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_70
@@ -6187,12 +5911,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SasDefinitionBundle-tags
+            name: SasDefinitionBundleTags
             description: Application specific metadata in the form of key-value pairs
         protocol: !<!Protocols> {}
       readOnly: true
@@ -6201,7 +5925,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -6224,7 +5947,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SasDefinitionCreateParameters-templateUri
+            name: SasDefinitionCreateParametersTemplateUri
             description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
         protocol: !<!Protocols> {}
       required: true
@@ -6233,7 +5956,6 @@ schemas: !<!Schemas>
         default:
           name: templateUri
           description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-          originalName: templateUri
       protocol: !<!Protocols> {}
     - !<!Property> &ref_779
       schema: *ref_49
@@ -6243,7 +5965,6 @@ schemas: !<!Schemas>
         default:
           name: sasType
           description: The type of SAS token the SAS definition will create.
-          originalName: sasType
       protocol: !<!Protocols> {}
     - !<!Property> &ref_780
       schema: !<!StringSchema> &ref_266
@@ -6253,7 +5974,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SasDefinitionCreateParameters-validityPeriod
+            name: SasDefinitionCreateParametersValidityPeriod
             description: The validity period of SAS tokens created according to the SAS definition.
         protocol: !<!Protocols> {}
       required: true
@@ -6262,7 +5983,6 @@ schemas: !<!Schemas>
         default:
           name: validityPeriod
           description: The validity period of SAS tokens created according to the SAS definition.
-          originalName: validityPeriod
       protocol: !<!Protocols> {}
     - !<!Property> &ref_781
       schema: *ref_46
@@ -6270,9 +5990,8 @@ schemas: !<!Schemas>
       serializedName: attributes
       language: !<!Languages> 
         default:
-          name: SasDefinitionAttributes
+          name: sasDefinitionAttributes
           description: The SAS definition management attributes.
-          originalName: SasDefinitionAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_782
       schema: !<!DictionarySchema> &ref_71
@@ -6284,12 +6003,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SasDefinitionCreateParameters-tags
+            name: SasDefinitionCreateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       required: false
@@ -6298,7 +6017,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -6320,7 +6038,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SasDefinitionUpdateParameters-templateUri
+            name: SasDefinitionUpdateParametersTemplateUri
             description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
         protocol: !<!Protocols> {}
       serializedName: templateUri
@@ -6328,7 +6046,6 @@ schemas: !<!Schemas>
         default:
           name: templateUri
           description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-          originalName: templateUri
       protocol: !<!Protocols> {}
     - !<!Property> &ref_796
       schema: *ref_49
@@ -6337,7 +6054,6 @@ schemas: !<!Schemas>
         default:
           name: sasType
           description: The type of SAS token the SAS definition will create.
-          originalName: sasType
       protocol: !<!Protocols> {}
     - !<!Property> &ref_797
       schema: !<!StringSchema> &ref_269
@@ -6347,7 +6063,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: SasDefinitionUpdateParameters-validityPeriod
+            name: SasDefinitionUpdateParametersValidityPeriod
             description: The validity period of SAS tokens created according to the SAS definition.
         protocol: !<!Protocols> {}
       serializedName: validityPeriod
@@ -6355,16 +6071,14 @@ schemas: !<!Schemas>
         default:
           name: validityPeriod
           description: The validity period of SAS tokens created according to the SAS definition.
-          originalName: validityPeriod
       protocol: !<!Protocols> {}
     - !<!Property> &ref_798
       schema: *ref_46
       serializedName: attributes
       language: !<!Languages> 
         default:
-          name: SasDefinitionAttributes
+          name: sasDefinitionAttributes
           description: The SAS definition management attributes.
-          originalName: SasDefinitionAttributes
       protocol: !<!Protocols> {}
     - !<!Property> &ref_799
       schema: !<!DictionarySchema> &ref_72
@@ -6376,12 +6090,12 @@ schemas: !<!Schemas>
             version: 7.0-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SasDefinitionUpdateParameters-tags
+            name: SasDefinitionUpdateParametersTags
             description: Application specific metadata in the form of key-value pairs.
         protocol: !<!Protocols> {}
       serializedName: tags
@@ -6389,7 +6103,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Application specific metadata in the form of key-value pairs.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -6411,7 +6124,7 @@ schemas: !<!Schemas>
           version: 7.0-preview
         language: !<!Languages> 
           default:
-            name: PendingCertificateSigningRequestResult-value
+            name: PendingCertificateSigningRequestResultValue
             description: The pending certificate signing request as Base64 encoded string.
         protocol: !<!Protocols> {}
       readOnly: true
@@ -6420,7 +6133,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: The pending certificate signing request as Base64 encoded string.
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -6500,7 +6212,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - *ref_105
@@ -6516,7 +6228,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - *ref_111
@@ -6567,7 +6279,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6581,7 +6293,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6595,7 +6307,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6609,7 +6321,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6623,7 +6335,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6637,7 +6349,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6651,7 +6363,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6665,7 +6377,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6679,7 +6391,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6693,7 +6405,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6707,7 +6419,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6721,7 +6433,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6735,7 +6447,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6749,7 +6461,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6763,7 +6475,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6777,7 +6489,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6791,7 +6503,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6805,7 +6517,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6819,7 +6531,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6833,7 +6545,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6847,7 +6559,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6861,7 +6573,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6875,7 +6587,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6889,7 +6601,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6903,7 +6615,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6917,7 +6629,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6931,7 +6643,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6945,7 +6657,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6959,7 +6671,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6973,7 +6685,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -6987,7 +6699,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7001,7 +6713,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7015,7 +6727,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7029,7 +6741,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7043,7 +6755,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7057,7 +6769,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7071,7 +6783,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7085,7 +6797,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7099,7 +6811,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7113,7 +6825,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7127,7 +6839,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7141,7 +6853,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7155,7 +6867,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7169,7 +6881,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7183,7 +6895,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7197,7 +6909,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7211,7 +6923,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7225,7 +6937,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7239,7 +6951,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7253,7 +6965,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7267,7 +6979,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7281,7 +6993,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7295,7 +7007,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7309,7 +7021,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7323,7 +7035,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7337,7 +7049,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7351,7 +7063,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7365,7 +7077,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7379,7 +7091,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7393,7 +7105,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7407,7 +7119,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7421,7 +7133,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7435,7 +7147,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7449,7 +7161,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7463,7 +7175,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7477,7 +7189,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7491,7 +7203,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7505,7 +7217,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7519,7 +7231,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7533,7 +7245,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7547,7 +7259,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7561,7 +7273,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7575,7 +7287,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7589,7 +7301,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7603,7 +7315,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7617,7 +7329,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7631,7 +7343,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -7645,7 +7357,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-7.0-preview
+        name: ApiVersion70Preview
         description: Api Version (7.0-preview)
     protocol: !<!Protocols> {}
   numbers:
@@ -7660,7 +7372,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_362
@@ -7673,7 +7385,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_435
@@ -7686,7 +7398,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_482
@@ -7699,7 +7411,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_487
@@ -7712,7 +7424,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_491
@@ -7725,7 +7437,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_513
@@ -7738,7 +7450,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_147
@@ -7755,7 +7467,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_594
@@ -7768,7 +7480,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_656
@@ -7781,7 +7493,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_671
@@ -7794,7 +7506,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_675
@@ -7807,7 +7519,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_743
@@ -7820,7 +7532,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - !<!NumberSchema> &ref_749
@@ -7833,7 +7545,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   sealedChoices:
@@ -7848,7 +7560,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z-]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_152
@@ -7865,7 +7577,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z-]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_158
@@ -7876,7 +7588,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_159
@@ -7887,7 +7599,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_339
@@ -7897,7 +7609,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_160
@@ -7908,7 +7620,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_352
@@ -7918,7 +7630,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_356
@@ -7928,7 +7640,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_161
@@ -7941,7 +7653,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_374
@@ -7951,7 +7663,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_375
@@ -7961,7 +7673,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_164
@@ -7972,7 +7684,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_387
@@ -7982,7 +7694,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_394
@@ -7992,7 +7704,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_395
@@ -8002,7 +7714,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_405
@@ -8012,7 +7724,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_406
@@ -8022,7 +7734,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_419
@@ -8032,7 +7744,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_420
@@ -8042,7 +7754,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_427
@@ -8052,7 +7764,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_428
@@ -8062,7 +7774,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_165
@@ -8074,7 +7786,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_442
@@ -8084,7 +7796,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_445
@@ -8094,7 +7806,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_448
@@ -8105,7 +7817,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z-]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_167
@@ -8123,7 +7835,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_175
@@ -8134,7 +7846,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_465
@@ -8144,7 +7856,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_176
@@ -8156,7 +7868,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_478
@@ -8166,7 +7878,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_178
@@ -8180,7 +7892,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_182
@@ -8192,7 +7904,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_498
@@ -8202,7 +7914,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_501
@@ -8212,7 +7924,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_504
@@ -8222,7 +7934,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_184
@@ -8235,7 +7947,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_187
@@ -8267,7 +7979,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_209
@@ -8287,7 +7999,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_219
@@ -8298,7 +8010,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_563
@@ -8308,7 +8020,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_566
@@ -8319,7 +8031,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z-]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_220
@@ -8336,7 +8048,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z-]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_226
@@ -8349,7 +8061,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_598
@@ -8359,7 +8071,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_601
@@ -8369,7 +8081,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_605
@@ -8379,7 +8091,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_606
@@ -8389,7 +8101,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_229
@@ -8400,7 +8112,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_619
@@ -8410,7 +8122,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_623
@@ -8420,7 +8132,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_630
@@ -8430,7 +8142,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_633
@@ -8440,7 +8152,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_636
@@ -8450,7 +8162,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_230
@@ -8461,7 +8173,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_231
@@ -8473,7 +8185,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_665
@@ -8483,7 +8195,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_668
@@ -8493,7 +8205,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_233
@@ -8510,7 +8222,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_239
@@ -8527,7 +8239,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_685
@@ -8538,7 +8250,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_688
@@ -8548,7 +8260,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_697
@@ -8559,7 +8271,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_700
@@ -8570,7 +8282,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_703
@@ -8581,7 +8293,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_245
@@ -8596,7 +8308,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_249
@@ -8610,7 +8322,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_252
@@ -8622,7 +8334,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_253
@@ -8637,7 +8349,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_257
@@ -8650,7 +8362,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_755
@@ -8661,7 +8373,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_259
@@ -8678,7 +8390,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_760
@@ -8689,7 +8401,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_764
@@ -8700,7 +8412,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_765
@@ -8711,7 +8423,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_769
@@ -8722,7 +8434,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_770
@@ -8733,7 +8445,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_774
@@ -8744,7 +8456,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_775
@@ -8755,7 +8467,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_265
@@ -8769,7 +8481,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_792
@@ -8780,7 +8492,7 @@ schemas: !<!Schemas>
     pattern: '^[0-9a-zA-Z]+$'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_268
@@ -8794,7 +8506,7 @@ schemas: !<!Schemas>
       version: 7.0-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   unixtimes:
@@ -8878,7 +8590,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name for the new key. The system will generate the version name for the new key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -8924,7 +8636,7 @@ operationGroups:
         targetProperty: *ref_308
         language: !<!Languages> 
           default:
-            name: key_size
+            name: keySize
             description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_317
@@ -8937,7 +8649,7 @@ operationGroups:
         targetProperty: *ref_309
         language: !<!Languages> 
           default:
-            name: key_ops
+            name: keyOps
             description: ''
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_318
@@ -9109,7 +8821,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: Name for the imported key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -9142,7 +8854,7 @@ operationGroups:
         targetProperty: *ref_325
         language: !<!Languages> 
           default:
-            name: Hsm
+            name: hsm
             description: Whether to import as a hardware key (HSM) or software key.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_332
@@ -9312,7 +9024,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key to delete.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -9430,7 +9142,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of key to update.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -9442,7 +9154,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-version
+            name: keyVersion
             description: The version of the key to update.
             serializedName: key-version
         protocol: !<!Protocols> 
@@ -9474,7 +9186,7 @@ operationGroups:
         targetProperty: *ref_342
         language: !<!Languages> 
           default:
-            name: key_ops
+            name: keyOps
             description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_349
@@ -9619,7 +9331,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key to get.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -9631,7 +9343,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-version
+            name: keyVersion
             description: Adding the version parameter retrieves a specific version of a key.
             serializedName: key-version
         protocol: !<!Protocols> 
@@ -9746,7 +9458,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -9969,7 +9681,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -10207,7 +9919,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -10219,7 +9931,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-version
+            name: keyVersion
             description: The version of the key.
             serializedName: key-version
         protocol: !<!Protocols> 
@@ -10333,7 +10045,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: encrypt
+        name: Encrypt
         description: >-
           The ENCRYPT operation encrypts an arbitrary sequence of bytes using an encryption key that is stored in Azure Key Vault. Note that the ENCRYPT operation only supports a single block of data, the size of which is dependent on the
           target key and the encryption algorithm to be used. The ENCRYPT operation is only strictly necessary for symmetric keys stored in Azure Key Vault since protection with an asymmetric key can be performed using public portion of the
@@ -10370,7 +10082,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -10382,7 +10094,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-version
+            name: keyVersion
             description: The version of the key.
             serializedName: key-version
         protocol: !<!Protocols> 
@@ -10496,7 +10208,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: decrypt
+        name: Decrypt
         description: >-
           The DECRYPT operation decrypts a well-formed block of ciphertext using the target encryption key and specified algorithm. This operation is the reverse of the ENCRYPT operation; only a single block of data may be decrypted, the
           size of this block is dependent on the target key and the algorithm to be used. The DECRYPT operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the private portion of the key. This operation
@@ -10533,7 +10245,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -10545,7 +10257,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-version
+            name: keyVersion
             description: The version of the key.
             serializedName: key-version
         protocol: !<!Protocols> 
@@ -10659,7 +10371,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: sign
+        name: Sign
         description: The SIGN operation is applicable to asymmetric and symmetric keys stored in Azure Key Vault since this operation uses the private portion of the key. This operation requires the keys/sign permission.
         summary: Creates a signature from a digest using the specified key.
     protocol: !<!Protocols> {}
@@ -10693,7 +10405,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -10705,7 +10417,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-version
+            name: keyVersion
             description: The version of the key.
             serializedName: key-version
         protocol: !<!Protocols> 
@@ -10831,7 +10543,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: verify
+        name: Verify
         description: >-
           The VERIFY operation is applicable to symmetric keys stored in Azure Key Vault. VERIFY is not strictly necessary for asymmetric keys stored in Azure Key Vault since signature verification can be performed using the public portion
           of the key but this operation is supported as a convenience for callers that only have a key-reference and not the public portion of the key. This operation requires the keys/verify permission.
@@ -10867,7 +10579,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -10879,7 +10591,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-version
+            name: keyVersion
             description: The version of the key.
             serializedName: key-version
         protocol: !<!Protocols> 
@@ -10993,7 +10705,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: wrapKey
+        name: WrapKey
         description: >-
           The WRAP operation supports encryption of a symmetric key using a key encryption key that has previously been stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys stored in Azure Key Vault
           since protection with an asymmetric key can be performed using the public portion of the key. This operation is supported for asymmetric keys as a convenience for callers that have a key-reference but do not have access to the
@@ -11030,7 +10742,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -11042,7 +10754,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-version
+            name: keyVersion
             description: The version of the key.
             serializedName: key-version
         protocol: !<!Protocols> 
@@ -11156,7 +10868,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: unwrapKey
+        name: UnwrapKey
         description: >-
           The UNWRAP operation supports decryption of a symmetric key using the target key encryption key. This operation is the reverse of the WRAP operation. The UNWRAP operation applies to asymmetric and symmetric keys stored in Azure
           Key Vault since it uses the private portion of the key. This operation requires the keys/unwrapKey permission.
@@ -11300,7 +11012,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -11418,7 +11130,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the key
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -11508,7 +11220,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: key-name
+            name: keyName
             description: The name of the deleted key.
             serializedName: key-name
         protocol: !<!Protocols> 
@@ -11623,7 +11335,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -11800,7 +11512,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -11901,7 +11613,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -11913,7 +11625,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-version
+            name: secretVersion
             description: The version of the secret.
             serializedName: secret-version
         protocol: !<!Protocols> 
@@ -12083,7 +11795,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -12095,7 +11807,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-version
+            name: secretVersion
             description: The version of the secret.
             serializedName: secret-version
         protocol: !<!Protocols> 
@@ -12300,7 +12012,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -12522,7 +12234,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -12623,7 +12335,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -12711,7 +12423,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the deleted secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -12809,7 +12521,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: secret-name
+            name: secretName
             description: The name of the secret.
             serializedName: secret-name
         protocol: !<!Protocols> 
@@ -13149,7 +12861,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -13303,7 +13015,7 @@ operationGroups:
         targetProperty: *ref_524
         language: !<!Languages> 
           default:
-            name: ContactList
+            name: contactList
             description: The contact list for the vault certificates.
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -13682,7 +13394,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: issuer-name
+            name: issuerName
             description: The name of the issuer.
             serializedName: issuer-name
         protocol: !<!Protocols> 
@@ -13741,7 +13453,7 @@ operationGroups:
         targetProperty: *ref_538
         language: !<!Languages> 
           default:
-            name: OrganizationDetails
+            name: organizationDetails
             description: Details of the organization of the certificate issuer.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_545
@@ -13876,7 +13588,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: issuer-name
+            name: issuerName
             description: The name of the issuer.
             serializedName: issuer-name
         protocol: !<!Protocols> 
@@ -13932,7 +13644,7 @@ operationGroups:
         targetProperty: *ref_552
         language: !<!Languages> 
           default:
-            name: OrganizationDetails
+            name: organizationDetails
             description: Details of the organization of the certificate issuer.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_559
@@ -14060,7 +13772,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: issuer-name
+            name: issuerName
             description: The name of the issuer.
             serializedName: issuer-name
         protocol: !<!Protocols> 
@@ -14167,7 +13879,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: issuer-name
+            name: issuerName
             description: The name of the issuer.
             serializedName: issuer-name
         protocol: !<!Protocols> 
@@ -14274,7 +13986,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -14306,7 +14018,7 @@ operationGroups:
         targetProperty: *ref_569
         language: !<!Languages> 
           default:
-            name: CertificatePolicy
+            name: certificatePolicy
             description: Management policy for a certificate.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_575
@@ -14318,7 +14030,7 @@ operationGroups:
         targetProperty: *ref_570
         language: !<!Languages> 
           default:
-            name: CertificateAttributes
+            name: certificateAttributes
             description: The certificate management attributes.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_576
@@ -14451,7 +14163,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -14510,7 +14222,7 @@ operationGroups:
         targetProperty: *ref_583
         language: !<!Languages> 
           default:
-            name: CertificatePolicy
+            name: certificatePolicy
             description: Management policy for a certificate.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_591
@@ -14523,7 +14235,7 @@ operationGroups:
         targetProperty: *ref_584
         language: !<!Languages> 
           default:
-            name: CertificateAttributes
+            name: certificateAttributes
             description: The certificate management attributes.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_592
@@ -14687,7 +14399,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -14811,7 +14523,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate in a given key vault.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -14929,7 +14641,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate in the given vault.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -15088,7 +14800,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate in the given key vault.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -15100,7 +14812,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-version
+            name: certificateVersion
             description: The version of the certificate.
             serializedName: certificate-version
         protocol: !<!Protocols> 
@@ -15132,7 +14844,7 @@ operationGroups:
         targetProperty: *ref_609
         language: !<!Languages> 
           default:
-            name: CertificatePolicy
+            name: certificatePolicy
             description: Management policy for a certificate.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_616
@@ -15144,7 +14856,7 @@ operationGroups:
         targetProperty: *ref_610
         language: !<!Languages> 
           default:
-            name: CertificateAttributes
+            name: certificateAttributes
             description: The certificate management attributes.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_617
@@ -15274,7 +14986,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate in the given vault.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -15286,7 +14998,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-version
+            name: certificateVersion
             description: The version of the certificate.
             serializedName: certificate-version
         protocol: !<!Protocols> 
@@ -15389,7 +15101,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -15422,7 +15134,7 @@ operationGroups:
         targetProperty: *ref_626
         language: !<!Languages> 
           default:
-            name: cancellation_requested
+            name: cancellationRequested
             description: Indicates if cancellation was requested on the certificate operation.
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -15526,7 +15238,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -15627,7 +15339,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -15728,7 +15440,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -15774,7 +15486,7 @@ operationGroups:
         targetProperty: *ref_640
         language: !<!Languages> 
           default:
-            name: CertificateAttributes
+            name: certificateAttributes
             description: The certificate management attributes.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_646
@@ -15924,7 +15636,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate.
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -16299,7 +16011,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -16437,7 +16149,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the certificate
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -16527,7 +16239,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: certificate-name
+            name: certificateName
             description: The name of the deleted certificate
             serializedName: certificate-name
         protocol: !<!Protocols> 
@@ -16898,7 +16610,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -17008,7 +16720,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -17100,7 +16812,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -17207,7 +16919,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -17434,7 +17146,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -17543,7 +17255,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -17649,7 +17361,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -17734,7 +17446,7 @@ operationGroups:
         targetProperty: *ref_710
         language: !<!Languages> 
           default:
-            name: StorageAccountAttributes
+            name: storageAccountAttributes
             description: The storage account management attributes.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_719
@@ -17869,7 +17581,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -17937,7 +17649,7 @@ operationGroups:
         targetProperty: *ref_726
         language: !<!Languages> 
           default:
-            name: StorageAccountAttributes
+            name: storageAccountAttributes
             description: The storage account management attributes.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_734
@@ -18063,7 +17775,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -18205,7 +17917,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -18328,7 +18040,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -18458,7 +18170,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -18470,7 +18182,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: sas-definition-name
+            name: sasDefinitionName
             description: The name of the SAS definition.
             serializedName: sas-definition-name
         protocol: !<!Protocols> 
@@ -18579,7 +18291,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -18591,7 +18303,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: sas-definition-name
+            name: sasDefinitionName
             description: The name of the SAS definition.
             serializedName: sas-definition-name
         protocol: !<!Protocols> 
@@ -18697,7 +18409,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -18709,7 +18421,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: sas-definition-name
+            name: sasDefinitionName
             description: The name of the SAS definition.
             serializedName: sas-definition-name
         protocol: !<!Protocols> 
@@ -18817,7 +18529,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -18829,7 +18541,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: sas-definition-name
+            name: sasDefinitionName
             description: The name of the SAS definition.
             serializedName: sas-definition-name
         protocol: !<!Protocols> 
@@ -18934,7 +18646,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -18946,7 +18658,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: sas-definition-name
+            name: sasDefinitionName
             description: The name of the SAS definition.
             serializedName: sas-definition-name
         protocol: !<!Protocols> 
@@ -19018,7 +18730,7 @@ operationGroups:
         targetProperty: *ref_781
         language: !<!Languages> 
           default:
-            name: SasDefinitionAttributes
+            name: sasDefinitionAttributes
             description: The SAS definition management attributes.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_790
@@ -19147,7 +18859,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: storage-account-name
+            name: storageAccountName
             description: The name of the storage account.
             serializedName: storage-account-name
         protocol: !<!Protocols> 
@@ -19159,7 +18871,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: sas-definition-name
+            name: sasDefinitionName
             description: The name of the SAS definition.
             serializedName: sas-definition-name
         protocol: !<!Protocols> 
@@ -19227,7 +18939,7 @@ operationGroups:
         targetProperty: *ref_798
         language: !<!Languages> 
           default:
-            name: SasDefinitionAttributes
+            name: sasDefinitionAttributes
             description: The SAS definition management attributes.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_807

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: Product-properties-provisioningState
+                name: ProductPropertiesProvisioningState
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -38,7 +38,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningState
               description: ''
-              originalName: provisioningState
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ChoiceSchema> &ref_3
@@ -59,7 +58,7 @@ schemas: !<!Schemas>
               value: canceled
               language:
                 default:
-                  name: canceled
+                  name: Canceled
                   description: ''
             - !<!ChoiceValue> 
               value: Accepted
@@ -107,7 +106,7 @@ schemas: !<!Schemas>
               value: OK
               language:
                 default:
-                  name: OK
+                  name: Ok
                   description: ''
             type: choice
             apiVersions:
@@ -117,12 +116,12 @@ schemas: !<!Schemas>
               type: string
               language: !<!Languages> 
                 default:
-                  name: string
+                  name: String
                   description: simple string
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: Product-properties-provisioningStateValues
+                name: ProductPropertiesProvisioningStateValues
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -134,7 +133,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningStateValues
               description: ''
-              originalName: provisioningStateValues
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -153,7 +151,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-id
+            name: ResourceId
             description: Resource Id
         protocol: !<!Protocols> {}
       readOnly: true
@@ -162,7 +160,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Resource Id
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_15
@@ -172,7 +169,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-type
+            name: ResourceType
             description: Resource Type
         protocol: !<!Protocols> {}
       readOnly: true
@@ -181,7 +178,6 @@ schemas: !<!Schemas>
         default:
           name: type
           description: Resource Type
-          originalName: type
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_10
@@ -193,21 +189,20 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
               header: Location
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Dictionary of string
-            description: Dictionary of <components·schemas·resource·properties·tags·additionalproperties>
+            name: ResourceTags
+            description: Dictionary of String
         protocol: !<!Protocols> {}
       serializedName: tags
       language: !<!Languages> 
         default:
           name: tags
           description: Dictionary of <components·schemas·resource·properties·tags·additionalproperties>
-          originalName: tags
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_17
@@ -217,7 +212,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-location
+            name: ResourceLocation
             description: Resource Location
         protocol: !<!Protocols> {}
       serializedName: location
@@ -225,7 +220,6 @@ schemas: !<!Schemas>
         default:
           name: location
           description: Resource Location
-          originalName: location
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_18
@@ -235,7 +229,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-name
+            name: ResourceName
             description: Resource Name
         protocol: !<!Protocols> {}
       readOnly: true
@@ -244,7 +238,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: Resource Name
-          originalName: name
       protocol: !<!Protocols> {}
     extensions:
       x-ms-azure-resource: true
@@ -268,7 +261,6 @@ schemas: !<!Schemas>
         default:
           name: provisioningState
           description: ''
-          originalName: provisioningState
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_3
@@ -278,14 +270,13 @@ schemas: !<!Schemas>
         default:
           name: provisioningStateValues
           description: ''
-          originalName: provisioningStateValues
       protocol: !<!Protocols> {}
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
     language: !<!Languages> 
       default:
-        name: Product-properties
+        name: ProductProperties
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -301,7 +292,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -309,7 +300,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_19
@@ -319,7 +309,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: CloudError-message
+            name: CloudErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -327,7 +317,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     extensions:
       x-ms-external: true
@@ -351,7 +340,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Sku-name
+            name: SkuName
             description: ''
         protocol: !<!Protocols> {}
       serializedName: name
@@ -359,7 +348,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> &ref_43
       schema: !<!StringSchema> &ref_21
@@ -369,7 +357,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Sku-id
+            name: SkuId
             description: ''
         protocol: !<!Protocols> {}
       serializedName: id
@@ -377,7 +365,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -411,7 +398,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: SubProduct-properties-provisioningState
+                name: SubProductPropertiesProvisioningState
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames: &ref_49
@@ -422,7 +409,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningState
               description: ''
-              originalName: provisioningState
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ChoiceSchema> &ref_8
@@ -443,7 +429,7 @@ schemas: !<!Schemas>
               value: canceled
               language:
                 default:
-                  name: canceled
+                  name: Canceled
                   description: ''
             - !<!ChoiceValue> 
               value: Accepted
@@ -491,7 +477,7 @@ schemas: !<!Schemas>
               value: OK
               language:
                 default:
-                  name: OK
+                  name: Ok
                   description: ''
             type: choice
             apiVersions:
@@ -500,7 +486,7 @@ schemas: !<!Schemas>
             choiceType: *ref_5
             language: !<!Languages> 
               default:
-                name: SubProduct-properties-provisioningStateValues
+                name: SubProductPropertiesProvisioningStateValues
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -512,7 +498,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningStateValues
               description: ''
-              originalName: provisioningStateValues
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -531,7 +516,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: SubResource-id
+            name: SubResourceId
             description: Sub Resource Id
         protocol: !<!Protocols> {}
       readOnly: true
@@ -540,7 +525,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Sub Resource Id
-          originalName: id
       protocol: !<!Protocols> {}
     extensions:
       x-ms-azure-resource: true
@@ -564,7 +548,6 @@ schemas: !<!Schemas>
         default:
           name: provisioningState
           description: ''
-          originalName: provisioningState
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_8
@@ -574,14 +557,13 @@ schemas: !<!Schemas>
         default:
           name: provisioningStateValues
           description: ''
-          originalName: provisioningStateValues
       protocol: !<!Protocols> {}
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
     language: !<!Languages> 
       default:
-        name: SubProduct-properties
+        name: SubProductProperties
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -610,7 +592,7 @@ schemas: !<!Schemas>
           value: canceled
           language:
             default:
-              name: canceled
+              name: Canceled
               description: ''
         - !<!ChoiceValue> 
           value: Accepted
@@ -658,7 +640,7 @@ schemas: !<!Schemas>
           value: OK
           language:
             default:
-              name: OK
+              name: Ok
               description: ''
         type: choice
         apiVersions:
@@ -667,7 +649,7 @@ schemas: !<!Schemas>
         choiceType: *ref_5
         language: !<!Languages> 
           default:
-            name: OperationResult-status
+            name: OperationResultStatus
             description: The status of the request
         protocol: !<!Protocols> {}
       serializedName: status
@@ -675,7 +657,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: The status of the request
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_9
@@ -690,7 +671,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeForcode
+                name: TypeForcode
                 description: The error code for an operation failure
             protocol: !<!Protocols> {}
           serializedName: code
@@ -698,7 +679,6 @@ schemas: !<!Schemas>
             default:
               name: code
               description: The error code for an operation failure
-              originalName: code
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_23
@@ -708,7 +688,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: OperationResult-error-message
+                name: OperationResultErrorMessage
                 description: The detailed arror message
             protocol: !<!Protocols> {}
           serializedName: message
@@ -716,11 +696,10 @@ schemas: !<!Schemas>
             default:
               name: message
               description: The detailed arror message
-              originalName: message
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: OperationResult-error
+            name: OperationResultError
             description: ''
             namespace: Api100
         protocol: !<!Protocols> {}
@@ -729,7 +708,6 @@ schemas: !<!Schemas>
         default:
           name: error
           description: ''
-          originalName: error
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -754,7 +732,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
         header: Retry-After
     protocol: !<!Protocols> {}
@@ -872,7 +850,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put200Succeeded
+        name: Put200Succeeded
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -942,7 +920,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put200SucceededNoState
+        name: Put200SucceededNoState
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1012,7 +990,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put202Retry200
+        name: Put202Retry200
         description: 'Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn''t contains ProvisioningState'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1095,7 +1073,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put201CreatingSucceeded200
+        name: Put201CreatingSucceeded200
         description: 'Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1165,7 +1143,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put200UpdatingSucceeded204
+        name: Put200UpdatingSucceeded204
         description: 'Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1248,7 +1226,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put201CreatingFailed200
+        name: Put201CreatingFailed200
         description: 'Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1318,7 +1296,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put200Acceptedcanceled200
+        name: Put200Acceptedcanceled200
         description: 'Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1392,7 +1370,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNoHeaderInRetry
+        name: PutNoHeaderInRetry
         description: 'Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1472,7 +1450,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRetrySucceeded
+        name: PutAsyncRetrySucceeded
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1549,7 +1527,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncNoRetrySucceeded
+        name: PutAsyncNoRetrySucceeded
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1629,7 +1607,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRetryFailed
+        name: PutAsyncRetryFailed
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1706,7 +1684,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncNoRetrycanceled
+        name: PutAsyncNoRetrycanceled
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1780,7 +1758,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncNoHeaderInRetry
+        name: PutAsyncNoHeaderInRetry
         description: 'Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1876,7 +1854,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNonResource
+        name: PutNonResource
         description: Long running put request with non resource.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1972,7 +1950,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncNonResource
+        name: PutAsyncNonResource
         description: Long running put request with non resource.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2056,7 +2034,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSubResource
+        name: PutSubResource
         description: Long running put request with sub resource.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2140,7 +2118,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncSubResource
+        name: PutAsyncSubResource
         description: Long running put request with sub resource.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2212,7 +2190,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteProvisioning202Accepted200Succeeded
+        name: DeleteProvisioning202Accepted200Succeeded
         description: 'Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2284,7 +2262,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteProvisioning202DeletingFailed200
+        name: DeleteProvisioning202DeletingFailed200
         description: 'Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2356,7 +2334,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteProvisioning202Deletingcanceled200
+        name: DeleteProvisioning202Deletingcanceled200
         description: 'Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2404,7 +2382,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: delete204Succeeded
+        name: Delete204Succeeded
         description: Long running delete succeeds and returns right away
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2472,7 +2450,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: delete202Retry200
+        name: Delete202Retry200
         description: 'Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2540,7 +2518,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: delete202NoRetry204
+        name: Delete202NoRetry204
         description: 'Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2601,7 +2579,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteNoHeaderInRetry
+        name: DeleteNoHeaderInRetry
         description: 'Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2662,7 +2640,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncNoHeaderInRetry
+        name: DeleteAsyncNoHeaderInRetry
         description: 'Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2720,7 +2698,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncRetrySucceeded
+        name: DeleteAsyncRetrySucceeded
         description: 'Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2778,7 +2756,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncNoRetrySucceeded
+        name: DeleteAsyncNoRetrySucceeded
         description: 'Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2836,7 +2814,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncRetryFailed
+        name: DeleteAsyncRetryFailed
         description: 'Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2894,7 +2872,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncRetrycanceled
+        name: DeleteAsyncRetrycanceled
         description: 'Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2959,7 +2937,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: post200WithPayload
+        name: Post200WithPayload
         description: 'Long running post request, service returns a 202 to the initial request, with ''Location'' header. Poll returns a 200 with a response body after success.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3032,7 +3010,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202Retry200
+        name: Post202Retry200
         description: 'Long running post request, service returns a 202 to the initial request, with ''Location'' and ''Retry-After'' headers, Polls return a 200 with a response body after success'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3109,7 +3087,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202NoRetry204
+        name: Post202NoRetry204
         description: 'Long running post request, service returns a 202 to the initial request, with ''Location'' header, 204 with noresponse body after success'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3163,7 +3141,7 @@ operationGroups:
         final-state-via: location
     language: !<!Languages> 
       default:
-        name: postDoubleHeadersFinalLocationGet
+        name: PostDoubleHeadersFinalLocationGet
         description: 'Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it''s success. Should poll Location to get the final object'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3217,7 +3195,7 @@ operationGroups:
         final-state-via: azure-async-operation
     language: !<!Languages> 
       default:
-        name: postDoubleHeadersFinalAzureHeaderGet
+        name: PostDoubleHeadersFinalAzureHeaderGet
         description: 'Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it''s success. Should NOT poll Location to get the final object'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3269,7 +3247,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: postDoubleHeadersFinalAzureHeaderGetDefault
+        name: PostDoubleHeadersFinalAzureHeaderGetDefault
         description: >-
           Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final object if you support initial Autorest
           behavior.
@@ -3360,7 +3338,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRetrySucceeded
+        name: PostAsyncRetrySucceeded
         description: 'Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3449,7 +3427,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncNoRetrySucceeded
+        name: PostAsyncNoRetrySucceeded
         description: 'Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3525,7 +3503,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRetryFailed
+        name: PostAsyncRetryFailed
         description: 'Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3601,12 +3579,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRetrycanceled
+        name: PostAsyncRetrycanceled
         description: 'Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: LROs
+      name: LrOS
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -3692,7 +3670,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put201CreatingSucceeded200
+        name: Put201CreatingSucceeded200
         description: >-
           Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with
           ProvisioningState=’Succeeded’
@@ -3774,7 +3752,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRelativeRetrySucceeded
+        name: PutAsyncRelativeRetrySucceeded
         description: 'Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3846,7 +3824,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteProvisioning202Accepted200Succeeded
+        name: DeleteProvisioning202Accepted200Succeeded
         description: >-
           Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with
           ProvisioningState=’Succeeded’
@@ -3903,7 +3881,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: delete202Retry200
+        name: Delete202Retry200
         description: 'Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3961,7 +3939,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncRelativeRetrySucceeded
+        name: DeleteAsyncRelativeRetrySucceeded
         description: 'Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4034,7 +4012,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202Retry200
+        name: Post202Retry200
         description: 'Long running post request, service returns a 500, then a 202 to the initial request, with ''Location'' and ''Retry-After'' headers, Polls return a 200 with a response body after success'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4110,12 +4088,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRelativeRetrySucceeded
+        name: PostAsyncRelativeRetrySucceeded
         description: 'Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: LRORetrys
+      name: LroRetrys
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4201,7 +4179,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNonRetry400
+        name: PutNonRetry400
         description: 'Long running put request, service returns a 400 to the initial request'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4284,7 +4262,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNonRetry201Creating400
+        name: PutNonRetry201Creating400
         description: 'Long running put request, service returns a Product with ''ProvisioningState'' = ''Creating'' and 201 response code'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4367,7 +4345,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putNonRetry201Creating400InvalidJson
+        name: PutNonRetry201Creating400InvalidJson
         description: 'Long running put request, service returns a Product with ''ProvisioningState'' = ''Creating'' and 201 response code'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4447,7 +4425,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRelativeRetry400
+        name: PutAsyncRelativeRetry400
         description: 'Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4502,7 +4480,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteNonRetry400
+        name: DeleteNonRetry400
         description: 'Long running delete request, service returns a 400 with an error body'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4557,7 +4535,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: delete202NonRetry400
+        name: Delete202NonRetry400
         description: 'Long running delete request, service returns a 202 with a location header'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4615,7 +4593,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncRelativeRetry400
+        name: DeleteAsyncRelativeRetry400
         description: 'Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4688,7 +4666,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postNonRetry400
+        name: PostNonRetry400
         description: 'Long running post request, service returns a 400 with no error body'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4761,7 +4739,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202NonRetry400
+        name: Post202NonRetry400
         description: 'Long running post request, service returns a 202 with a location header'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4837,7 +4815,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRelativeRetry400
+        name: PostAsyncRelativeRetry400
         description: 'Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4920,7 +4898,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putError201NoProvisioningStatePayload
+        name: PutError201NoProvisioningStatePayload
         description: 'Long running put request, service returns a 201 to the initial request with no payload'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5000,7 +4978,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRelativeRetryNoStatus
+        name: PutAsyncRelativeRetryNoStatus
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5080,7 +5058,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRelativeRetryNoStatusPayload
+        name: PutAsyncRelativeRetryNoStatusPayload
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5128,7 +5106,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: delete204Succeeded
+        name: Delete204Succeeded
         description: 'Long running delete request, service returns a 204 to the initial request, indicating success.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5186,7 +5164,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncRelativeRetryNoStatus
+        name: DeleteAsyncRelativeRetryNoStatus
         description: 'Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5259,7 +5237,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202NoLocation
+        name: Post202NoLocation
         description: 'Long running post request, service returns a 202 to the initial request, without a location header.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5335,7 +5313,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRelativeRetryNoPayload
+        name: PostAsyncRelativeRetryNoPayload
         description: 'Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5414,7 +5392,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put200InvalidJson
+        name: Put200InvalidJson
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5494,7 +5472,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRelativeRetryInvalidHeader
+        name: PutAsyncRelativeRetryInvalidHeader
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5574,7 +5552,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRelativeRetryInvalidJsonPolling
+        name: PutAsyncRelativeRetryInvalidJsonPolling
         description: 'Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5629,7 +5607,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: delete202RetryInvalidHeader
+        name: Delete202RetryInvalidHeader
         description: 'Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid ''Location'' and ''Retry-After'' headers'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5687,7 +5665,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncRelativeRetryInvalidHeader
+        name: DeleteAsyncRelativeRetryInvalidHeader
         description: 'Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5745,7 +5723,7 @@ operationGroups:
       x-ms-long-running-operation: true
     language: !<!Languages> 
       default:
-        name: deleteAsyncRelativeRetryInvalidJsonPolling
+        name: DeleteAsyncRelativeRetryInvalidJsonPolling
         description: 'Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5818,7 +5796,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202RetryInvalidHeader
+        name: Post202RetryInvalidHeader
         description: 'Long running post request, service returns a 202 to the initial request, with invalid ''Location'' and ''Retry-After'' headers.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5894,7 +5872,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRelativeRetryInvalidHeader
+        name: PostAsyncRelativeRetryInvalidHeader
         description: 'Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -5970,12 +5948,12 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRelativeRetryInvalidJsonPolling
+        name: PostAsyncRelativeRetryInvalidJsonPolling
         description: 'Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: LROSADs
+      name: LrosaDs
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -6058,7 +6036,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putAsyncRetrySucceeded
+        name: PutAsyncRetrySucceeded
         description: >-
           x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains
           ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
@@ -6143,7 +6121,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: put201CreatingSucceeded200
+        name: Put201CreatingSucceeded200
         description: >-
           x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains
           ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
@@ -6218,7 +6196,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: post202Retry200
+        name: Post202Retry200
         description: >-
           x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls
           return a 200 with a response body after success
@@ -6296,14 +6274,14 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postAsyncRetrySucceeded
+        name: PostAsyncRetrySucceeded
         description: >-
           x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains
           ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: LROsCustomHeader
+      name: LrOSCustomHeader
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: FlattenedProduct-properties-p.name
+                name: FlattenedProductPropertiesPName
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -38,7 +38,6 @@ schemas: !<!Schemas>
             default:
               name: pName
               description: ''
-              originalName: p.name
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_4
@@ -48,7 +47,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: FlattenedProduct-properties-type
+                name: FlattenedProductPropertiesType
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -59,7 +58,6 @@ schemas: !<!Schemas>
             default:
               name: typePropertiesType
               description: ''
-              originalName: type
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ChoiceSchema> &ref_5
@@ -80,7 +78,7 @@ schemas: !<!Schemas>
               value: canceled
               language:
                 default:
-                  name: canceled
+                  name: Canceled
                   description: ''
             - !<!ChoiceValue> 
               value: Accepted
@@ -128,7 +126,7 @@ schemas: !<!Schemas>
               value: OK
               language:
                 default:
-                  name: OK
+                  name: Ok
                   description: ''
             type: choice
             apiVersions:
@@ -138,12 +136,12 @@ schemas: !<!Schemas>
               type: string
               language: !<!Languages> 
                 default:
-                  name: string
+                  name: String
                   description: simple string
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: FlattenedProduct-properties-provisioningStateValues
+                name: FlattenedProductPropertiesProvisioningStateValues
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -155,7 +153,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningStateValues
               description: ''
-              originalName: provisioningStateValues
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_6
@@ -165,7 +162,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: FlattenedProduct-properties-provisioningState
+                name: FlattenedProductPropertiesProvisioningState
                 description: ''
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -176,7 +173,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningState
               description: ''
-              originalName: provisioningState
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -195,7 +191,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-id
+            name: ResourceId
             description: Resource Id
         protocol: !<!Protocols> {}
       readOnly: true
@@ -204,7 +200,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Resource Id
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_40
@@ -214,7 +209,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-type
+            name: ResourceType
             description: Resource Type
         protocol: !<!Protocols> {}
       readOnly: true
@@ -223,7 +218,6 @@ schemas: !<!Schemas>
         default:
           name: type
           description: Resource Type
-          originalName: type
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_17
@@ -235,20 +229,19 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Dictionary of string
-            description: Dictionary of <components·schemas·resource·properties·tags·additionalproperties>
+            name: ResourceTags
+            description: Dictionary of String
         protocol: !<!Protocols> {}
       serializedName: tags
       language: !<!Languages> 
         default:
           name: tags
           description: Dictionary of <components·schemas·resource·properties·tags·additionalproperties>
-          originalName: tags
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_41
@@ -258,7 +251,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-location
+            name: ResourceLocation
             description: Resource Location
         protocol: !<!Protocols> {}
       serializedName: location
@@ -266,7 +259,6 @@ schemas: !<!Schemas>
         default:
           name: location
           description: Resource Location
-          originalName: location
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_42
@@ -276,7 +268,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Resource-name
+            name: ResourceName
             description: Resource Name
         protocol: !<!Protocols> {}
       readOnly: true
@@ -285,7 +277,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: Resource Name
-          originalName: name
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -305,7 +296,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -313,7 +304,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_43
@@ -323,7 +313,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -331,7 +321,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_2
@@ -340,7 +329,6 @@ schemas: !<!Schemas>
         default:
           name: parentError
           description: ''
-          originalName: parentError
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -362,7 +350,6 @@ schemas: !<!Schemas>
         default:
           name: pName
           description: ''
-          originalName: p.name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_4
@@ -371,7 +358,6 @@ schemas: !<!Schemas>
         default:
           name: type
           description: ''
-          originalName: type
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_5
@@ -381,7 +367,6 @@ schemas: !<!Schemas>
         default:
           name: provisioningStateValues
           description: ''
-          originalName: provisioningStateValues
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_6
@@ -390,14 +375,13 @@ schemas: !<!Schemas>
         default:
           name: provisioningState
           description: ''
-          originalName: provisioningState
       protocol: !<!Protocols> {}
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
     language: !<!Languages> 
       default:
-        name: FlattenedProduct-properties
+        name: FlattenedProductProperties
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -415,7 +399,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: WrappedProduct-value
+            name: WrappedProductValue
             description: the product value
         protocol: !<!Protocols> {}
       serializedName: value
@@ -423,7 +407,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: the product value
-          originalName: value
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -449,7 +432,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: the product value
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -470,7 +452,6 @@ schemas: !<!Schemas>
         default:
           name: productresource
           description: Flattened product.
-          originalName: productresource
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_21
@@ -481,15 +462,14 @@ schemas: !<!Schemas>
         elementType: *ref_1
         language: !<!Languages> 
           default:
-            name: ResourceCollection-arrayofresources
-            description: ''
+            name: ResourceCollectionArrayofresources
+            description: Array of FlattenedProduct
         protocol: !<!Protocols> {}
       serializedName: arrayofresources
       language: !<!Languages> 
         default:
           name: arrayofresources
           description: ''
-          originalName: arrayofresources
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_18
@@ -497,7 +477,7 @@ schemas: !<!Schemas>
         elementType: *ref_1
         language: !<!Languages> 
           default:
-            name: ResourceCollection-dictionaryofresources
+            name: ResourceCollectionDictionaryofresources
             description: Dictionary of <FlattenedProduct>
         protocol: !<!Protocols> {}
       serializedName: dictionaryofresources
@@ -505,7 +485,6 @@ schemas: !<!Schemas>
         default:
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
-          originalName: dictionaryofresources
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -539,7 +518,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: SimpleProductProperties-max_product_display_name
+                name: SimpleProductPropertiesMaxProductDisplayName
                 description: Display name of product.
             protocol: !<!Protocols> {}
           flattenedNames: &ref_30
@@ -550,7 +529,6 @@ schemas: !<!Schemas>
             default:
               name: maxProductDisplayName
               description: Display name of product.
-              originalName: max_product_display_name
           protocol: !<!Protocols> {}
         - !<!Property> &ref_33
           schema: !<!ConstantSchema> &ref_12
@@ -567,7 +545,7 @@ schemas: !<!Schemas>
             valueType: *ref_9
             language: !<!Languages> 
               default:
-                name: capacity
+                name: Capacity
                 description: 'Capacity of product. For example, 4 people.'
             protocol: !<!Protocols> {}
           flattenedNames: &ref_32
@@ -578,7 +556,6 @@ schemas: !<!Schemas>
             default:
               name: capacity
               description: 'Capacity of product. For example, 4 people.'
-              originalName: capacity
           protocol: !<!Protocols> {}
         - !<!Property> &ref_35
           schema: !<!StringSchema> &ref_13
@@ -588,7 +565,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: GenericUrl-generic_value
+                name: GenericUrlGenericValue
                 description: Generic URL value.
             protocol: !<!Protocols> {}
           flattenedNames: &ref_34
@@ -600,7 +577,6 @@ schemas: !<!Schemas>
             default:
               name: genericValue
               description: Generic URL value.
-              originalName: generic_value
           protocol: !<!Protocols> {}
         - !<!Property> &ref_37
           schema: !<!StringSchema> &ref_14
@@ -610,7 +586,7 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: ProductUrl-@odata.value
+                name: ProductUrlOdataValue
                 description: URL value.
             protocol: !<!Protocols> {}
           flattenedNames: &ref_36
@@ -620,9 +596,8 @@ schemas: !<!Schemas>
           serializedName: '@odata.value'
           language: !<!Languages> 
             default:
-              name: OdataValue
+              name: odataValue
               description: URL value.
-              originalName: '@odata.value'
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -641,7 +616,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: productId
+            name: ProductId
             description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
         protocol: !<!Protocols> {}
       required: true
@@ -650,7 +625,6 @@ schemas: !<!Schemas>
         default:
           name: productId
           description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
-          originalName: productId
       protocol: !<!Protocols> {}
     - !<!Property> &ref_29
       schema: !<!StringSchema> &ref_28
@@ -660,7 +634,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: description
+            name: Description
             description: Description of product.
         protocol: !<!Protocols> {}
       required: false
@@ -669,7 +643,6 @@ schemas: !<!Schemas>
         default:
           name: description
           description: Description of product.
-          originalName: description
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -692,7 +665,6 @@ schemas: !<!Schemas>
         default:
           name: maxProductDisplayName
           description: Display name of product.
-          originalName: max_product_display_name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_12
@@ -702,7 +674,6 @@ schemas: !<!Schemas>
         default:
           name: capacity
           description: 'Capacity of product. For example, 4 people.'
-          originalName: capacity
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_13
@@ -715,7 +686,6 @@ schemas: !<!Schemas>
         default:
           name: genericValue
           description: Generic URL value.
-          originalName: generic_value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_14
@@ -726,9 +696,8 @@ schemas: !<!Schemas>
       serializedName: '@odata.value'
       language: !<!Languages> 
         default:
-          name: OdataValue
+          name: odataValue
           description: URL value.
-          originalName: '@odata.value'
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -761,9 +730,8 @@ schemas: !<!Schemas>
           serializedName: '@odata.value'
           language: !<!Languages> 
             default:
-              name: OdataValue
+              name: odataValue
               description: URL value.
-              originalName: '@odata.value'
           protocol: !<!Protocols> {}
         extensions:
           x-ms-flattened: true
@@ -783,7 +751,6 @@ schemas: !<!Schemas>
         default:
           name: genericValue
           description: Generic URL value.
-          originalName: generic_value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -814,8 +781,8 @@ schemas: !<!Schemas>
     elementType: *ref_0
     language: !<!Languages> 
       default:
-        name: Array of Resource
-        description: ''
+        name: ArrayOfResource
+        description: Array of Resource
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_47
     type: array
@@ -825,8 +792,8 @@ schemas: !<!Schemas>
     elementType: *ref_1
     language: !<!Languages> 
       default:
-        name: Array of FlattenedProduct
-        description: ''
+        name: ArrayOfFlattenedProduct
+        description: Array of FlattenedProduct
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_48
     type: array
@@ -836,8 +803,8 @@ schemas: !<!Schemas>
     elementType: *ref_19
     language: !<!Languages> 
       default:
-        name: Array of WrappedProduct
-        description: ''
+        name: ArrayOfWrappedProduct
+        description: Array of WrappedProduct
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_50
     type: array
@@ -847,8 +814,8 @@ schemas: !<!Schemas>
     elementType: *ref_20
     language: !<!Languages> 
       default:
-        name: Array of ProductWrapper
-        description: ''
+        name: ArrayOfProductWrapper
+        description: Array of ProductWrapper
     protocol: !<!Protocols> {}
   - *ref_21
   constants:
@@ -1114,7 +1081,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceArray
         language: !<!Languages> 
           default:
-            name: ResourceArray
+            name: resourceArray
             description: External Resource as an Array to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -1162,7 +1129,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putArray
+        name: PutArray
         description: Put External Resource as an Array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1212,7 +1179,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getArray
+        name: GetArray
         description: Get External Resource as an Array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1229,7 +1196,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceArray
         language: !<!Languages> 
           default:
-            name: ResourceArray
+            name: resourceArray
             description: External Resource as an Array to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -1277,7 +1244,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putWrappedArray
+        name: PutWrappedArray
         description: No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1327,7 +1294,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getWrappedArray
+        name: GetWrappedArray
         description: No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1344,7 +1311,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceDictionary
         language: !<!Languages> 
           default:
-            name: ResourceDictionary
+            name: resourceDictionary
             description: External Resource as a Dictionary to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -1392,7 +1359,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putDictionary
+        name: PutDictionary
         description: Put External Resource as a Dictionary
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1442,7 +1409,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getDictionary
+        name: GetDictionary
         description: Get External Resource as a Dictionary
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1459,7 +1426,7 @@ operationGroups:
           x-ms-requestBody-name: ResourceComplexObject
         language: !<!Languages> 
           default:
-            name: ResourceComplexObject
+            name: resourceComplexObject
             description: External Resource as a ResourceCollection to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -1507,7 +1474,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putResourceCollection
+        name: PutResourceCollection
         description: Put External Resource as a ResourceCollection
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1557,7 +1524,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getResourceCollection
+        name: GetResourceCollection
         description: Get External Resource as a ResourceCollection
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1574,7 +1541,7 @@ operationGroups:
           x-ms-requestBody-name: SimpleBodyProduct
         language: !<!Languages> 
           default:
-            name: SimpleBodyProduct
+            name: simpleBodyProduct
             description: Simple body product to put
         protocol: !<!Protocols> 
           http: !<!HttpParameter> 
@@ -1626,7 +1593,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSimpleProduct
+        name: PutSimpleProduct
         description: Put Simple Product with client flattening true on the model
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1687,7 +1654,7 @@ operationGroups:
         targetProperty: *ref_31
         language: !<!Languages> 
           default:
-            name: max_product_display_name
+            name: maxProductDisplayName
             description: Display name of product.
         protocol: !<!Protocols> {}
       - !<!Parameter> 
@@ -1713,7 +1680,7 @@ operationGroups:
         targetProperty: *ref_35
         language: !<!Languages> 
           default:
-            name: generic_value
+            name: genericValue
             description: Generic URL value.
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_61
@@ -1726,7 +1693,7 @@ operationGroups:
         targetProperty: *ref_37
         language: !<!Languages> 
           default:
-            name: '@odata.value'
+            name: odataValue
             description: URL value.
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -1779,7 +1746,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postFlattenedSimpleProduct
+        name: PostFlattenedSimpleProduct
         description: Put Flattened Simple Product with client flattening true on the parameter
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1844,7 +1811,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSimpleProductWithGrouping
+        name: PutSimpleProductWithGrouping
         description: Put Simple Product with client flattening true on the model
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/paging/namer.yaml
+++ b/modelerfour/test/scenarios/paging/namer.yaml
@@ -32,7 +32,7 @@ schemas: !<!Schemas>
                   precision: 32
                   language: !<!Languages> 
                     default:
-                      name: typeForid
+                      name: TypeForid
                       description: ''
                   protocol: !<!Protocols> {}
                 serializedName: id
@@ -40,7 +40,6 @@ schemas: !<!Schemas>
                   default:
                     name: id
                     description: ''
-                    originalName: id
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_22
@@ -50,7 +49,7 @@ schemas: !<!Schemas>
                     version: 1.0.0
                   language: !<!Languages> 
                     default:
-                      name: Product-properties-name
+                      name: ProductPropertiesName
                       description: ''
                   protocol: !<!Protocols> {}
                 serializedName: name
@@ -58,11 +57,10 @@ schemas: !<!Schemas>
                   default:
                     name: name
                     description: ''
-                    originalName: name
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: Product-properties
+                  name: ProductProperties
                   description: ''
                   namespace: Api100
               protocol: !<!Protocols> {}
@@ -71,7 +69,6 @@ schemas: !<!Schemas>
               default:
                 name: properties
                 description: ''
-                originalName: properties
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -81,15 +78,14 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: ProductResultValue-value
-            description: ''
+            name: ProductResultValue
+            description: Array of Product
         protocol: !<!Protocols> {}
       serializedName: value
       language: !<!Languages> 
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_23
@@ -99,7 +95,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ProductResultValue-nextLink
+            name: ProductResultValueNextLink
             description: ''
         protocol: !<!Protocols> {}
       serializedName: nextLink
@@ -107,7 +103,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: ''
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -132,15 +127,14 @@ schemas: !<!Schemas>
         elementType: *ref_0
         language: !<!Languages> 
           default:
-            name: ProductResult-values
-            description: ''
+            name: ProductResultValues
+            description: Array of Product
         protocol: !<!Protocols> {}
       serializedName: values
       language: !<!Languages> 
         default:
           name: values
           description: ''
-          originalName: values
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_24
@@ -150,7 +144,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ProductResult-nextLink
+            name: ProductResultNextLink
             description: ''
         protocol: !<!Protocols> {}
       serializedName: nextLink
@@ -158,7 +152,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: ''
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -181,15 +174,14 @@ schemas: !<!Schemas>
         elementType: *ref_0
         language: !<!Languages> 
           default:
-            name: OdataProductResult-values
-            description: ''
+            name: OdataProductResultValues
+            description: Array of Product
         protocol: !<!Protocols> {}
       serializedName: values
       language: !<!Languages> 
         default:
           name: values
           description: ''
-          originalName: values
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_25
@@ -199,7 +191,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: OdataProductResult-odata.nextLink
+            name: OdataProductResultOdataNextLink
             description: ''
         protocol: !<!Protocols> {}
       serializedName: odata.nextLink
@@ -207,7 +199,6 @@ schemas: !<!Schemas>
         default:
           name: odataNextLink
           description: ''
-          originalName: odata.nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -240,7 +231,7 @@ schemas: !<!Schemas>
           value: canceled
           language:
             default:
-              name: canceled
+              name: Canceled
               description: ''
         - !<!ChoiceValue> 
           value: Accepted
@@ -288,7 +279,7 @@ schemas: !<!Schemas>
           value: OK
           language:
             default:
-              name: OK
+              name: Ok
               description: ''
         type: choice
         apiVersions:
@@ -298,12 +289,12 @@ schemas: !<!Schemas>
           type: string
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: simple string
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: OperationResult-status
+            name: OperationResultStatus
             description: The status of the request
         protocol: !<!Protocols> {}
       serializedName: status
@@ -311,7 +302,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: The status of the request
-          originalName: status
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -338,7 +328,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -377,7 +367,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: integer
+            name: Integer
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -553,7 +543,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: string
+            name: String
             description: ''
         protocol: !<!Protocols> {}
       originalParameter:
@@ -784,7 +774,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getNoItemNamePages
+        name: GetNoItemNamePages
         description: A paging operation that must return result of the default 'value' node.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -834,7 +824,7 @@ operationGroups:
         nextLinkName: {}
     language: !<!Languages> 
       default:
-        name: getNullNextLinkNamePages
+        name: GetNullNextLinkNamePages
         description: 'A paging operation that must ignore any kind of nextLink, and stop after page 1.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -884,7 +874,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getSinglePages
+        name: GetSinglePages
         description: A paging operation that finishes on the first call without a nextlink
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -899,7 +889,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: client-request-id
+            name: clientRequestId
             description: ''
             serializedName: client-request-id
         protocol: !<!Protocols> 
@@ -950,7 +940,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getMultiplePages
+        name: GetMultiplePages
         description: A paging operation that includes a nextLink that has 10 pages
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -965,7 +955,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: client-request-id
+            name: clientRequestId
             description: ''
             serializedName: client-request-id
         protocol: !<!Protocols> 
@@ -1016,7 +1006,7 @@ operationGroups:
         nextLinkName: odata.nextLink
     language: !<!Languages> 
       default:
-        name: getOdataMultiplePages
+        name: GetOdataMultiplePages
         description: A paging operation that includes a nextLink in odata format that has 10 pages
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1031,7 +1021,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: client-request-id
+            name: clientRequestId
             description: ''
             serializedName: client-request-id
         protocol: !<!Protocols> 
@@ -1083,7 +1073,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getMultiplePagesWithOffset
+        name: GetMultiplePagesWithOffset
         description: A paging operation that includes a nextLink that has 10 pages
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1133,7 +1123,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getMultiplePagesRetryFirst
+        name: GetMultiplePagesRetryFirst
         description: A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1183,7 +1173,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getMultiplePagesRetrySecond
+        name: GetMultiplePagesRetrySecond
         description: 'A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1233,7 +1223,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getSinglePagesFailure
+        name: GetSinglePagesFailure
         description: A paging operation that receives a 400 on the first call
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1283,7 +1273,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getMultiplePagesFailure
+        name: GetMultiplePagesFailure
         description: A paging operation that receives a 400 on the second call
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1333,7 +1323,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: getMultiplePagesFailureUri
+        name: GetMultiplePagesFailureUri
         description: A paging operation that receives an invalid nextLink
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1349,7 +1339,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: api_version
+            name: apiVersion
             description: Sets the api version to use.
             serializedName: api_version
         protocol: !<!Protocols> 
@@ -1410,7 +1400,7 @@ operationGroups:
         operationName: Paging_nextFragment
     language: !<!Languages> 
       default:
-        name: getMultiplePagesFragmentNextLink
+        name: GetMultiplePagesFragmentNextLink
         description: 'A paging operation that doesn''t return a full URL, just a fragment'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1465,7 +1455,7 @@ operationGroups:
         operationName: Paging_nextFragmentWithGrouping
     language: !<!Languages> 
       default:
-        name: getMultiplePagesFragmentWithGroupingNextLink
+        name: GetMultiplePagesFragmentWithGroupingNextLink
         description: 'A paging operation that doesn''t return a full URL, just a fragment with parameters grouped'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1480,7 +1470,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: client-request-id
+            name: clientRequestId
             description: ''
             serializedName: client-request-id
         protocol: !<!Protocols> 
@@ -1532,7 +1522,7 @@ operationGroups:
         nextLinkName: nextLink
     language: !<!Languages> 
       default:
-        name: GetMultiplePagesLRO
+        name: GetMultiplePagesLro
         description: A long-running paging operation that includes a nextLink that has 10 pages
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1548,7 +1538,7 @@ operationGroups:
         required: true
         language: !<!Languages> 
           default:
-            name: api_version
+            name: apiVersion
             description: Sets the api version to use.
             serializedName: api_version
         protocol: !<!Protocols> 
@@ -1624,7 +1614,7 @@ operationGroups:
         operationName: Paging_nextFragment
     language: !<!Languages> 
       default:
-        name: nextFragment
+        name: NextFragment
         description: 'A paging operation that doesn''t return a full URL, just a fragment'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1694,7 +1684,7 @@ operationGroups:
         operationName: Paging_nextFragmentWithGrouping
     language: !<!Languages> 
       default:
-        name: nextFragmentWithGrouping
+        name: NextFragmentWithGrouping
         description: 'A paging operation that doesn''t return a full URL, just a fragment'
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/parameter-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/namer.yaml
@@ -17,12 +17,12 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: AvailabilitySetUpdateParameters-tags
+            name: AvailabilitySetUpdateParametersTags
             description: A description about the set of tags.
         protocol: !<!Protocols> {}
       required: true
@@ -31,7 +31,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: A description about the set of tags.
-          originalName: tags
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -46,7 +45,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_1
@@ -58,7 +57,7 @@ schemas: !<!Schemas>
     maxLength: 80
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
 globalParameters:
@@ -140,7 +139,7 @@ operationGroups:
         targetProperty: *ref_7
         language: !<!Languages> 
           default:
-            name: AvailabilitySetUpdateParametersTags
+            name: tags
             description: A description about the set of tags.
         protocol: !<!Protocols> {}
       signatureParameters:

--- a/modelerfour/test/scenarios/report/namer.yaml
+++ b/modelerfour/test/scenarios/report/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_2
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -58,13 +56,13 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: integer
+          name: Integer
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Dictionary of integer
-        description: Dictionary of <paths·report·get·responses·200·content·application-json·schema·additionalproperties>
+        name: DictionaryOfInteger
+        description: Dictionary of Integer
     protocol: !<!Protocols> {}
   numbers:
   - *ref_0
@@ -74,7 +72,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_5
@@ -84,7 +82,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_2
@@ -170,7 +168,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getReport
+        name: GetReport
         description: Get test coverage report
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -232,7 +230,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getOptionalReport
+        name: GetOptionalReport
         description: Get optional test coverage report
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/required-optional/namer.yaml
+++ b/modelerfour/test/scenarios/required-optional/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_8
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -59,7 +57,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForvalue
+            name: TypeForvalue
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -68,11 +66,10 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: int-wrapper
+        name: IntWrapper
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -88,7 +85,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForvalue
+            name: TypeForvalue
             description: ''
         protocol: !<!Protocols> {}
       serializedName: value
@@ -96,11 +93,10 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: int-optional-wrapper
+        name: IntOptionalWrapper
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -118,7 +114,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: string-wrapper-value
+            name: StringWrapperValue
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -127,11 +123,10 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: string-wrapper
+        name: StringWrapper
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -149,7 +144,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: string-optional-wrapper-value
+            name: StringOptionalWrapperValue
             description: ''
         protocol: !<!Protocols> {}
       serializedName: value
@@ -157,11 +152,10 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: string-optional-wrapper
+        name: StringOptionalWrapper
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -177,7 +171,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -186,7 +180,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> &ref_54
       schema: !<!StringSchema> &ref_11
@@ -196,7 +189,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: product-name
+            name: ProductName
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -205,11 +198,10 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: product
+        name: Product
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -227,11 +219,10 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: class-wrapper
+        name: ClassWrapper
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -248,11 +239,10 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: class-optional-wrapper
+        name: ClassOptionalWrapper
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -275,13 +265,13 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: array-wrapper-valueItem
+              name: ArrayWrapperValueItem
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: array-wrapper-value
-            description: ''
+            name: ArrayWrapperValue
+            description: Array of ArrayWrapperValueItem
         protocol: !<!Protocols> {}
       required: true
       serializedName: value
@@ -289,11 +279,10 @@ schemas: !<!Schemas>
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: array-wrapper
+        name: ArrayWrapper
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -316,24 +305,23 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: array-optional-wrapper-valueItem
+              name: ArrayOptionalWrapperValueItem
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: array-optional-wrapper-value
-            description: ''
+            name: ArrayOptionalWrapperValue
+            description: Array of ArrayOptionalWrapperValueItem
         protocol: !<!Protocols> {}
       serializedName: value
       language: !<!Languages> 
         default:
           name: value
           description: ''
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: array-optional-wrapper
+        name: ArrayOptionalWrapper
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -350,13 +338,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: post-content-schemaItem
+          name: PostContentSchemaItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of post-content-schemaItem
-        description: ''
+        name: ArrayOfPostContentSchemaItem
+        description: Array of PostContentSchemaItem
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_70
     type: array
@@ -370,13 +358,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of string
-        description: ''
+        name: ArrayOfString
+        description: Array of String
     protocol: !<!Protocols> {}
   - *ref_1
   - *ref_2
@@ -392,13 +380,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: post-0-itemsItem
+          name: Post0ItemsItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of post-0-itemsItem
-        description: ''
+        name: ArrayOfPost0ItemsItem
+        description: Array of Post0ItemsItem
     protocol: !<!Protocols> {}
   numbers:
   - *ref_3
@@ -410,7 +398,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_4
@@ -424,7 +412,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   strings:
@@ -432,7 +420,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_7
@@ -564,7 +552,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getRequiredPath
+        name: GetRequiredPath
         description: Test implicitly required path parameter
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -622,7 +610,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: putOptionalQuery
+        name: PutOptionalQuery
         description: Test implicitly optional query parameter
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -680,7 +668,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: putOptionalHeader
+        name: PutOptionalHeader
         description: Test implicitly optional header parameter
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -745,7 +733,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putOptionalBody
+        name: PutOptionalBody
         description: Test implicitly optional body parameter
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -792,7 +780,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getRequiredGlobalPath
+        name: GetRequiredGlobalPath
         description: Test implicitly required path parameter
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -839,7 +827,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getRequiredGlobalQuery
+        name: GetRequiredGlobalQuery
         description: Test implicitly required query parameter
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -886,12 +874,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getOptionalGlobalQuery
+        name: GetOptionalGlobalQuery
         description: Test implicitly optional query parameter
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: implicit
+      name: Implicit
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -960,7 +948,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequiredIntegerParameter
+        name: PostRequiredIntegerParameter
         description: Test explicitly required integer. Please put null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1025,7 +1013,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postOptionalIntegerParameter
+        name: PostOptionalIntegerParameter
         description: Test explicitly optional integer. Please put null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1105,7 +1093,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequiredIntegerProperty
+        name: PostRequiredIntegerProperty
         description: Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1183,7 +1171,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postOptionalIntegerProperty
+        name: PostOptionalIntegerProperty
         description: Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1242,7 +1230,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postRequiredIntegerHeader
+        name: PostRequiredIntegerHeader
         description: Test explicitly required integer. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1300,7 +1288,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postOptionalIntegerHeader
+        name: PostOptionalIntegerHeader
         description: Test explicitly optional integer. Please put a header 'headerParameter' => null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1366,7 +1354,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequiredStringParameter
+        name: PostRequiredStringParameter
         description: Test explicitly required string. Please put null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1431,7 +1419,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postOptionalStringParameter
+        name: PostOptionalStringParameter
         description: Test explicitly optional string. Please put null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1511,7 +1499,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequiredStringProperty
+        name: PostRequiredStringProperty
         description: Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1589,7 +1577,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postOptionalStringProperty
+        name: PostOptionalStringProperty
         description: Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1648,7 +1636,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postRequiredStringHeader
+        name: PostRequiredStringHeader
         description: Test explicitly required string. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1706,7 +1694,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postOptionalStringHeader
+        name: PostOptionalStringHeader
         description: Test explicitly optional string. Please put a header 'headerParameter' => null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1800,7 +1788,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequiredClassParameter
+        name: PostRequiredClassParameter
         description: Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1893,7 +1881,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postOptionalClassParameter
+        name: PostOptionalClassParameter
         description: Test explicitly optional complex object. Please put null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1973,7 +1961,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequiredClassProperty
+        name: PostRequiredClassProperty
         description: Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2051,7 +2039,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postOptionalClassProperty
+        name: PostOptionalClassProperty
         description: Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2117,7 +2105,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequiredArrayParameter
+        name: PostRequiredArrayParameter
         description: Test explicitly required array. Please put null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2182,7 +2170,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postOptionalArrayParameter
+        name: PostOptionalArrayParameter
         description: Test explicitly optional array. Please put null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2262,7 +2250,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postRequiredArrayProperty
+        name: PostRequiredArrayProperty
         description: Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2340,7 +2328,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: postOptionalArrayProperty
+        name: PostOptionalArrayProperty
         description: Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2400,7 +2388,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postRequiredArrayHeader
+        name: PostRequiredArrayHeader
         description: Test explicitly required array. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2459,12 +2447,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: postOptionalArrayHeader
+        name: PostOptionalArrayHeader
         description: Test explicitly optional integer. Please put a header 'headerParameter' => null.
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: explicit
+      name: Explicit
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountCheckNameAvailabilityParameters-name
+            name: StorageAccountCheckNameAvailabilityParametersName
             description: ''
         protocol: !<!Protocols> {}
       required: true
@@ -24,7 +24,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> &ref_52
       schema: !<!StringSchema> &ref_31
@@ -35,7 +34,7 @@ schemas: !<!Schemas>
         defaultValue: Microsoft.Storage/storageAccounts
         language: !<!Languages> 
           default:
-            name: StorageAccountCheckNameAvailabilityParameters-type
+            name: StorageAccountCheckNameAvailabilityParametersType
             description: ''
         protocol: !<!Protocols> {}
       required: false
@@ -44,7 +43,6 @@ schemas: !<!Schemas>
         default:
           name: type
           description: ''
-          originalName: type
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -63,7 +61,7 @@ schemas: !<!Schemas>
         type: boolean
         language: !<!Languages> 
           default:
-            name: typeFornameAvailable
+            name: TypeFornameAvailable
             description: 'Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or invalid and cannot be used.'
         protocol: !<!Protocols> {}
       serializedName: nameAvailable
@@ -71,7 +69,6 @@ schemas: !<!Schemas>
         default:
           name: nameAvailable
           description: 'Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or invalid and cannot be used.'
-          originalName: nameAvailable
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!SealedChoiceSchema> &ref_26
@@ -96,7 +93,7 @@ schemas: !<!Schemas>
           type: string
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: simple string
           protocol: !<!Protocols> {}
         language: !<!Languages> 
@@ -109,7 +106,6 @@ schemas: !<!Schemas>
         default:
           name: reason
           description: Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.
-          originalName: reason
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_32
@@ -119,7 +115,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: CheckNameAvailabilityResult-message
+            name: CheckNameAvailabilityResultMessage
             description: Gets an error message explaining the Reason value in more detail.
         protocol: !<!Protocols> {}
       serializedName: message
@@ -127,7 +123,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: Gets an error message explaining the Reason value in more detail.
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -160,31 +155,31 @@ schemas: !<!Schemas>
               value: Standard_LRS
               language:
                 default:
-                  name: Standard_LRS
+                  name: StandardLrs
                   description: ''
             - !<!ChoiceValue> 
               value: Standard_ZRS
               language:
                 default:
-                  name: Standard_ZRS
+                  name: StandardZrs
                   description: ''
             - !<!ChoiceValue> 
               value: Standard_GRS
               language:
                 default:
-                  name: Standard_GRS
+                  name: StandardGrs
                   description: ''
             - !<!ChoiceValue> 
               value: Standard_RAGRS
               language:
                 default:
-                  name: Standard_RAGRS
+                  name: StandardRagrs
                   description: ''
             - !<!ChoiceValue> 
               value: Premium_LRS
               language:
                 default:
-                  name: Premium_LRS
+                  name: PremiumLrs
                   description: ''
             type: sealed-choice
             apiVersions:
@@ -204,7 +199,6 @@ schemas: !<!Schemas>
             default:
               name: accountType
               description: Gets or sets the account type.
-              originalName: accountType
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -236,7 +230,7 @@ schemas: !<!Schemas>
               value: ResolvingDNS
               language:
                 default:
-                  name: ResolvingDNS
+                  name: ResolvingDns
                   description: ''
             - !<!ChoiceValue> 
               value: Succeeded
@@ -262,7 +256,6 @@ schemas: !<!Schemas>
             default:
               name: provisioningState
               description: Gets the status of the storage account at the time the operation was called.
-              originalName: provisioningState
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_2
@@ -274,7 +267,6 @@ schemas: !<!Schemas>
             default:
               name: accountType
               description: Gets or sets the account type.
-              originalName: accountType
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ObjectSchema> &ref_3
@@ -291,7 +283,7 @@ schemas: !<!Schemas>
                   version: 2015-05-01-preview
                 language: !<!Languages> 
                   default:
-                    name: Endpoints-blob
+                    name: EndpointsBlob
                     description: Gets the blob endpoint.
                 protocol: !<!Protocols> {}
               serializedName: blob
@@ -299,7 +291,6 @@ schemas: !<!Schemas>
                 default:
                   name: blob
                   description: Gets the blob endpoint.
-                  originalName: blob
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!StringSchema> &ref_38
@@ -309,7 +300,7 @@ schemas: !<!Schemas>
                   version: 2015-05-01-preview
                 language: !<!Languages> 
                   default:
-                    name: Endpoints-queue
+                    name: EndpointsQueue
                     description: Gets the queue endpoint.
                 protocol: !<!Protocols> {}
               serializedName: queue
@@ -317,7 +308,6 @@ schemas: !<!Schemas>
                 default:
                   name: queue
                   description: Gets the queue endpoint.
-                  originalName: queue
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!StringSchema> &ref_39
@@ -327,7 +317,7 @@ schemas: !<!Schemas>
                   version: 2015-05-01-preview
                 language: !<!Languages> 
                   default:
-                    name: Endpoints-table
+                    name: EndpointsTable
                     description: Gets the table endpoint.
                 protocol: !<!Protocols> {}
               serializedName: table
@@ -335,7 +325,6 @@ schemas: !<!Schemas>
                 default:
                   name: table
                   description: Gets the table endpoint.
-                  originalName: table
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: *ref_3
@@ -344,7 +333,6 @@ schemas: !<!Schemas>
                 default:
                   name: dummyEndPoint
                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
-                  originalName: dummyEndPoint
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!ObjectSchema> &ref_14
@@ -365,9 +353,8 @@ schemas: !<!Schemas>
                       serializedName: RecursivePoint
                       language: !<!Languages> 
                         default:
-                          name: RecursivePoint
+                          name: recursivePoint
                           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
-                          originalName: RecursivePoint
                       protocol: !<!Protocols> {}
                     language: !<!Languages> 
                       default:
@@ -380,7 +367,6 @@ schemas: !<!Schemas>
                     default:
                       name: barPoint
                       description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
-                      originalName: Bar.Point
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
@@ -391,9 +377,8 @@ schemas: !<!Schemas>
               serializedName: FooPoint
               language: !<!Languages> 
                 default:
-                  name: FooPoint
+                  name: fooPoint
                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
-                  originalName: FooPoint
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -409,7 +394,6 @@ schemas: !<!Schemas>
             default:
               name: primaryEndpoints
               description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
-              originalName: primaryEndpoints
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_10
@@ -419,7 +403,7 @@ schemas: !<!Schemas>
               version: 2015-05-01-preview
             language: !<!Languages> 
               default:
-                name: StorageAccountProperties-primaryLocation
+                name: StorageAccountPropertiesPrimaryLocation
                 description: Gets the location of the primary for the storage account.
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -430,7 +414,6 @@ schemas: !<!Schemas>
             default:
               name: primaryLocation
               description: Gets the location of the primary for the storage account.
-              originalName: primaryLocation
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!SealedChoiceSchema> &ref_4
@@ -465,7 +448,6 @@ schemas: !<!Schemas>
             default:
               name: statusOfPrimary
               description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
-              originalName: statusOfPrimary
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!DateTimeSchema> &ref_11
@@ -476,7 +458,7 @@ schemas: !<!Schemas>
               version: 2015-05-01-preview
             language: !<!Languages> 
               default:
-                name: StorageAccountProperties-lastGeoFailoverTime
+                name: StorageAccountPropertiesLastGeoFailoverTime
                 description: >-
                   Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available
                   if the accountType is StandardGRS or StandardRAGRS.
@@ -491,7 +473,6 @@ schemas: !<!Schemas>
               description: >-
                 Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if
                 the accountType is StandardGRS or StandardRAGRS.
-              originalName: lastGeoFailoverTime
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_12
@@ -501,7 +482,7 @@ schemas: !<!Schemas>
               version: 2015-05-01-preview
             language: !<!Languages> 
               default:
-                name: StorageAccountProperties-secondaryLocation
+                name: StorageAccountPropertiesSecondaryLocation
                 description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -512,7 +493,6 @@ schemas: !<!Schemas>
             default:
               name: secondaryLocation
               description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
-              originalName: secondaryLocation
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_4
@@ -524,7 +504,6 @@ schemas: !<!Schemas>
             default:
               name: statusOfSecondary
               description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
-              originalName: statusOfSecondary
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!DateTimeSchema> &ref_13
@@ -535,7 +514,7 @@ schemas: !<!Schemas>
               version: 2015-05-01-preview
             language: !<!Languages> 
               default:
-                name: StorageAccountProperties-creationTime
+                name: StorageAccountPropertiesCreationTime
                 description: Gets the creation date and time of the storage account in UTC.
             protocol: !<!Protocols> {}
           flattenedNames:
@@ -546,7 +525,6 @@ schemas: !<!Schemas>
             default:
               name: creationTime
               description: Gets the creation date and time of the storage account in UTC.
-              originalName: creationTime
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ObjectSchema> &ref_5
@@ -563,7 +541,7 @@ schemas: !<!Schemas>
                   version: 2015-05-01-preview
                 language: !<!Languages> 
                   default:
-                    name: CustomDomain-name
+                    name: CustomDomainName
                     description: Gets or sets the custom domain name. Name is the CNAME source.
                 protocol: !<!Protocols> {}
               serializedName: name
@@ -571,14 +549,13 @@ schemas: !<!Schemas>
                 default:
                   name: name
                   description: Gets or sets the custom domain name. Name is the CNAME source.
-                  originalName: name
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!BooleanSchema> &ref_23
                 type: boolean
                 language: !<!Languages> 
                   default:
-                    name: typeForuseSubDomain
+                    name: TypeForuseSubDomain
                     description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
                 protocol: !<!Protocols> {}
               serializedName: useSubDomain
@@ -586,7 +563,6 @@ schemas: !<!Schemas>
                 default:
                   name: useSubDomain
                   description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
-                  originalName: useSubDomain
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -602,7 +578,6 @@ schemas: !<!Schemas>
             default:
               name: customDomain
               description: The custom domain assigned to this storage account. This can be set via Update.
-              originalName: customDomain
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_3
@@ -614,7 +589,6 @@ schemas: !<!Schemas>
             default:
               name: secondaryEndpoints
               description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
-              originalName: secondaryEndpoints
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -643,7 +617,6 @@ schemas: !<!Schemas>
             default:
               name: accountType
               description: Gets or sets the account type.
-              originalName: accountType
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_5
@@ -655,7 +628,6 @@ schemas: !<!Schemas>
             default:
               name: customDomain
               description: The custom domain assigned to this storage account. This can be set via Update.
-              originalName: customDomain
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -676,7 +648,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: Resource-id
+            name: ResourceId
             description: Resource Id
         protocol: !<!Protocols> {}
       readOnly: true
@@ -686,7 +658,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Resource Id
-          originalName: id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_34
@@ -696,7 +667,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: Resource-name
+            name: ResourceName
             description: Resource name
         protocol: !<!Protocols> {}
       readOnly: true
@@ -706,7 +677,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: Resource name
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_35
@@ -716,7 +686,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: Resource-type
+            name: ResourceType
             description: Resource type
         protocol: !<!Protocols> {}
       readOnly: true
@@ -726,7 +696,6 @@ schemas: !<!Schemas>
         default:
           name: type
           description: Resource type
-          originalName: type
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_36
@@ -736,7 +705,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: Resource-location
+            name: ResourceLocation
             description: Resource location
         protocol: !<!Protocols> {}
       required: true
@@ -745,7 +714,6 @@ schemas: !<!Schemas>
         default:
           name: location
           description: Resource location
-          originalName: location
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DictionarySchema> &ref_19
@@ -757,12 +725,12 @@ schemas: !<!Schemas>
             version: 2015-05-01-preview
           language: !<!Languages> 
             default:
-              name: string
+              name: String
               description: ''
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Resource-tags
+            name: ResourceTags
             description: Resource tags
         protocol: !<!Protocols> {}
       required: false
@@ -771,7 +739,6 @@ schemas: !<!Schemas>
         default:
           name: tags
           description: Resource tags
-          originalName: tags
       protocol: !<!Protocols> {}
     extensions:
       x-ms-azure-resource: true
@@ -795,7 +762,6 @@ schemas: !<!Schemas>
         default:
           name: accountType
           description: Gets or sets the account type.
-          originalName: accountType
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -819,7 +785,6 @@ schemas: !<!Schemas>
         default:
           name: provisioningState
           description: Gets the status of the storage account at the time the operation was called.
-          originalName: provisioningState
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_2
@@ -828,7 +793,6 @@ schemas: !<!Schemas>
         default:
           name: accountType
           description: Gets or sets the account type.
-          originalName: accountType
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_3
@@ -837,7 +801,6 @@ schemas: !<!Schemas>
         default:
           name: primaryEndpoints
           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
-          originalName: primaryEndpoints
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_10
@@ -846,7 +809,6 @@ schemas: !<!Schemas>
         default:
           name: primaryLocation
           description: Gets the location of the primary for the storage account.
-          originalName: primaryLocation
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_4
@@ -855,7 +817,6 @@ schemas: !<!Schemas>
         default:
           name: statusOfPrimary
           description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
-          originalName: statusOfPrimary
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_11
@@ -866,7 +827,6 @@ schemas: !<!Schemas>
           description: >-
             Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the
             accountType is StandardGRS or StandardRAGRS.
-          originalName: lastGeoFailoverTime
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_12
@@ -875,7 +835,6 @@ schemas: !<!Schemas>
         default:
           name: secondaryLocation
           description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
-          originalName: secondaryLocation
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_4
@@ -884,7 +843,6 @@ schemas: !<!Schemas>
         default:
           name: statusOfSecondary
           description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
-          originalName: statusOfSecondary
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_13
@@ -893,7 +851,6 @@ schemas: !<!Schemas>
         default:
           name: creationTime
           description: Gets the creation date and time of the storage account in UTC.
-          originalName: creationTime
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_5
@@ -902,7 +859,6 @@ schemas: !<!Schemas>
         default:
           name: customDomain
           description: The custom domain assigned to this storage account. This can be set via Update.
-          originalName: customDomain
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_3
@@ -911,7 +867,6 @@ schemas: !<!Schemas>
         default:
           name: secondaryEndpoints
           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
-          originalName: secondaryEndpoints
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -939,7 +894,6 @@ schemas: !<!Schemas>
         default:
           name: accountType
           description: Gets or sets the account type.
-          originalName: accountType
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_5
@@ -948,7 +902,6 @@ schemas: !<!Schemas>
         default:
           name: customDomain
           description: The custom domain assigned to this storage account. This can be set via Update.
-          originalName: customDomain
       protocol: !<!Protocols> {}
     extensions:
       x-ms-flattened: true
@@ -972,7 +925,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountKeys-key1
+            name: StorageAccountKeysKey1
             description: Gets the value of key 1.
         protocol: !<!Protocols> {}
       serializedName: key1
@@ -980,7 +933,6 @@ schemas: !<!Schemas>
         default:
           name: key1
           description: Gets the value of key 1.
-          originalName: key1
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_16
@@ -989,7 +941,6 @@ schemas: !<!Schemas>
         default:
           name: key2
           description: Gets the value of key 1.
-          originalName: key2
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1012,7 +963,7 @@ schemas: !<!Schemas>
         elementType: *ref_7
         language: !<!Languages> 
           default:
-            name: StorageAccountListResult-value
+            name: StorageAccountListResultValue
             description: Gets the list of storage accounts and their properties.
         protocol: !<!Protocols> {}
       serializedName: value
@@ -1020,7 +971,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: Gets the list of storage accounts and their properties.
-          originalName: value
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_41
@@ -1030,7 +980,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: StorageAccountListResult-nextLink
+            name: StorageAccountListResultNextLink
             description: Gets the link to the next set of results. Currently this will always be empty as the API does not support pagination.
         protocol: !<!Protocols> {}
       serializedName: nextLink
@@ -1038,7 +988,6 @@ schemas: !<!Schemas>
         default:
           name: nextLink
           description: Gets the link to the next set of results. Currently this will always be empty as the API does not support pagination.
-          originalName: nextLink
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1059,13 +1008,13 @@ schemas: !<!Schemas>
           value: key1
           language:
             default:
-              name: key1
+              name: Key1
               description: ''
         - !<!ChoiceValue> 
           value: key2
           language:
             default:
-              name: key2
+              name: Key2
               description: ''
         type: sealed-choice
         apiVersions:
@@ -1082,7 +1031,6 @@ schemas: !<!Schemas>
         default:
           name: keyName
           description: ''
-          originalName: keyName
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1162,7 +1110,6 @@ schemas: !<!Schemas>
               default:
                 name: unit
                 description: Gets the unit of measurement.
-                originalName: unit
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!NumberSchema> &ref_24
@@ -1170,7 +1117,7 @@ schemas: !<!Schemas>
               precision: 32
               language: !<!Languages> 
                 default:
-                  name: typeForcurrentValue
+                  name: TypeForcurrentValue
                   description: Gets the current count of the allocated resources in the subscription.
               protocol: !<!Protocols> {}
             serializedName: currentValue
@@ -1178,7 +1125,6 @@ schemas: !<!Schemas>
               default:
                 name: currentValue
                 description: Gets the current count of the allocated resources in the subscription.
-                originalName: currentValue
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!NumberSchema> &ref_25
@@ -1186,7 +1132,7 @@ schemas: !<!Schemas>
               precision: 32
               language: !<!Languages> 
                 default:
-                  name: typeForlimit
+                  name: TypeForlimit
                   description: Gets the maximum count of the resources that can be allocated in the subscription.
               protocol: !<!Protocols> {}
             serializedName: limit
@@ -1194,7 +1140,6 @@ schemas: !<!Schemas>
               default:
                 name: limit
                 description: Gets the maximum count of the resources that can be allocated in the subscription.
-                originalName: limit
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_18
@@ -1211,7 +1156,7 @@ schemas: !<!Schemas>
                     version: 2015-05-01-preview
                   language: !<!Languages> 
                     default:
-                      name: UsageName-value
+                      name: UsageNameValue
                       description: Gets a string describing the resource name.
                   protocol: !<!Protocols> {}
                 serializedName: value
@@ -1219,7 +1164,6 @@ schemas: !<!Schemas>
                   default:
                     name: value
                     description: Gets a string describing the resource name.
-                    originalName: value
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_43
@@ -1229,7 +1173,7 @@ schemas: !<!Schemas>
                     version: 2015-05-01-preview
                   language: !<!Languages> 
                     default:
-                      name: UsageName-localizedValue
+                      name: UsageNameLocalizedValue
                       description: Gets a localized string describing the resource name.
                   protocol: !<!Protocols> {}
                 serializedName: localizedValue
@@ -1237,7 +1181,6 @@ schemas: !<!Schemas>
                   default:
                     name: localizedValue
                     description: Gets a localized string describing the resource name.
-                    originalName: localizedValue
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -1250,7 +1193,6 @@ schemas: !<!Schemas>
               default:
                 name: name
                 description: The Usage Names.
-                originalName: name
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -1260,7 +1202,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: UsageListResult-value
+            name: UsageListResultValue
             description: Gets or sets the list Storage Resource Usages.
         protocol: !<!Protocols> {}
       serializedName: value
@@ -1268,7 +1210,6 @@ schemas: !<!Schemas>
         default:
           name: value
           description: Gets or sets the list Storage Resource Usages.
-          originalName: value
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1292,7 +1233,7 @@ schemas: !<!Schemas>
           version: 2015-05-01-preview
         language: !<!Languages> 
           default:
-            name: SubResource-id
+            name: SubResourceId
             description: Resource Id
         protocol: !<!Protocols> {}
       serializedName: id
@@ -1300,7 +1241,6 @@ schemas: !<!Schemas>
         default:
           name: id
           description: Resource Id
-          originalName: id
       protocol: !<!Protocols> {}
     extensions:
       x-ms-azure-resource: true
@@ -1330,7 +1270,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1344,7 +1284,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1358,7 +1298,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1372,7 +1312,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1386,7 +1326,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1400,7 +1340,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1414,7 +1354,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1428,7 +1368,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1442,7 +1382,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> 
@@ -1456,7 +1396,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: ApiVersion-2015-05-01-preview
+        name: ApiVersion20150501Preview
         description: Api Version (2015-05-01-preview)
     protocol: !<!Protocols> {}
   dateTimes:

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           version: 2014-04-01-preview
         language: !<!Languages> 
           default:
-            name: SampleResourceGroup-name
+            name: SampleResourceGroupName
             description: resource group name 'testgroup101'
         protocol: !<!Protocols> {}
       serializedName: name
@@ -23,7 +23,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: resource group name 'testgroup101'
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_3
@@ -33,7 +32,7 @@ schemas: !<!Schemas>
           version: 2014-04-01-preview
         language: !<!Languages> 
           default:
-            name: SampleResourceGroup-location
+            name: SampleResourceGroupLocation
             description: resource group location 'West US'
         protocol: !<!Protocols> {}
       serializedName: location
@@ -41,7 +40,6 @@ schemas: !<!Schemas>
         default:
           name: location
           description: resource group location 'West US'
-          originalName: location
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -61,7 +59,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForcode
+            name: TypeForcode
             description: ''
         protocol: !<!Protocols> {}
       serializedName: code
@@ -69,7 +67,6 @@ schemas: !<!Schemas>
         default:
           name: code
           description: ''
-          originalName: code
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_4
@@ -79,7 +76,7 @@ schemas: !<!Schemas>
           version: 2014-04-01-preview
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -87,7 +84,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -108,12 +104,12 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: ApiVersion-2014-04-01-preview
+        name: ApiVersion20140401Preview
         description: Api Version (2014-04-01-preview)
     protocol: !<!Protocols> {}
   numbers:
@@ -127,7 +123,7 @@ schemas: !<!Schemas>
       version: 2014-04-01-preview
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_2
@@ -244,12 +240,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSampleResourceGroup
+        name: GetSampleResourceGroup
         description: Provides a resouce group with name 'testgroup101' and location 'West US'.
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: group
+      name: Group
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/text-analytics/namer.yaml
+++ b/modelerfour/test/scenarios/text-analytics/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: MultiLanguageInput-id
+                  name: MultiLanguageInputId
                   description: 'A unique, non-empty document identifier.'
               protocol: !<!Protocols> {}
             required: true
@@ -36,7 +36,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: 'A unique, non-empty document identifier.'
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_63
@@ -46,7 +45,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: MultiLanguageInput-text
+                  name: MultiLanguageInputText
                   description: The input text to process.
               protocol: !<!Protocols> {}
             required: true
@@ -55,7 +54,6 @@ schemas: !<!Schemas>
               default:
                 name: text
                 description: The input text to process.
-                originalName: text
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_64
@@ -65,7 +63,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: MultiLanguageInput-language
+                  name: MultiLanguageInputLanguage
                   description: '(Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use "en" for English; "es" for Spanish etc. If not set, use "en" for English as default.'
               protocol: !<!Protocols> {}
             required: false
@@ -74,7 +72,6 @@ schemas: !<!Schemas>
               default:
                 name: language
                 description: '(Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use "en" for English; "es" for Spanish etc. If not set, use "en" for English as default.'
-                originalName: language
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -84,7 +81,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: MultiLanguageBatchInput-documents
+            name: MultiLanguageBatchInputDocuments
             description: The set of documents to process as part of this batch.
         protocol: !<!Protocols> {}
       required: true
@@ -93,7 +90,6 @@ schemas: !<!Schemas>
         default:
           name: documents
           description: The set of documents to process as part of this batch.
-          originalName: documents
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -128,7 +124,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: DocumentEntities-id
+                  name: DocumentEntitiesId
                   description: 'Unique, non-empty document identifier.'
               protocol: !<!Protocols> {}
             required: true
@@ -137,7 +133,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: 'Unique, non-empty document identifier.'
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ArraySchema> &ref_21
@@ -159,7 +154,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: Entity-text
+                        name: EntityText
                         description: Entity text as appears in the request.
                     protocol: !<!Protocols> {}
                   required: true
@@ -168,7 +163,6 @@ schemas: !<!Schemas>
                     default:
                       name: text
                       description: Entity text as appears in the request.
-                      originalName: text
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!StringSchema> &ref_67
@@ -178,7 +172,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: Entity-type
+                        name: EntityType
                         description: 'Entity type, such as Person/Location/Org/SSN etc'
                     protocol: !<!Protocols> {}
                   required: true
@@ -187,7 +181,6 @@ schemas: !<!Schemas>
                     default:
                       name: type
                       description: 'Entity type, such as Person/Location/Org/SSN etc'
-                      originalName: type
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!StringSchema> &ref_68
@@ -197,7 +190,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: Entity-subtype
+                        name: EntitySubtype
                         description: 'Entity sub type, such as Age/Year/TimeRange etc'
                     protocol: !<!Protocols> {}
                   required: false
@@ -206,7 +199,6 @@ schemas: !<!Schemas>
                     default:
                       name: subtype
                       description: 'Entity sub type, such as Age/Year/TimeRange etc'
-                      originalName: subtype
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!NumberSchema> &ref_40
@@ -214,7 +206,7 @@ schemas: !<!Schemas>
                     precision: 32
                     language: !<!Languages> 
                       default:
-                        name: typeForoffset
+                        name: TypeForoffset
                         description: Start position (in Unicode characters) for the entity text.
                     protocol: !<!Protocols> {}
                   required: true
@@ -223,7 +215,6 @@ schemas: !<!Schemas>
                     default:
                       name: offset
                       description: Start position (in Unicode characters) for the entity text.
-                      originalName: offset
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!NumberSchema> &ref_41
@@ -231,7 +222,7 @@ schemas: !<!Schemas>
                     precision: 32
                     language: !<!Languages> 
                       default:
-                        name: typeForlength
+                        name: TypeForlength
                         description: Length (in Unicode characters) for the entity text.
                     protocol: !<!Protocols> {}
                   required: true
@@ -240,7 +231,6 @@ schemas: !<!Schemas>
                     default:
                       name: length
                       description: Length (in Unicode characters) for the entity text.
-                      originalName: length
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!NumberSchema> &ref_42
@@ -248,7 +238,7 @@ schemas: !<!Schemas>
                     precision: 64
                     language: !<!Languages> 
                       default:
-                        name: typeForscore
+                        name: TypeForscore
                         description: Confidence score between 0 and 1 of the extracted entity.
                     protocol: !<!Protocols> {}
                   required: true
@@ -257,7 +247,6 @@ schemas: !<!Schemas>
                     default:
                       name: score
                       description: Confidence score between 0 and 1 of the extracted entity.
-                      originalName: score
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
@@ -267,7 +256,7 @@ schemas: !<!Schemas>
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: DocumentEntities-entities
+                  name: DocumentEntities
                   description: Recognized entities in the document.
               protocol: !<!Protocols> {}
             required: true
@@ -276,7 +265,6 @@ schemas: !<!Schemas>
               default:
                 name: entities
                 description: Recognized entities in the document.
-                originalName: entities
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_6
@@ -291,7 +279,7 @@ schemas: !<!Schemas>
                   precision: 32
                   language: !<!Languages> 
                     default:
-                      name: typeForcharactersCount
+                      name: TypeForcharactersCount
                       description: Number of text elements recognized in the document.
                   protocol: !<!Protocols> {}
                 required: true
@@ -300,7 +288,6 @@ schemas: !<!Schemas>
                   default:
                     name: charactersCount
                     description: Number of text elements recognized in the document.
-                    originalName: charactersCount
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!NumberSchema> &ref_44
@@ -308,7 +295,7 @@ schemas: !<!Schemas>
                   precision: 32
                   language: !<!Languages> 
                     default:
-                      name: typeFortransactionsCount
+                      name: TypeFortransactionsCount
                       description: Number of transactions for the document.
                   protocol: !<!Protocols> {}
                 required: true
@@ -317,7 +304,6 @@ schemas: !<!Schemas>
                   default:
                     name: transactionsCount
                     description: Number of transactions for the document.
-                    originalName: transactionsCount
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -331,7 +317,6 @@ schemas: !<!Schemas>
               default:
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
-                originalName: statistics
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -341,7 +326,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: EntitiesResult-documents
+            name: EntitiesResultDocuments
             description: Response by document
         protocol: !<!Protocols> {}
       required: true
@@ -350,7 +335,6 @@ schemas: !<!Schemas>
         default:
           name: documents
           description: Response by document
-          originalName: documents
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_24
@@ -372,7 +356,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: DocumentError-id
+                  name: DocumentErrorId
                   description: Document Id.
               protocol: !<!Protocols> {}
             required: true
@@ -381,7 +365,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: Document Id.
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_3
@@ -397,25 +380,25 @@ schemas: !<!Schemas>
                     value: invalidRequest
                     language:
                       default:
-                        name: invalidRequest
+                        name: InvalidRequest
                         description: ''
                   - !<!ChoiceValue> 
                     value: invalidArgument
                     language:
                       default:
-                        name: invalidArgument
+                        name: InvalidArgument
                         description: ''
                   - !<!ChoiceValue> 
                     value: internalServerError
                     language:
                       default:
-                        name: internalServerError
+                        name: InternalServerError
                         description: ''
                   - !<!ChoiceValue> 
                     value: serviceUnavailable
                     language:
                       default:
-                        name: serviceUnavailable
+                        name: ServiceUnavailable
                         description: ''
                   type: sealed-choice
                   apiVersions:
@@ -425,7 +408,7 @@ schemas: !<!Schemas>
                     type: string
                     language: !<!Languages> 
                       default:
-                        name: string
+                        name: String
                         description: simple string
                     protocol: !<!Protocols> {}
                   language: !<!Languages> 
@@ -439,7 +422,6 @@ schemas: !<!Schemas>
                   default:
                     name: code
                     description: Error code.
-                    originalName: code
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_70
@@ -449,7 +431,7 @@ schemas: !<!Schemas>
                     version: v3.0-preview.1
                   language: !<!Languages> 
                     default:
-                      name: TextAnalyticsError-message
+                      name: TextAnalyticsErrorMessage
                       description: Error message.
                   protocol: !<!Protocols> {}
                 required: true
@@ -458,7 +440,6 @@ schemas: !<!Schemas>
                   default:
                     name: message
                     description: Error message.
-                    originalName: message
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_71
@@ -468,7 +449,7 @@ schemas: !<!Schemas>
                     version: v3.0-preview.1
                   language: !<!Languages> 
                     default:
-                      name: TextAnalyticsError-target
+                      name: TextAnalyticsErrorTarget
                       description: Error target.
                   protocol: !<!Protocols> {}
                 required: false
@@ -477,7 +458,6 @@ schemas: !<!Schemas>
                   default:
                     name: target
                     description: Error target.
-                    originalName: target
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_2
@@ -493,55 +473,55 @@ schemas: !<!Schemas>
                         value: invalidParameterValue
                         language:
                           default:
-                            name: invalidParameterValue
+                            name: InvalidParameterValue
                             description: ''
                       - !<!ChoiceValue> 
                         value: invalidRequestBodyFormat
                         language:
                           default:
-                            name: invalidRequestBodyFormat
+                            name: InvalidRequestBodyFormat
                             description: ''
                       - !<!ChoiceValue> 
                         value: emptyRequest
                         language:
                           default:
-                            name: emptyRequest
+                            name: EmptyRequest
                             description: ''
                       - !<!ChoiceValue> 
                         value: missingInputRecords
                         language:
                           default:
-                            name: missingInputRecords
+                            name: MissingInputRecords
                             description: ''
                       - !<!ChoiceValue> 
                         value: invalidDocument
                         language:
                           default:
-                            name: invalidDocument
+                            name: InvalidDocument
                             description: ''
                       - !<!ChoiceValue> 
                         value: modelVersionIncorrect
                         language:
                           default:
-                            name: modelVersionIncorrect
+                            name: ModelVersionIncorrect
                             description: ''
                       - !<!ChoiceValue> 
                         value: invalidDocumentBatch
                         language:
                           default:
-                            name: invalidDocumentBatch
+                            name: InvalidDocumentBatch
                             description: ''
                       - !<!ChoiceValue> 
                         value: unsupportedLanguageCode
                         language:
                           default:
-                            name: unsupportedLanguageCode
+                            name: UnsupportedLanguageCode
                             description: ''
                       - !<!ChoiceValue> 
                         value: invalidCountryHint
                         language:
                           default:
-                            name: invalidCountryHint
+                            name: InvalidCountryHint
                             description: ''
                       type: sealed-choice
                       apiVersions:
@@ -559,7 +539,6 @@ schemas: !<!Schemas>
                       default:
                         name: code
                         description: Error code.
-                        originalName: code
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_72
@@ -569,7 +548,7 @@ schemas: !<!Schemas>
                         version: v3.0-preview.1
                       language: !<!Languages> 
                         default:
-                          name: InnerError-message
+                          name: InnerErrorMessage
                           description: Error message.
                       protocol: !<!Protocols> {}
                     required: true
@@ -578,7 +557,6 @@ schemas: !<!Schemas>
                       default:
                         name: message
                         description: Error message.
-                        originalName: message
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!DictionarySchema> &ref_19
@@ -590,12 +568,12 @@ schemas: !<!Schemas>
                           version: v3.0-preview.1
                         language: !<!Languages> 
                           default:
-                            name: string
+                            name: String
                             description: ''
                         protocol: !<!Protocols> {}
                       language: !<!Languages> 
                         default:
-                          name: InnerError-details
+                          name: InnerErrorDetails
                           description: Error details.
                       protocol: !<!Protocols> {}
                     required: false
@@ -604,7 +582,6 @@ schemas: !<!Schemas>
                       default:
                         name: details
                         description: Error details.
-                        originalName: details
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_74
@@ -614,7 +591,7 @@ schemas: !<!Schemas>
                         version: v3.0-preview.1
                       language: !<!Languages> 
                         default:
-                          name: InnerError-target
+                          name: InnerErrorTarget
                           description: Error target.
                       protocol: !<!Protocols> {}
                     required: false
@@ -623,7 +600,6 @@ schemas: !<!Schemas>
                       default:
                         name: target
                         description: Error target.
-                        originalName: target
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: *ref_2
@@ -633,7 +609,6 @@ schemas: !<!Schemas>
                       default:
                         name: innerError
                         description: ''
-                        originalName: innerError
                     protocol: !<!Protocols> {}
                   language: !<!Languages> 
                     default:
@@ -647,7 +622,6 @@ schemas: !<!Schemas>
                   default:
                     name: innerError
                     description: ''
-                    originalName: innerError
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!ArraySchema> &ref_23
@@ -658,7 +632,7 @@ schemas: !<!Schemas>
                   elementType: *ref_3
                   language: !<!Languages> 
                     default:
-                      name: TextAnalyticsError-details
+                      name: TextAnalyticsErrorDetails
                       description: Details about specific errors that led to this reported error.
                   protocol: !<!Protocols> {}
                 required: false
@@ -667,7 +641,6 @@ schemas: !<!Schemas>
                   default:
                     name: details
                     description: Details about specific errors that led to this reported error.
-                    originalName: details
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -681,7 +654,6 @@ schemas: !<!Schemas>
               default:
                 name: error
                 description: ''
-                originalName: error
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -691,7 +663,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: EntitiesResult-errors
+            name: EntitiesResultErrors
             description: Errors by document id.
         protocol: !<!Protocols> {}
       required: true
@@ -700,7 +672,6 @@ schemas: !<!Schemas>
         default:
           name: errors
           description: Errors by document id.
-          originalName: errors
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_8
@@ -715,7 +686,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeFordocumentsCount
+                name: TypeFordocumentsCount
                 description: Number of documents submitted in the request.
             protocol: !<!Protocols> {}
           required: true
@@ -724,7 +695,6 @@ schemas: !<!Schemas>
             default:
               name: documentsCount
               description: Number of documents submitted in the request.
-              originalName: documentsCount
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!NumberSchema> &ref_46
@@ -732,7 +702,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeForvalidDocumentsCount
+                name: TypeForvalidDocumentsCount
                 description: 'Number of valid documents. This excludes empty, over-size limit or non-supported languages documents.'
             protocol: !<!Protocols> {}
           required: true
@@ -741,7 +711,6 @@ schemas: !<!Schemas>
             default:
               name: validDocumentsCount
               description: 'Number of valid documents. This excludes empty, over-size limit or non-supported languages documents.'
-              originalName: validDocumentsCount
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!NumberSchema> &ref_47
@@ -749,7 +718,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeForerroneousDocumentsCount
+                name: TypeForerroneousDocumentsCount
                 description: 'Number of invalid documents. This includes empty, over-size limit or non-supported languages documents.'
             protocol: !<!Protocols> {}
           required: true
@@ -758,7 +727,6 @@ schemas: !<!Schemas>
             default:
               name: erroneousDocumentsCount
               description: 'Number of invalid documents. This includes empty, over-size limit or non-supported languages documents.'
-              originalName: erroneousDocumentsCount
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!NumberSchema> &ref_48
@@ -766,7 +734,7 @@ schemas: !<!Schemas>
             precision: 64
             language: !<!Languages> 
               default:
-                name: typeFortransactionsCount
+                name: TypeFortransactionsCount
                 description: Number of transactions for the request.
             protocol: !<!Protocols> {}
           required: true
@@ -775,7 +743,6 @@ schemas: !<!Schemas>
             default:
               name: transactionsCount
               description: Number of transactions for the request.
-              originalName: transactionsCount
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -789,7 +756,6 @@ schemas: !<!Schemas>
         default:
           name: statistics
           description: if showStats=true was specified in the request this field will contain information about the request payload.
-          originalName: statistics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_75
@@ -799,7 +765,7 @@ schemas: !<!Schemas>
           version: v3.0-preview.1
         language: !<!Languages> 
           default:
-            name: EntitiesResult-modelVersion
+            name: EntitiesResultModelVersion
             description: This field indicates which model is used for scoring.
         protocol: !<!Protocols> {}
       required: true
@@ -808,7 +774,6 @@ schemas: !<!Schemas>
         default:
           name: modelVersion
           description: This field indicates which model is used for scoring.
-          originalName: modelVersion
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -849,7 +814,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: DocumentLinkedEntities-id
+                  name: DocumentLinkedEntitiesId
                   description: 'Unique, non-empty document identifier.'
               protocol: !<!Protocols> {}
             required: true
@@ -858,7 +823,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: 'Unique, non-empty document identifier.'
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ArraySchema> &ref_26
@@ -880,7 +844,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: LinkedEntity-name
+                        name: LinkedEntityName
                         description: Entity Linking formal name.
                     protocol: !<!Protocols> {}
                   required: true
@@ -889,7 +853,6 @@ schemas: !<!Schemas>
                     default:
                       name: name
                       description: Entity Linking formal name.
-                      originalName: name
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_25
@@ -909,7 +872,7 @@ schemas: !<!Schemas>
                           precision: 64
                           language: !<!Languages> 
                             default:
-                              name: typeForscore
+                              name: TypeForscore
                               description: 'If a well-known item is recognized, a decimal number denoting the confidence level between 0 and 1 will be returned.'
                           protocol: !<!Protocols> {}
                         required: true
@@ -918,7 +881,6 @@ schemas: !<!Schemas>
                           default:
                             name: score
                             description: 'If a well-known item is recognized, a decimal number denoting the confidence level between 0 and 1 will be returned.'
-                            originalName: score
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: !<!StringSchema> &ref_78
@@ -928,7 +890,7 @@ schemas: !<!Schemas>
                             version: v3.0-preview.1
                           language: !<!Languages> 
                             default:
-                              name: Match-text
+                              name: MatchText
                               description: Entity text as appears in the request.
                           protocol: !<!Protocols> {}
                         required: true
@@ -937,7 +899,6 @@ schemas: !<!Schemas>
                           default:
                             name: text
                             description: Entity text as appears in the request.
-                            originalName: text
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: !<!NumberSchema> &ref_50
@@ -945,7 +906,7 @@ schemas: !<!Schemas>
                           precision: 32
                           language: !<!Languages> 
                             default:
-                              name: typeForoffset
+                              name: TypeForoffset
                               description: Start position (in Unicode characters) for the entity match text.
                           protocol: !<!Protocols> {}
                         required: true
@@ -954,7 +915,6 @@ schemas: !<!Schemas>
                           default:
                             name: offset
                             description: Start position (in Unicode characters) for the entity match text.
-                            originalName: offset
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: !<!NumberSchema> &ref_51
@@ -962,7 +922,7 @@ schemas: !<!Schemas>
                           precision: 32
                           language: !<!Languages> 
                             default:
-                              name: typeForlength
+                              name: TypeForlength
                               description: Length (in Unicode characters) for the entity match text.
                           protocol: !<!Protocols> {}
                         required: true
@@ -971,7 +931,6 @@ schemas: !<!Schemas>
                           default:
                             name: length
                             description: Length (in Unicode characters) for the entity match text.
-                            originalName: length
                         protocol: !<!Protocols> {}
                       language: !<!Languages> 
                         default:
@@ -981,7 +940,7 @@ schemas: !<!Schemas>
                       protocol: !<!Protocols> {}
                     language: !<!Languages> 
                       default:
-                        name: LinkedEntity-matches
+                        name: LinkedEntityMatches
                         description: List of instances this entity appears in the text.
                     protocol: !<!Protocols> {}
                   required: true
@@ -990,7 +949,6 @@ schemas: !<!Schemas>
                     default:
                       name: matches
                       description: List of instances this entity appears in the text.
-                      originalName: matches
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!StringSchema> &ref_79
@@ -1000,7 +958,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: LinkedEntity-language
+                        name: LinkedEntityLanguage
                         description: Language used in the data source.
                     protocol: !<!Protocols> {}
                   required: true
@@ -1009,7 +967,6 @@ schemas: !<!Schemas>
                     default:
                       name: language
                       description: Language used in the data source.
-                      originalName: language
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!StringSchema> &ref_80
@@ -1019,7 +976,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: LinkedEntity-id
+                        name: LinkedEntityId
                         description: Unique identifier of the recognized entity from the data source.
                     protocol: !<!Protocols> {}
                   required: false
@@ -1028,7 +985,6 @@ schemas: !<!Schemas>
                     default:
                       name: id
                       description: Unique identifier of the recognized entity from the data source.
-                      originalName: id
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!StringSchema> &ref_81
@@ -1038,7 +994,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: LinkedEntity-url
+                        name: LinkedEntityUrl
                         description: URL for the entity's page from the data source.
                     protocol: !<!Protocols> {}
                   required: true
@@ -1047,7 +1003,6 @@ schemas: !<!Schemas>
                     default:
                       name: url
                       description: URL for the entity's page from the data source.
-                      originalName: url
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!StringSchema> &ref_82
@@ -1057,7 +1012,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: LinkedEntity-dataSource
+                        name: LinkedEntityDataSource
                         description: 'Data source used to extract entity linking, such as Wiki/Bing etc.'
                     protocol: !<!Protocols> {}
                   required: true
@@ -1066,7 +1021,6 @@ schemas: !<!Schemas>
                     default:
                       name: dataSource
                       description: 'Data source used to extract entity linking, such as Wiki/Bing etc.'
-                      originalName: dataSource
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
@@ -1076,7 +1030,7 @@ schemas: !<!Schemas>
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: DocumentLinkedEntities-entities
+                  name: DocumentLinkedEntities
                   description: Recognized well-known entities in the document.
               protocol: !<!Protocols> {}
             required: true
@@ -1085,7 +1039,6 @@ schemas: !<!Schemas>
               default:
                 name: entities
                 description: Recognized well-known entities in the document.
-                originalName: entities
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: *ref_6
@@ -1095,7 +1048,6 @@ schemas: !<!Schemas>
               default:
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
-                originalName: statistics
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -1105,7 +1057,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: EntityLinkingResult-documents
+            name: EntityLinkingResultDocuments
             description: Response by document
         protocol: !<!Protocols> {}
       required: true
@@ -1114,7 +1066,6 @@ schemas: !<!Schemas>
         default:
           name: documents
           description: Response by document
-          originalName: documents
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_28
@@ -1125,7 +1076,7 @@ schemas: !<!Schemas>
         elementType: *ref_7
         language: !<!Languages> 
           default:
-            name: EntityLinkingResult-errors
+            name: EntityLinkingResultErrors
             description: Errors by document id.
         protocol: !<!Protocols> {}
       required: true
@@ -1134,7 +1085,6 @@ schemas: !<!Schemas>
         default:
           name: errors
           description: Errors by document id.
-          originalName: errors
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_8
@@ -1144,7 +1094,6 @@ schemas: !<!Schemas>
         default:
           name: statistics
           description: if showStats=true was specified in the request this field will contain information about the request payload.
-          originalName: statistics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_83
@@ -1154,7 +1103,7 @@ schemas: !<!Schemas>
           version: v3.0-preview.1
         language: !<!Languages> 
           default:
-            name: EntityLinkingResult-modelVersion
+            name: EntityLinkingResultModelVersion
             description: This field indicates which model is used for scoring.
         protocol: !<!Protocols> {}
       required: true
@@ -1163,7 +1112,6 @@ schemas: !<!Schemas>
         default:
           name: modelVersion
           description: This field indicates which model is used for scoring.
-          originalName: modelVersion
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1200,7 +1148,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: DocumentKeyPhrases-id
+                  name: DocumentKeyPhrasesId
                   description: 'Unique, non-empty document identifier.'
               protocol: !<!Protocols> {}
             required: true
@@ -1209,7 +1157,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: 'Unique, non-empty document identifier.'
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ArraySchema> &ref_29
@@ -1224,12 +1171,12 @@ schemas: !<!Schemas>
                   version: v3.0-preview.1
                 language: !<!Languages> 
                   default:
-                    name: DocumentKeyPhrases-keyPhrasesItem
+                    name: DocumentKeyPhrasesItem
                     description: ''
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: DocumentKeyPhrases-keyPhrases
+                  name: DocumentKeyPhrases
                   description: A list of representative words or phrases. The number of key phrases returned is proportional to the number of words in the input document.
               protocol: !<!Protocols> {}
             required: true
@@ -1238,7 +1185,6 @@ schemas: !<!Schemas>
               default:
                 name: keyPhrases
                 description: A list of representative words or phrases. The number of key phrases returned is proportional to the number of words in the input document.
-                originalName: keyPhrases
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: *ref_6
@@ -1248,7 +1194,6 @@ schemas: !<!Schemas>
               default:
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
-                originalName: statistics
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -1258,7 +1203,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: KeyPhraseResult-documents
+            name: KeyPhraseResultDocuments
             description: Response by document
         protocol: !<!Protocols> {}
       required: true
@@ -1267,7 +1212,6 @@ schemas: !<!Schemas>
         default:
           name: documents
           description: Response by document
-          originalName: documents
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_31
@@ -1278,7 +1222,7 @@ schemas: !<!Schemas>
         elementType: *ref_7
         language: !<!Languages> 
           default:
-            name: KeyPhraseResult-errors
+            name: KeyPhraseResultErrors
             description: Errors by document id.
         protocol: !<!Protocols> {}
       required: true
@@ -1287,7 +1231,6 @@ schemas: !<!Schemas>
         default:
           name: errors
           description: Errors by document id.
-          originalName: errors
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_8
@@ -1297,7 +1240,6 @@ schemas: !<!Schemas>
         default:
           name: statistics
           description: if showStats=true was specified in the request this field will contain information about the request payload.
-          originalName: statistics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_86
@@ -1307,7 +1249,7 @@ schemas: !<!Schemas>
           version: v3.0-preview.1
         language: !<!Languages> 
           default:
-            name: KeyPhraseResult-modelVersion
+            name: KeyPhraseResultModelVersion
             description: This field indicates which model is used for scoring.
         protocol: !<!Protocols> {}
       required: true
@@ -1316,7 +1258,6 @@ schemas: !<!Schemas>
         default:
           name: modelVersion
           description: This field indicates which model is used for scoring.
-          originalName: modelVersion
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1351,7 +1292,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: LanguageInput-id
+                  name: LanguageInputId
                   description: 'Unique, non-empty document identifier.'
               protocol: !<!Protocols> {}
             required: true
@@ -1360,7 +1301,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: 'Unique, non-empty document identifier.'
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_88
@@ -1370,7 +1310,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: LanguageInput-text
+                  name: LanguageInputText
                   description: ''
               protocol: !<!Protocols> {}
             required: true
@@ -1379,7 +1319,6 @@ schemas: !<!Schemas>
               default:
                 name: text
                 description: ''
-                originalName: text
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_89
@@ -1389,7 +1328,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: LanguageInput-countryHint
+                  name: LanguageInputCountryHint
                   description: ''
               protocol: !<!Protocols> {}
             required: false
@@ -1398,7 +1337,6 @@ schemas: !<!Schemas>
               default:
                 name: countryHint
                 description: ''
-                originalName: countryHint
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -1408,8 +1346,8 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: LanguageBatchInput-documents
-            description: ''
+            name: LanguageBatchInputDocuments
+            description: Array of LanguageInput
         protocol: !<!Protocols> {}
       required: true
       serializedName: documents
@@ -1417,7 +1355,6 @@ schemas: !<!Schemas>
         default:
           name: documents
           description: ''
-          originalName: documents
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1452,7 +1389,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: DocumentLanguage-id
+                  name: DocumentLanguageId
                   description: 'Unique, non-empty document identifier.'
               protocol: !<!Protocols> {}
             required: true
@@ -1461,7 +1398,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: 'Unique, non-empty document identifier.'
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ArraySchema> &ref_33
@@ -1483,7 +1419,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: DetectedLanguage-name
+                        name: DetectedLanguageName
                         description: 'Long name of a detected language (e.g. English, French).'
                     protocol: !<!Protocols> {}
                   required: true
@@ -1492,7 +1428,6 @@ schemas: !<!Schemas>
                     default:
                       name: name
                       description: 'Long name of a detected language (e.g. English, French).'
-                      originalName: name
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!StringSchema> &ref_92
@@ -1502,7 +1437,7 @@ schemas: !<!Schemas>
                       version: v3.0-preview.1
                     language: !<!Languages> 
                       default:
-                        name: DetectedLanguage-iso6391Name
+                        name: DetectedLanguageIso6391Name
                         description: 'A two letter representation of the detected language according to the ISO 639-1 standard (e.g. en, fr).'
                     protocol: !<!Protocols> {}
                   required: true
@@ -1511,7 +1446,6 @@ schemas: !<!Schemas>
                     default:
                       name: iso6391Name
                       description: 'A two letter representation of the detected language according to the ISO 639-1 standard (e.g. en, fr).'
-                      originalName: iso6391Name
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!NumberSchema> &ref_52
@@ -1519,7 +1453,7 @@ schemas: !<!Schemas>
                     precision: 64
                     language: !<!Languages> 
                       default:
-                        name: typeForscore
+                        name: TypeForscore
                         description: A confidence score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true.
                     protocol: !<!Protocols> {}
                   required: true
@@ -1528,7 +1462,6 @@ schemas: !<!Schemas>
                     default:
                       name: score
                       description: A confidence score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true.
-                      originalName: score
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
@@ -1538,7 +1471,7 @@ schemas: !<!Schemas>
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: DocumentLanguage-detectedLanguages
+                  name: DocumentLanguageDetectedLanguages
                   description: A list of extracted languages.
               protocol: !<!Protocols> {}
             required: true
@@ -1547,7 +1480,6 @@ schemas: !<!Schemas>
               default:
                 name: detectedLanguages
                 description: A list of extracted languages.
-                originalName: detectedLanguages
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: *ref_6
@@ -1557,7 +1489,6 @@ schemas: !<!Schemas>
               default:
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
-                originalName: statistics
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -1567,7 +1498,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: LanguageResult-documents
+            name: LanguageResultDocuments
             description: Response by document
         protocol: !<!Protocols> {}
       required: true
@@ -1576,7 +1507,6 @@ schemas: !<!Schemas>
         default:
           name: documents
           description: Response by document
-          originalName: documents
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_35
@@ -1587,7 +1517,7 @@ schemas: !<!Schemas>
         elementType: *ref_7
         language: !<!Languages> 
           default:
-            name: LanguageResult-errors
+            name: LanguageResultErrors
             description: Errors by document id.
         protocol: !<!Protocols> {}
       required: true
@@ -1596,7 +1526,6 @@ schemas: !<!Schemas>
         default:
           name: errors
           description: Errors by document id.
-          originalName: errors
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_8
@@ -1606,7 +1535,6 @@ schemas: !<!Schemas>
         default:
           name: statistics
           description: if showStats=true was specified in the request this field will contain information about the request payload.
-          originalName: statistics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_93
@@ -1616,7 +1544,7 @@ schemas: !<!Schemas>
           version: v3.0-preview.1
         language: !<!Languages> 
           default:
-            name: LanguageResult-modelVersion
+            name: LanguageResultModelVersion
             description: This field indicates which model is used for scoring.
         protocol: !<!Protocols> {}
       required: true
@@ -1625,7 +1553,6 @@ schemas: !<!Schemas>
         default:
           name: modelVersion
           description: This field indicates which model is used for scoring.
-          originalName: modelVersion
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1661,7 +1588,7 @@ schemas: !<!Schemas>
                 version: v3.0-preview.1
               language: !<!Languages> 
                 default:
-                  name: DocumentSentiment-id
+                  name: DocumentSentimentId
                   description: 'Unique, non-empty document identifier.'
               protocol: !<!Protocols> {}
             required: true
@@ -1670,7 +1597,6 @@ schemas: !<!Schemas>
               default:
                 name: id
                 description: 'Unique, non-empty document identifier.'
-                originalName: id
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!SealedChoiceSchema> &ref_60
@@ -1679,25 +1605,25 @@ schemas: !<!Schemas>
                 value: positive
                 language:
                   default:
-                    name: positive
+                    name: Positive
                     description: ''
               - !<!ChoiceValue> 
                 value: neutral
                 language:
                   default:
-                    name: neutral
+                    name: Neutral
                     description: ''
               - !<!ChoiceValue> 
                 value: negative
                 language:
                   default:
-                    name: negative
+                    name: Negative
                     description: ''
               - !<!ChoiceValue> 
                 value: mixed
                 language:
                   default:
-                    name: mixed
+                    name: Mixed
                     description: ''
               type: sealed-choice
               apiVersions:
@@ -1715,7 +1641,6 @@ schemas: !<!Schemas>
               default:
                 name: sentiment
                 description: 'Predicted sentiment for document (Negative, Neutral, Positive, or Mixed).'
-                originalName: sentiment
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: *ref_6
@@ -1725,7 +1650,6 @@ schemas: !<!Schemas>
               default:
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
-                originalName: statistics
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_16
@@ -1740,7 +1664,7 @@ schemas: !<!Schemas>
                   precision: 64
                   language: !<!Languages> 
                     default:
-                      name: typeForpositive
+                      name: TypeForpositive
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
@@ -1749,7 +1673,6 @@ schemas: !<!Schemas>
                   default:
                     name: positive
                     description: ''
-                    originalName: positive
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!NumberSchema> &ref_54
@@ -1757,7 +1680,7 @@ schemas: !<!Schemas>
                   precision: 64
                   language: !<!Languages> 
                     default:
-                      name: typeForneutral
+                      name: TypeForneutral
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
@@ -1766,7 +1689,6 @@ schemas: !<!Schemas>
                   default:
                     name: neutral
                     description: ''
-                    originalName: neutral
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!NumberSchema> &ref_55
@@ -1774,7 +1696,7 @@ schemas: !<!Schemas>
                   precision: 64
                   language: !<!Languages> 
                     default:
-                      name: typeFornegative
+                      name: TypeFornegative
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
@@ -1783,7 +1705,6 @@ schemas: !<!Schemas>
                   default:
                     name: negative
                     description: ''
-                    originalName: negative
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -1797,7 +1718,6 @@ schemas: !<!Schemas>
               default:
                 name: documentScores
                 description: 'Represents the confidence scores between 0 and 1 across all sentiment classes: positive, neutral, negative.'
-                originalName: documentScores
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ArraySchema> &ref_37
@@ -1818,19 +1738,19 @@ schemas: !<!Schemas>
                       value: positive
                       language:
                         default:
-                          name: positive
+                          name: Positive
                           description: ''
                     - !<!ChoiceValue> 
                       value: neutral
                       language:
                         default:
-                          name: neutral
+                          name: Neutral
                           description: ''
                     - !<!ChoiceValue> 
                       value: negative
                       language:
                         default:
-                          name: negative
+                          name: Negative
                           description: ''
                     type: sealed-choice
                     apiVersions:
@@ -1848,7 +1768,6 @@ schemas: !<!Schemas>
                     default:
                       name: sentiment
                       description: The predicted Sentiment for the sentence.
-                      originalName: sentiment
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: *ref_16
@@ -1858,7 +1777,6 @@ schemas: !<!Schemas>
                     default:
                       name: sentenceScores
                       description: 'Represents the confidence scores between 0 and 1 across all sentiment classes: positive, neutral, negative.'
-                      originalName: sentenceScores
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!NumberSchema> &ref_56
@@ -1866,7 +1784,7 @@ schemas: !<!Schemas>
                     precision: 32
                     language: !<!Languages> 
                       default:
-                        name: typeForoffset
+                        name: TypeForoffset
                         description: The sentence offset from the start of the document.
                     protocol: !<!Protocols> {}
                   required: true
@@ -1875,7 +1793,6 @@ schemas: !<!Schemas>
                     default:
                       name: offset
                       description: The sentence offset from the start of the document.
-                      originalName: offset
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!NumberSchema> &ref_57
@@ -1883,7 +1800,7 @@ schemas: !<!Schemas>
                     precision: 32
                     language: !<!Languages> 
                       default:
-                        name: typeForlength
+                        name: TypeForlength
                         description: The length of the sentence by Unicode standard.
                     protocol: !<!Protocols> {}
                   required: true
@@ -1892,7 +1809,6 @@ schemas: !<!Schemas>
                     default:
                       name: length
                       description: The length of the sentence by Unicode standard.
-                      originalName: length
                   protocol: !<!Protocols> {}
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_36
@@ -1907,12 +1823,12 @@ schemas: !<!Schemas>
                         version: v3.0-preview.1
                       language: !<!Languages> 
                         default:
-                          name: SentenceSentiment-warningsItem
+                          name: SentenceSentimentWarningsItem
                           description: ''
                       protocol: !<!Protocols> {}
                     language: !<!Languages> 
                       default:
-                        name: SentenceSentiment-warnings
+                        name: SentenceSentimentWarnings
                         description: The warnings generated for the sentence.
                     protocol: !<!Protocols> {}
                   required: false
@@ -1921,7 +1837,6 @@ schemas: !<!Schemas>
                     default:
                       name: warnings
                       description: The warnings generated for the sentence.
-                      originalName: warnings
                   protocol: !<!Protocols> {}
                 language: !<!Languages> 
                   default:
@@ -1931,7 +1846,7 @@ schemas: !<!Schemas>
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: DocumentSentiment-sentences
+                  name: DocumentSentimentSentences
                   description: Sentence level sentiment analysis.
               protocol: !<!Protocols> {}
             required: true
@@ -1940,7 +1855,6 @@ schemas: !<!Schemas>
               default:
                 name: sentences
                 description: Sentence level sentiment analysis.
-                originalName: sentences
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -1950,7 +1864,7 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: SentimentResponse-documents
+            name: SentimentResponseDocuments
             description: Sentiment analysis per document.
         protocol: !<!Protocols> {}
       required: true
@@ -1959,7 +1873,6 @@ schemas: !<!Schemas>
         default:
           name: documents
           description: Sentiment analysis per document.
-          originalName: documents
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_39
@@ -1970,7 +1883,7 @@ schemas: !<!Schemas>
         elementType: *ref_7
         language: !<!Languages> 
           default:
-            name: SentimentResponse-errors
+            name: SentimentResponseErrors
             description: Errors by document id.
         protocol: !<!Protocols> {}
       required: true
@@ -1979,7 +1892,6 @@ schemas: !<!Schemas>
         default:
           name: errors
           description: Errors by document id.
-          originalName: errors
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_8
@@ -1989,7 +1901,6 @@ schemas: !<!Schemas>
         default:
           name: statistics
           description: if showStats=true was specified in the request this field will contain information about the request payload.
-          originalName: statistics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_96
@@ -1999,7 +1910,7 @@ schemas: !<!Schemas>
           version: v3.0-preview.1
         language: !<!Languages> 
           default:
-            name: SentimentResponse-modelVersion
+            name: SentimentResponseModelVersion
             description: This field indicates which model is used for scoring.
         protocol: !<!Protocols> {}
       required: true
@@ -2008,7 +1919,6 @@ schemas: !<!Schemas>
         default:
           name: modelVersion
           description: This field indicates which model is used for scoring.
-          originalName: modelVersion
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -2050,7 +1960,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_108
@@ -2060,7 +1970,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_114
@@ -2070,7 +1980,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_121
@@ -2080,7 +1990,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_128
@@ -2090,7 +2000,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_137
@@ -2100,7 +2010,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   numbers:
@@ -2136,7 +2046,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_62
@@ -2160,7 +2070,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_113
@@ -2170,7 +2080,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_76
@@ -2188,7 +2098,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_84
@@ -2201,7 +2111,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_87
@@ -2218,7 +2128,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_94
@@ -2231,7 +2141,7 @@ schemas: !<!Schemas>
       version: v3.0-preview.1
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
 globalParameters:
@@ -2280,7 +2190,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: model-version
+            name: modelVersion
             description: '(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. '
             serializedName: model-version
         protocol: !<!Protocols> 
@@ -2450,7 +2360,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: model-version
+            name: modelVersion
             description: '(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. '
             serializedName: model-version
         protocol: !<!Protocols> 
@@ -2611,7 +2521,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: model-version
+            name: modelVersion
             description: '(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. '
             serializedName: model-version
         protocol: !<!Protocols> 
@@ -2782,7 +2692,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: model-version
+            name: modelVersion
             description: '(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. '
             serializedName: model-version
         protocol: !<!Protocols> 
@@ -2929,7 +2839,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: model-version
+            name: modelVersion
             description: '(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. '
             serializedName: model-version
         protocol: !<!Protocols> 
@@ -3079,7 +2989,7 @@ operationGroups:
         implementation: Method
         language: !<!Languages> 
           default:
-            name: model-version
+            name: modelVersion
             description: '(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. '
             serializedName: model-version
         protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_2
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -60,13 +58,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: get-0-itemsItem
+          name: Get0ItemsItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of get-0-itemsItem
-        description: ''
+        name: ArrayOfGet0ItemsItem
+        description: Array of Get0ItemsItem
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_9
     type: array
@@ -80,13 +78,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of string
-        description: ''
+        name: ArrayOfString
+        description: Array of String
     protocol: !<!Protocols> {}
   numbers:
   - *ref_0
@@ -95,7 +93,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - *ref_1
@@ -303,7 +301,7 @@ operationGroups:
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: queries
+      name: Queries
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/url/namer.yaml
+++ b/modelerfour/test/scenarios/url/namer.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -21,7 +21,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_25
@@ -31,7 +30,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -39,7 +38,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -60,13 +58,13 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: get-0-itemsItem
+          name: Get0ItemsItem
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of get-0-itemsItem
-        description: ''
+        name: ArrayOfGet0ItemsItem
+        description: Array of Get0ItemsItem
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_97
     type: array
@@ -80,20 +78,20 @@ schemas: !<!Schemas>
         version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Array of string
-        description: ''
+        name: ArrayOfString
+        description: Array of String
     protocol: !<!Protocols> {}
   booleans:
   - !<!BooleanSchema> &ref_0
     type: boolean
     language: !<!Languages> 
       default:
-        name: bool
+        name: Bool
         description: simple boolean
     protocol: !<!Protocols> {}
   - !<!BooleanSchema> &ref_66
@@ -103,7 +101,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: boolean
+        name: Boolean
         description: ''
     protocol: !<!Protocols> {}
   byteArrays:
@@ -115,7 +113,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_2
@@ -123,7 +121,7 @@ schemas: !<!Schemas>
     format: byte
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_58
@@ -134,7 +132,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   - !<!ByteArraySchema> &ref_3
@@ -142,7 +140,7 @@ schemas: !<!Schemas>
     format: byte
     language: !<!Languages> 
       default:
-        name: byte-array
+        name: ByteArray
         description: ''
     protocol: !<!Protocols> {}
   constants:
@@ -157,7 +155,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant0
+        name: Constant1
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_31
@@ -171,7 +169,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant1
+        name: Constant2
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_32
@@ -187,12 +185,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant2
+        name: Constant3
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_33
@@ -208,12 +206,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant3
+        name: Constant4
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_34
@@ -229,12 +227,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant4
+        name: Constant5
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_35
@@ -250,12 +248,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant5
+        name: Constant6
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_36
@@ -271,12 +269,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant6
+        name: Constant7
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_37
@@ -292,12 +290,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant7
+        name: Constant8
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_38
@@ -313,12 +311,12 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant8
+        name: Constant9
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_39
@@ -334,12 +332,12 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant9
+        name: Constant10
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_40
@@ -354,12 +352,12 @@ schemas: !<!Schemas>
       type: string
       language: !<!Languages> 
         default:
-          name: string
+          name: String
           description: simple string
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant10
+        name: Constant11
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_41
@@ -373,7 +371,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: Constant11
+        name: Constant12
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_42
@@ -387,7 +385,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: Constant12
+        name: Constant13
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_43
@@ -401,7 +399,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: Constant13
+        name: Constant14
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_50
@@ -415,7 +413,7 @@ schemas: !<!Schemas>
     valueType: *ref_2
     language: !<!Languages> 
       default:
-        name: Constant14
+        name: Constant15
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_52
@@ -430,12 +428,12 @@ schemas: !<!Schemas>
       type: date
       language: !<!Languages> 
         default:
-          name: date
+          name: Date
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant15
+        name: Constant16
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_55
@@ -451,12 +449,12 @@ schemas: !<!Schemas>
       format: date-time
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant16
+        name: Constant17
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_64
@@ -470,7 +468,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant17
+        name: Constant18
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_65
@@ -484,7 +482,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant18
+        name: Constant19
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_68
@@ -500,12 +498,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant19
+        name: Constant20
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_69
@@ -521,12 +519,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant20
+        name: Constant21
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_72
@@ -542,12 +540,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant21
+        name: Constant22
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_73
@@ -563,12 +561,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant22
+        name: Constant23
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_76
@@ -584,12 +582,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant23
+        name: Constant24
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_77
@@ -605,12 +603,12 @@ schemas: !<!Schemas>
       precision: 32
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant24
+        name: Constant25
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_80
@@ -626,12 +624,12 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant25
+        name: Constant26
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_81
@@ -647,12 +645,12 @@ schemas: !<!Schemas>
       precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: Number
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant26
+        name: Constant27
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_84
@@ -666,7 +664,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: Constant27
+        name: Constant28
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_85
@@ -680,7 +678,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: Constant28
+        name: Constant29
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_86
@@ -694,7 +692,7 @@ schemas: !<!Schemas>
     valueType: *ref_1
     language: !<!Languages> 
       default:
-        name: Constant29
+        name: Constant30
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_91
@@ -708,7 +706,7 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant30
+        name: Constant31
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_93
@@ -723,12 +721,12 @@ schemas: !<!Schemas>
       type: date
       language: !<!Languages> 
         default:
-          name: date
+          name: Date
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant31
+        name: Constant32
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_95
@@ -744,12 +742,12 @@ schemas: !<!Schemas>
       format: date-time
       language: !<!Languages> 
         default:
-          name: date-time
+          name: DateTime
           description: ''
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: Constant32
+        name: Constant33
         description: ''
     protocol: !<!Protocols> {}
   dateTimes:
@@ -762,7 +760,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: date-time
+        name: DateTime
         description: ''
     protocol: !<!Protocols> {}
   - *ref_5
@@ -775,7 +773,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: date
+        name: Date
         description: ''
     protocol: !<!Protocols> {}
   - *ref_7
@@ -799,7 +797,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_19
@@ -812,7 +810,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_21
@@ -825,7 +823,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   - *ref_23
@@ -838,7 +836,7 @@ schemas: !<!Schemas>
     precision: 64
     language: !<!Languages> 
       default:
-        name: number
+        name: Number
         description: ''
     protocol: !<!Protocols> {}
   sealedChoices:
@@ -848,19 +846,19 @@ schemas: !<!Schemas>
       value: red color
       language:
         default:
-          name: red color
+          name: RedColor
           description: ''
     - !<!ChoiceValue> 
       value: green color
       language:
         default:
-          name: green color
+          name: GreenColor
           description: ''
     - !<!ChoiceValue> 
       value: blue color
       language:
         default:
-          name: blue color
+          name: BlueColor
           description: ''
     type: sealed-choice
     apiVersions:
@@ -885,7 +883,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: unixtime
+        name: Unixtime
         description: 'date in seconds since 1970-01-01T00:00:00Z.'
     protocol: !<!Protocols> {}
 globalParameters:
@@ -993,7 +991,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanTrue
+        name: GetBooleanTrue
         description: Get true Boolean value on path
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1051,7 +1049,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanFalse
+        name: GetBooleanFalse
         description: Get false Boolean value on path
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1109,7 +1107,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntOneMillion
+        name: GetIntOneMillion
         description: Get '1000000' integer value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1167,7 +1165,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntNegativeOneMillion
+        name: GetIntNegativeOneMillion
         description: Get '-1000000' integer value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1225,7 +1223,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getTenBillion
+        name: GetTenBillion
         description: Get '10000000000' 64 bit integer value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1283,7 +1281,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNegativeTenBillion
+        name: GetNegativeTenBillion
         description: Get '-10000000000' 64 bit integer value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1341,7 +1339,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: floatScientificPositive
+        name: FloatScientificPositive
         description: Get '1.034E+20' numeric value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1399,7 +1397,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: floatScientificNegative
+        name: FloatScientificNegative
         description: Get '-1.034E-20' numeric value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1457,7 +1455,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: doubleDecimalPositive
+        name: DoubleDecimalPositive
         description: Get '9999999.999' numeric value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1515,7 +1513,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: doubleDecimalNegative
+        name: DoubleDecimalNegative
         description: Get '-9999999.999' numeric value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1573,7 +1571,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringUnicode
+        name: StringUnicode
         description: Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1631,7 +1629,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringUrlEncoded
+        name: StringUrlEncoded
         description: 'Get ''begin!*''();:@ &=+$,/?#[]end'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1691,7 +1689,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringUrlNonEncoded
+        name: StringUrlNonEncoded
         description: 'Get ''begin!*''();:@&=+$,end'
         summary: 'https://tools.ietf.org/html/rfc3986#appendix-A ''path'' accept any ''pchar'' not encoded'
     protocol: !<!Protocols> {}
@@ -1750,7 +1748,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringEmpty
+        name: StringEmpty
         description: Get ''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1809,7 +1807,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringNull
+        name: StringNull
         description: Get null (should throw)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1868,7 +1866,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: enumValid
+        name: EnumValid
         description: Get using uri with 'green color' in path parameter
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1927,7 +1925,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: enumNull
+        name: EnumNull
         description: Get null (should throw on the client before the request is sent on wire)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -1986,7 +1984,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: byteMultiByte
+        name: ByteMultiByte
         description: Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2044,7 +2042,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: byteEmpty
+        name: ByteEmpty
         description: Get '' as byte array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2103,7 +2101,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: byteNull
+        name: ByteNull
         description: Get null as byte array (should throw)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2396,7 +2394,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: base64Url
+        name: Base64Url
         description: Get 'lorem' encoded value as 'bG9yZW0' (base64url)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2515,12 +2513,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: unixTimeUrl
+        name: UnixTimeUrl
         description: Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: paths
+      name: Paths
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -2581,7 +2579,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanTrue
+        name: GetBooleanTrue
         description: Get true Boolean value on path
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2639,7 +2637,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanFalse
+        name: GetBooleanFalse
         description: Get false Boolean value on path
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2697,7 +2695,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getBooleanNull
+        name: GetBooleanNull
         description: Get null Boolean value on query (query string should be absent)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2755,7 +2753,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntOneMillion
+        name: GetIntOneMillion
         description: Get '1000000' integer value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2813,7 +2811,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntNegativeOneMillion
+        name: GetIntNegativeOneMillion
         description: Get '-1000000' integer value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2871,7 +2869,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getIntNull
+        name: GetIntNull
         description: Get null integer value (no query parameter)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2929,7 +2927,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getTenBillion
+        name: GetTenBillion
         description: Get '10000000000' 64 bit integer value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2987,7 +2985,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getNegativeTenBillion
+        name: GetNegativeTenBillion
         description: Get '-10000000000' 64 bit integer value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3045,7 +3043,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLongNull
+        name: GetLongNull
         description: Get 'null 64 bit integer value (no query param in uri)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3103,7 +3101,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: floatScientificPositive
+        name: FloatScientificPositive
         description: Get '1.034E+20' numeric value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3161,7 +3159,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: floatScientificNegative
+        name: FloatScientificNegative
         description: Get '-1.034E-20' numeric value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3219,7 +3217,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: floatNull
+        name: FloatNull
         description: Get null numeric value (no query parameter)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3277,7 +3275,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: doubleDecimalPositive
+        name: DoubleDecimalPositive
         description: Get '9999999.999' numeric value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3335,7 +3333,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: doubleDecimalNegative
+        name: DoubleDecimalNegative
         description: Get '-9999999.999' numeric value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3393,7 +3391,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: doubleNull
+        name: DoubleNull
         description: Get null numeric value (no query parameter)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3451,7 +3449,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringUnicode
+        name: StringUnicode
         description: Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3509,7 +3507,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringUrlEncoded
+        name: StringUrlEncoded
         description: 'Get ''begin!*''();:@ &=+$,/?#[]end'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3567,7 +3565,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringEmpty
+        name: StringEmpty
         description: Get ''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3625,7 +3623,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: stringNull
+        name: StringNull
         description: Get null (no query parameter in url)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3683,7 +3681,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: enumValid
+        name: EnumValid
         description: Get using uri with query parameter 'green color'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3741,7 +3739,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: enumNull
+        name: EnumNull
         description: Get null (no query parameter in url)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3799,7 +3797,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: byteMultiByte
+        name: ByteMultiByte
         description: Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3857,7 +3855,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: byteEmpty
+        name: ByteEmpty
         description: Get '' as byte array
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3915,7 +3913,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: byteNull
+        name: ByteNull
         description: Get null as byte array (no query parameters in uri)
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4506,7 +4504,7 @@ operationGroups:
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: queries
+      name: Queries
       description: ''
   protocol: !<!Protocols> {}
 - !<!OperationGroup> 
@@ -4607,7 +4605,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getAllWithValues
+        name: GetAllWithValues
         description: >-
           send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery',
           localStringQuery='localStringQuery'
@@ -4707,7 +4705,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getGlobalQueryNull
+        name: GetGlobalQueryNull
         description: 'send globalStringPath=''globalStringPath'', pathItemStringPath=''pathItemStringPath'', localStringPath=''localStringPath'', globalStringQuery=null, pathItemStringQuery=''pathItemStringQuery'', localStringQuery=''localStringQuery'''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4805,7 +4803,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getGlobalAndLocalQueryNull
+        name: GetGlobalAndLocalQueryNull
         description: 'send globalStringPath=globalStringPath, pathItemStringPath=''pathItemStringPath'', localStringPath=''localStringPath'', globalStringQuery=null, pathItemStringQuery=''pathItemStringQuery'', localStringQuery=null'
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4903,12 +4901,12 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getLocalPathItemQueryNull
+        name: GetLocalPathItemQueryNull
         description: 'send globalStringPath=''globalStringPath'', pathItemStringPath=''pathItemStringPath'', localStringPath=''localStringPath'', globalStringQuery=''globalStringQuery'', pathItemStringQuery=null, localStringQuery=null'
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: pathItems
+      name: PathItems
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/validation/namer.yaml
+++ b/modelerfour/test/scenarios/validation/namer.yaml
@@ -20,14 +20,14 @@ schemas: !<!Schemas>
             version: 1.0.0
           language: !<!Languages> 
             default:
-              name: Product-display_namesItem
+              name: ProductDisplayNamesItem
               description: ''
           protocol: !<!Protocols> {}
         maxItems: 6
         uniqueItems: true
         language: !<!Languages> 
           default:
-            name: Product-display_names
+            name: ProductDisplayNames
             description: Non required array of unique items from 0 to 6 elements.
         protocol: !<!Protocols> {}
       required: false
@@ -36,7 +36,6 @@ schemas: !<!Schemas>
         default:
           name: displayNames
           description: Non required array of unique items from 0 to 6 elements.
-          originalName: display_names
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!NumberSchema> &ref_10
@@ -48,7 +47,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForcapacity
+            name: TypeForcapacity
             description: Non required int betwen 0 and 100 exclusive.
         protocol: !<!Protocols> {}
       required: false
@@ -57,7 +56,6 @@ schemas: !<!Schemas>
         default:
           name: capacity
           description: Non required int betwen 0 and 100 exclusive.
-          originalName: capacity
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_15
@@ -68,7 +66,7 @@ schemas: !<!Schemas>
         pattern: 'http://\w+'
         language: !<!Languages> 
           default:
-            name: Product-image
+            name: ProductImage
             description: Image URL representing the product.
         protocol: !<!Protocols> {}
       required: false
@@ -77,7 +75,6 @@ schemas: !<!Schemas>
         default:
           name: image
           description: Image URL representing the product.
-          originalName: image
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_1
@@ -102,12 +99,12 @@ schemas: !<!Schemas>
               type: string
               language: !<!Languages> 
                 default:
-                  name: string
+                  name: String
                   description: simple string
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: ChildProduct-constProperty
+                name: ChildProductConstProperty
                 description: Constant string
             protocol: !<!Protocols> {}
           required: true
@@ -116,7 +113,6 @@ schemas: !<!Schemas>
             default:
               name: constProperty
               description: Constant string
-              originalName: constProperty
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!NumberSchema> &ref_11
@@ -124,7 +120,7 @@ schemas: !<!Schemas>
             precision: 32
             language: !<!Languages> 
               default:
-                name: typeForcount
+                name: TypeForcount
                 description: Count
             protocol: !<!Protocols> {}
           required: false
@@ -133,7 +129,6 @@ schemas: !<!Schemas>
             default:
               name: count
               description: Count
-              originalName: count
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -147,7 +142,6 @@ schemas: !<!Schemas>
         default:
           name: child
           description: The product documentation.
-          originalName: child
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_2
@@ -171,7 +165,7 @@ schemas: !<!Schemas>
             valueType: *ref_0
             language: !<!Languages> 
               default:
-                name: ConstantProduct-constProperty
+                name: ConstantProductConstProperty
                 description: Constant string
             protocol: !<!Protocols> {}
           required: true
@@ -180,7 +174,6 @@ schemas: !<!Schemas>
             default:
               name: constProperty
               description: Constant string
-              originalName: constProperty
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ConstantSchema> &ref_6
@@ -197,7 +190,7 @@ schemas: !<!Schemas>
             valueType: *ref_0
             language: !<!Languages> 
               default:
-                name: ConstantProduct-constProperty2
+                name: ConstantProductConstProperty2
                 description: Constant string2
             protocol: !<!Protocols> {}
           required: true
@@ -206,7 +199,6 @@ schemas: !<!Schemas>
             default:
               name: constProperty2
               description: Constant string2
-              originalName: constProperty2
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -220,7 +212,6 @@ schemas: !<!Schemas>
         default:
           name: constChild
           description: The product documentation.
-          originalName: constChild
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ConstantSchema> &ref_7
@@ -236,12 +227,12 @@ schemas: !<!Schemas>
           precision: 32
           language: !<!Languages> 
             default:
-              name: number
+              name: Number
               description: Constant int
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: typeForconstInt
+            name: TypeForconstInt
             description: Constant int
         protocol: !<!Protocols> {}
       required: true
@@ -250,7 +241,6 @@ schemas: !<!Schemas>
         default:
           name: constInt
           description: Constant int
-          originalName: constInt
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ConstantSchema> &ref_8
@@ -267,7 +257,7 @@ schemas: !<!Schemas>
         valueType: *ref_0
         language: !<!Languages> 
           default:
-            name: Product-constString
+            name: ProductConstString
             description: Constant string
         protocol: !<!Protocols> {}
       required: true
@@ -276,7 +266,6 @@ schemas: !<!Schemas>
         default:
           name: constString
           description: Constant string
-          originalName: constString
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ConstantSchema> &ref_9
@@ -302,7 +291,6 @@ schemas: !<!Schemas>
         default:
           name: constStringAsEnum
           description: Constant string as Enum
-          originalName: constStringAsEnum
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -324,7 +312,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForcode
+            name: TypeForcode
             description: ''
         protocol: !<!Protocols> {}
       serializedName: code
@@ -332,7 +320,6 @@ schemas: !<!Schemas>
         default:
           name: code
           description: ''
-          originalName: code
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_16
@@ -342,7 +329,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -350,7 +337,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_17
@@ -360,7 +346,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-fields
+            name: ErrorFields
             description: ''
         protocol: !<!Protocols> {}
       serializedName: fields
@@ -368,7 +354,6 @@ schemas: !<!Schemas>
         default:
           name: fields
           description: ''
-          originalName: fields
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -390,7 +375,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-1.0.0
+        name: ApiVersion10
         description: Api Version (1.0.0)
     protocol: !<!Protocols> {}
   - *ref_4
@@ -410,7 +395,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: ApiVersion-1.0.0
+        name: ApiVersion10
         description: Api Version (1.0.0)
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_32
@@ -424,7 +409,7 @@ schemas: !<!Schemas>
     valueType: *ref_0
     language: !<!Languages> 
       default:
-        name: Constant0
+        name: Constant8
         description: ''
     protocol: !<!Protocols> {}
   numbers:
@@ -439,7 +424,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   - *ref_10
@@ -455,7 +440,7 @@ schemas: !<!Schemas>
       version: 1.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_22
@@ -468,7 +453,7 @@ schemas: !<!Schemas>
     pattern: '[a-zA-Z0-9]+'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_14
@@ -483,7 +468,7 @@ schemas: !<!Schemas>
     pattern: '\d{2}-\d{2}-\d{4}'
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
 globalParameters:
@@ -610,7 +595,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: validationOfMethodParameters
+        name: ValidationOfMethodParameters
         description: Validates input parameters on the method. See swagger for details.
         summary: ''
     protocol: !<!Protocols> {}
@@ -708,7 +693,7 @@ operationGroups:
       x-ms-requestBody-index: 3
     language: !<!Languages> 
       default:
-        name: validationOfBody
+        name: ValidationOfBody
         description: Validates body parameters on the method. See swagger for details.
         summary: ''
     protocol: !<!Protocols> {}
@@ -753,7 +738,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getWithConstantInPath
+        name: GetWithConstantInPath
         description: ''
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -820,7 +805,7 @@ operationGroups:
       x-ms-requestBody-index: 1
     language: !<!Languages> 
       default:
-        name: postWithConstantInBody
+        name: PostWithConstantInBody
         description: ''
     protocol: !<!Protocols> {}
   language: !<!Languages> 

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -22,15 +22,14 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: ComplexTypeNoMeta-ID
+                name: ComplexTypeNoMetaId
                 description: The id of the res
             protocol: !<!Protocols> {}
           serializedName: ID
           language: !<!Languages> 
             default:
-              name: ID
+              name: id
               description: The id of the res
-              originalName: ID
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -41,9 +40,8 @@ schemas: !<!Schemas>
       serializedName: RefToModel
       language: !<!Languages> 
         default:
-          name: RefToModel
+          name: refToModel
           description: I am a complex type with no XML node
-          originalName: RefToModel
       protocol: !<!Protocols> {}
     - !<!Property> &ref_117
       schema: !<!StringSchema> &ref_62
@@ -53,15 +51,14 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: RootWithRefAndNoMeta-Something
+            name: RootWithRefAndNoMetaSomething
             description: Something else (just to avoid flattening)
         protocol: !<!Protocols> {}
       serializedName: Something
       language: !<!Languages> 
         default:
-          name: Something
+          name: something
           description: Something else (just to avoid flattening)
-          originalName: Something
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -91,15 +88,14 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: ComplexTypeWithMeta-ID
+                name: ComplexTypeWithMetaId
                 description: The id of the res
             protocol: !<!Protocols> {}
           serializedName: ID
           language: !<!Languages> 
             default:
-              name: ID
+              name: id
               description: The id of the res
-              originalName: ID
           protocol: !<!Protocols> {}
         serialization:
           xml:
@@ -115,9 +111,8 @@ schemas: !<!Schemas>
       serializedName: RefToModel
       language: !<!Languages> 
         default:
-          name: RefToModel
+          name: refToModel
           description: I am a complex type with XML node
-          originalName: RefToModel
       protocol: !<!Protocols> {}
     - !<!Property> &ref_123
       schema: !<!StringSchema> &ref_64
@@ -127,15 +122,14 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: RootWithRefAndMeta-Something
+            name: RootWithRefAndMetaSomething
             description: Something else (just to avoid flattening)
         protocol: !<!Protocols> {}
       serializedName: Something
       language: !<!Languages> 
         default:
-          name: Something
+          name: something
           description: Something else (just to avoid flattening)
-          originalName: Something
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -162,7 +156,7 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: Slideshow-title
+            name: SlideshowTitle
             description: ''
         protocol: !<!Protocols> {}
       serializedName: title
@@ -170,7 +164,6 @@ schemas: !<!Schemas>
         default:
           name: title
           description: ''
-          originalName: title
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_66
@@ -184,7 +177,7 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: Slideshow-date
+            name: SlideshowDate
             description: ''
         protocol: !<!Protocols> {}
       serializedName: date
@@ -192,7 +185,6 @@ schemas: !<!Schemas>
         default:
           name: date
           description: ''
-          originalName: date
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_67
@@ -206,7 +198,7 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: Slideshow-author
+            name: SlideshowAuthor
             description: ''
         protocol: !<!Protocols> {}
       serializedName: author
@@ -214,7 +206,6 @@ schemas: !<!Schemas>
         default:
           name: author
           description: ''
-          originalName: author
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_23
@@ -240,7 +231,7 @@ schemas: !<!Schemas>
                   wrapped: false
               language: !<!Languages> 
                 default:
-                  name: Slide-type
+                  name: SlideType
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: type
@@ -248,7 +239,6 @@ schemas: !<!Schemas>
               default:
                 name: type
                 description: ''
-                originalName: type
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_69
@@ -258,7 +248,7 @@ schemas: !<!Schemas>
                 version: 1.0.0
               language: !<!Languages> 
                 default:
-                  name: Slide-title
+                  name: SlideTitle
                   description: ''
               protocol: !<!Protocols> {}
             serializedName: title
@@ -266,7 +256,6 @@ schemas: !<!Schemas>
               default:
                 name: title
                 description: ''
-                originalName: title
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ArraySchema> &ref_22
@@ -286,20 +275,19 @@ schemas: !<!Schemas>
                     wrapped: false
                 language: !<!Languages> 
                   default:
-                    name: Slide-itemsItem
+                    name: SlideItemsItem
                     description: ''
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: Slide-items
-                  description: ''
+                  name: SlideItems
+                  description: Array of SlideItemsItem
               protocol: !<!Protocols> {}
             serializedName: items
             language: !<!Languages> 
               default:
                 name: items
                 description: ''
-                originalName: items
             protocol: !<!Protocols> {}
           serialization:
             xml:
@@ -314,15 +302,14 @@ schemas: !<!Schemas>
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
-            name: Slideshow-slides
-            description: ''
+            name: SlideshowSlides
+            description: Array of Slide
         protocol: !<!Protocols> {}
       serializedName: slides
       language: !<!Languages> 
         default:
           name: slides
           description: ''
-          originalName: slides
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -348,7 +335,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForstatus
+            name: TypeForstatus
             description: ''
         protocol: !<!Protocols> {}
       serializedName: status
@@ -356,7 +343,6 @@ schemas: !<!Schemas>
         default:
           name: status
           description: ''
-          originalName: status
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_71
@@ -366,7 +352,7 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: Error-message
+            name: ErrorMessage
             description: ''
         protocol: !<!Protocols> {}
       serializedName: message
@@ -374,7 +360,6 @@ schemas: !<!Schemas>
         default:
           name: message
           description: ''
-          originalName: message
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -406,7 +391,7 @@ schemas: !<!Schemas>
               wrapped: false
           language: !<!Languages> 
             default:
-              name: AppleBarrel-GoodApplesItem
+              name: AppleBarrelGoodApplesItem
               description: ''
           protocol: !<!Protocols> {}
         serialization:
@@ -415,15 +400,14 @@ schemas: !<!Schemas>
             wrapped: true
         language: !<!Languages> 
           default:
-            name: AppleBarrel-GoodApples
-            description: ''
+            name: AppleBarrelGoodApples
+            description: Array of AppleBarrelGoodApplesItem
         protocol: !<!Protocols> {}
       serializedName: GoodApples
       language: !<!Languages> 
         default:
-          name: GoodApples
+          name: goodApples
           description: ''
-          originalName: GoodApples
       protocol: !<!Protocols> {}
     - !<!Property> &ref_132
       schema: !<!ArraySchema> &ref_25
@@ -443,7 +427,7 @@ schemas: !<!Schemas>
               wrapped: false
           language: !<!Languages> 
             default:
-              name: AppleBarrel-BadApplesItem
+              name: AppleBarrelBadApplesItem
               description: ''
           protocol: !<!Protocols> {}
         serialization:
@@ -452,15 +436,14 @@ schemas: !<!Schemas>
             wrapped: true
         language: !<!Languages> 
           default:
-            name: AppleBarrel-BadApples
-            description: ''
+            name: AppleBarrelBadApples
+            description: Array of AppleBarrelBadApplesItem
         protocol: !<!Protocols> {}
       serializedName: BadApples
       language: !<!Languages> 
         default:
-          name: BadApples
+          name: badApples
           description: ''
-          originalName: BadApples
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -487,7 +470,7 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: Banana-name
+            name: BananaName
             description: ''
         protocol: !<!Protocols> {}
       serializedName: name
@@ -495,7 +478,6 @@ schemas: !<!Schemas>
         default:
           name: name
           description: ''
-          originalName: name
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_76
@@ -510,7 +492,7 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: Banana-flavor
+            name: BananaFlavor
             description: ''
         protocol: !<!Protocols> {}
       serializedName: flavor
@@ -518,7 +500,6 @@ schemas: !<!Schemas>
         default:
           name: flavor
           description: ''
-          originalName: flavor
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!DateTimeSchema> &ref_42
@@ -534,7 +515,7 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: Banana-expiration
+            name: BananaExpiration
             description: The time at which you should reconsider eating this banana
         protocol: !<!Protocols> {}
       serializedName: expiration
@@ -542,7 +523,6 @@ schemas: !<!Schemas>
         default:
           name: expiration
           description: The time at which you should reconsider eating this banana
-          originalName: expiration
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -573,16 +553,15 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: ListContainersResponse-ServiceEndpoint
+            name: ListContainersResponseServiceEndpoint
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: ServiceEndpoint
       language: !<!Languages> 
         default:
-          name: ServiceEndpoint
+          name: serviceEndpoint
           description: ''
-          originalName: ServiceEndpoint
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_78
@@ -592,16 +571,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ListContainersResponse-Prefix
+            name: ListContainersResponsePrefix
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: Prefix
       language: !<!Languages> 
         default:
-          name: Prefix
+          name: prefix
           description: ''
-          originalName: Prefix
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_79
@@ -611,16 +589,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ListContainersResponse-Marker
+            name: ListContainersResponseMarker
             description: ''
         protocol: !<!Protocols> {}
       required: false
       serializedName: Marker
       language: !<!Languages> 
         default:
-          name: Marker
+          name: marker
           description: ''
-          originalName: Marker
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!NumberSchema> &ref_50
@@ -628,16 +605,15 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForMaxResults
+            name: TypeForMaxResults
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: MaxResults
       language: !<!Languages> 
         default:
-          name: MaxResults
+          name: maxResults
           description: ''
-          originalName: MaxResults
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_27
@@ -659,16 +635,15 @@ schemas: !<!Schemas>
                 version: 1.0.0
               language: !<!Languages> 
                 default:
-                  name: Container-Name
+                  name: ContainerName
                   description: ''
               protocol: !<!Protocols> {}
             required: true
             serializedName: Name
             language: !<!Languages> 
               default:
-                name: Name
+                name: name
                 description: ''
-                originalName: Name
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_5
@@ -686,7 +661,7 @@ schemas: !<!Schemas>
                     version: 1.0.0
                   language: !<!Languages> 
                     default:
-                      name: ContainerProperties-Last-Modified
+                      name: ContainerPropertiesLastModified
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
@@ -695,7 +670,6 @@ schemas: !<!Schemas>
                   default:
                     name: lastModified
                     description: ''
-                    originalName: Last-Modified
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_81
@@ -705,16 +679,15 @@ schemas: !<!Schemas>
                     version: 1.0.0
                   language: !<!Languages> 
                     default:
-                      name: ContainerProperties-Etag
+                      name: ContainerPropertiesEtag
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Etag
                 language: !<!Languages> 
                   default:
-                    name: Etag
+                    name: etag
                     description: ''
-                    originalName: Etag
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!SealedChoiceSchema> &ref_11
@@ -723,13 +696,13 @@ schemas: !<!Schemas>
                     value: locked
                     language:
                       default:
-                        name: locked
+                        name: Locked
                         description: ''
                   - !<!ChoiceValue> 
                     value: unlocked
                     language:
                       default:
-                        name: unlocked
+                        name: Unlocked
                         description: ''
                   type: sealed-choice
                   apiVersions:
@@ -739,7 +712,7 @@ schemas: !<!Schemas>
                     type: string
                     language: !<!Languages> 
                       default:
-                        name: string
+                        name: String
                         description: simple string
                     protocol: !<!Protocols> {}
                   language: !<!Languages> 
@@ -751,9 +724,8 @@ schemas: !<!Schemas>
                 serializedName: LeaseStatus
                 language: !<!Languages> 
                   default:
-                    name: LeaseStatus
+                    name: leaseStatus
                     description: ''
-                    originalName: LeaseStatus
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!SealedChoiceSchema> &ref_12
@@ -762,31 +734,31 @@ schemas: !<!Schemas>
                     value: available
                     language:
                       default:
-                        name: available
+                        name: Available
                         description: ''
                   - !<!ChoiceValue> 
                     value: leased
                     language:
                       default:
-                        name: leased
+                        name: Leased
                         description: ''
                   - !<!ChoiceValue> 
                     value: expired
                     language:
                       default:
-                        name: expired
+                        name: Expired
                         description: ''
                   - !<!ChoiceValue> 
                     value: breaking
                     language:
                       default:
-                        name: breaking
+                        name: Breaking
                         description: ''
                   - !<!ChoiceValue> 
                     value: broken
                     language:
                       default:
-                        name: broken
+                        name: Broken
                         description: ''
                   type: sealed-choice
                   apiVersions:
@@ -802,9 +774,8 @@ schemas: !<!Schemas>
                 serializedName: LeaseState
                 language: !<!Languages> 
                   default:
-                    name: LeaseState
+                    name: leaseState
                     description: ''
-                    originalName: LeaseState
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!SealedChoiceSchema> &ref_13
@@ -813,13 +784,13 @@ schemas: !<!Schemas>
                     value: infinite
                     language:
                       default:
-                        name: infinite
+                        name: Infinite
                         description: ''
                   - !<!ChoiceValue> 
                     value: fixed
                     language:
                       default:
-                        name: fixed
+                        name: Fixed
                         description: ''
                   type: sealed-choice
                   apiVersions:
@@ -835,9 +806,8 @@ schemas: !<!Schemas>
                 serializedName: LeaseDuration
                 language: !<!Languages> 
                   default:
-                    name: LeaseDuration
+                    name: leaseDuration
                     description: ''
-                    originalName: LeaseDuration
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!ChoiceSchema> &ref_19
@@ -846,13 +816,13 @@ schemas: !<!Schemas>
                     value: container
                     language:
                       default:
-                        name: container
+                        name: Container
                         description: ''
                   - !<!ChoiceValue> 
                     value: blob
                     language:
                       default:
-                        name: blob
+                        name: Blob
                         description: ''
                   type: choice
                   apiVersions:
@@ -868,9 +838,8 @@ schemas: !<!Schemas>
                 serializedName: PublicAccess
                 language: !<!Languages> 
                   default:
-                    name: PublicAccess
+                    name: publicAccess
                     description: ''
-                    originalName: PublicAccess
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -882,9 +851,8 @@ schemas: !<!Schemas>
             serializedName: Properties
             language: !<!Languages> 
               default:
-                name: Properties
+                name: properties
                 description: Properties of a container
-                originalName: Properties
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!DictionarySchema> &ref_14
@@ -896,22 +864,21 @@ schemas: !<!Schemas>
                   version: 1.0.0
                 language: !<!Languages> 
                   default:
-                    name: string
+                    name: String
                     description: ''
                     header: Custom-Header
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
-                  name: Dictionary of string
-                  description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
+                  name: Metadata
+                  description: Dictionary of String
               protocol: !<!Protocols> {}
             required: false
             serializedName: Metadata
             language: !<!Languages> 
               default:
-                name: Metadata
+                name: metadata
                 description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
-                originalName: Metadata
             protocol: !<!Protocols> {}
           language: !<!Languages> 
             default:
@@ -925,16 +892,15 @@ schemas: !<!Schemas>
             wrapped: true
         language: !<!Languages> 
           default:
-            name: ListContainersResponse-Containers
-            description: ''
+            name: ListContainersResponseContainers
+            description: Array of Container
         protocol: !<!Protocols> {}
       required: false
       serializedName: Containers
       language: !<!Languages> 
         default:
-          name: Containers
+          name: containers
           description: ''
-          originalName: Containers
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_82
@@ -944,16 +910,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ListContainersResponse-NextMarker
+            name: ListContainersResponseNextMarker
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: NextMarker
       language: !<!Languages> 
         default:
-          name: NextMarker
+          name: nextMarker
           description: ''
-          originalName: NextMarker
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -989,64 +954,60 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: Logging-Version
+                name: LoggingVersion
                 description: The version of Storage Analytics to configure.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Version
           language: !<!Languages> 
             default:
-              name: Version
+              name: version
               description: The version of Storage Analytics to configure.
-              originalName: Version
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_32
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForDelete
+                name: TypeForDelete
                 description: Indicates whether all delete requests should be logged.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Delete
           language: !<!Languages> 
             default:
-              name: Delete
+              name: delete
               description: Indicates whether all delete requests should be logged.
-              originalName: Delete
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_33
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForRead
+                name: TypeForRead
                 description: Indicates whether all read requests should be logged.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Read
           language: !<!Languages> 
             default:
-              name: Read
+              name: read
               description: Indicates whether all read requests should be logged.
-              originalName: Read
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_34
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForWrite
+                name: TypeForWrite
                 description: Indicates whether all write requests should be logged.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Write
           language: !<!Languages> 
             default:
-              name: Write
+              name: write
               description: Indicates whether all write requests should be logged.
-              originalName: Write
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ObjectSchema> &ref_6
@@ -1060,16 +1021,15 @@ schemas: !<!Schemas>
                 type: boolean
                 language: !<!Languages> 
                   default:
-                    name: typeForEnabled
+                    name: TypeForEnabled
                     description: Indicates whether a retention policy is enabled for the storage service
                 protocol: !<!Protocols> {}
               required: true
               serializedName: Enabled
               language: !<!Languages> 
                 default:
-                  name: Enabled
+                  name: enabled
                   description: Indicates whether a retention policy is enabled for the storage service
-                  originalName: Enabled
               protocol: !<!Protocols> {}
             - !<!Property> 
               schema: !<!NumberSchema> &ref_51
@@ -1078,16 +1038,15 @@ schemas: !<!Schemas>
                 precision: 32
                 language: !<!Languages> 
                   default:
-                    name: typeForDays
+                    name: TypeForDays
                     description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
                 protocol: !<!Protocols> {}
               required: false
               serializedName: Days
               language: !<!Languages> 
                 default:
-                  name: Days
+                  name: days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
-                  originalName: Days
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -1099,9 +1058,8 @@ schemas: !<!Schemas>
           serializedName: RetentionPolicy
           language: !<!Languages> 
             default:
-              name: RetentionPolicy
+              name: retentionPolicy
               description: the retention policy
-              originalName: RetentionPolicy
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -1112,9 +1070,8 @@ schemas: !<!Schemas>
       serializedName: Logging
       language: !<!Languages> 
         default:
-          name: Logging
+          name: logging
           description: Azure Analytics Logging settings.
-          originalName: Logging
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -1131,48 +1088,45 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: Metrics-Version
+                name: MetricsVersion
                 description: The version of Storage Analytics to configure.
             protocol: !<!Protocols> {}
           required: false
           serializedName: Version
           language: !<!Languages> 
             default:
-              name: Version
+              name: version
               description: The version of Storage Analytics to configure.
-              originalName: Version
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_36
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForEnabled
+                name: TypeForEnabled
                 description: Indicates whether metrics are enabled for the Blob service.
             protocol: !<!Protocols> {}
           required: true
           serializedName: Enabled
           language: !<!Languages> 
             default:
-              name: Enabled
+              name: enabled
               description: Indicates whether metrics are enabled for the Blob service.
-              originalName: Enabled
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!BooleanSchema> &ref_37
             type: boolean
             language: !<!Languages> 
               default:
-                name: typeForIncludeAPIs
+                name: TypeForIncludeApIs
                 description: Indicates whether metrics should generate summary statistics for called API operations.
             protocol: !<!Protocols> {}
           required: false
           serializedName: IncludeAPIs
           language: !<!Languages> 
             default:
-              name: IncludeAPIs
+              name: includeApIs
               description: Indicates whether metrics should generate summary statistics for called API operations.
-              originalName: IncludeAPIs
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_6
@@ -1180,9 +1134,8 @@ schemas: !<!Schemas>
           serializedName: RetentionPolicy
           language: !<!Languages> 
             default:
-              name: RetentionPolicy
+              name: retentionPolicy
               description: the retention policy
-              originalName: RetentionPolicy
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -1193,18 +1146,16 @@ schemas: !<!Schemas>
       serializedName: HourMetrics
       language: !<!Languages> 
         default:
-          name: HourMetrics
+          name: hourMetrics
           description: ''
-          originalName: HourMetrics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_7
       serializedName: MinuteMetrics
       language: !<!Languages> 
         default:
-          name: MinuteMetrics
+          name: minuteMetrics
           description: ''
-          originalName: MinuteMetrics
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ArraySchema> &ref_28
@@ -1226,7 +1177,7 @@ schemas: !<!Schemas>
                 version: 1.0.0
               language: !<!Languages> 
                 default:
-                  name: CorsRule-AllowedOrigins
+                  name: CorsRuleAllowedOrigins
                   description: >-
                     The origin domains that are permitted to make a request against the storage service via CORS. The origin domain is the domain from which the request originates. Note that the origin must be an exact case-sensitive match
                     with the origin that the user age sends to the service. You can also use the wildcard character '*' to allow all origin domains to make requests via CORS.
@@ -1235,11 +1186,10 @@ schemas: !<!Schemas>
             serializedName: AllowedOrigins
             language: !<!Languages> 
               default:
-                name: AllowedOrigins
+                name: allowedOrigins
                 description: >-
                   The origin domains that are permitted to make a request against the storage service via CORS. The origin domain is the domain from which the request originates. Note that the origin must be an exact case-sensitive match
                   with the origin that the user age sends to the service. You can also use the wildcard character '*' to allow all origin domains to make requests via CORS.
-                originalName: AllowedOrigins
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_86
@@ -1249,16 +1199,15 @@ schemas: !<!Schemas>
                 version: 1.0.0
               language: !<!Languages> 
                 default:
-                  name: CorsRule-AllowedMethods
+                  name: CorsRuleAllowedMethods
                   description: The methods (HTTP request verbs) that the origin domain may use for a CORS request. (comma separated)
               protocol: !<!Protocols> {}
             required: true
             serializedName: AllowedMethods
             language: !<!Languages> 
               default:
-                name: AllowedMethods
+                name: allowedMethods
                 description: The methods (HTTP request verbs) that the origin domain may use for a CORS request. (comma separated)
-                originalName: AllowedMethods
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_87
@@ -1268,16 +1217,15 @@ schemas: !<!Schemas>
                 version: 1.0.0
               language: !<!Languages> 
                 default:
-                  name: CorsRule-AllowedHeaders
+                  name: CorsRuleAllowedHeaders
                   description: the request headers that the origin domain may specify on the CORS request.
               protocol: !<!Protocols> {}
             required: true
             serializedName: AllowedHeaders
             language: !<!Languages> 
               default:
-                name: AllowedHeaders
+                name: allowedHeaders
                 description: the request headers that the origin domain may specify on the CORS request.
-                originalName: AllowedHeaders
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!StringSchema> &ref_88
@@ -1287,16 +1235,15 @@ schemas: !<!Schemas>
                 version: 1.0.0
               language: !<!Languages> 
                 default:
-                  name: CorsRule-ExposedHeaders
+                  name: CorsRuleExposedHeaders
                   description: The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer
               protocol: !<!Protocols> {}
             required: true
             serializedName: ExposedHeaders
             language: !<!Languages> 
               default:
-                name: ExposedHeaders
+                name: exposedHeaders
                 description: The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer
-                originalName: ExposedHeaders
             protocol: !<!Protocols> {}
           - !<!Property> 
             schema: !<!NumberSchema> &ref_52
@@ -1305,16 +1252,15 @@ schemas: !<!Schemas>
               precision: 32
               language: !<!Languages> 
                 default:
-                  name: typeForMaxAgeInSeconds
+                  name: TypeForMaxAgeInSeconds
                   description: The maximum amount time that a browser should cache the preflight OPTIONS request.
               protocol: !<!Protocols> {}
             required: true
             serializedName: MaxAgeInSeconds
             language: !<!Languages> 
               default:
-                name: MaxAgeInSeconds
+                name: maxAgeInSeconds
                 description: The maximum amount time that a browser should cache the preflight OPTIONS request.
-                originalName: MaxAgeInSeconds
             protocol: !<!Protocols> {}
           serialization:
             xml:
@@ -1335,15 +1281,14 @@ schemas: !<!Schemas>
             wrapped: true
         language: !<!Languages> 
           default:
-            name: StorageServiceProperties-Cors
+            name: StorageServicePropertiesCors
             description: The set of CORS rules.
         protocol: !<!Protocols> {}
       serializedName: Cors
       language: !<!Languages> 
         default:
-          name: Cors
+          name: cors
           description: The set of CORS rules.
-          originalName: Cors
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_89
@@ -1353,24 +1298,22 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: StorageServiceProperties-DefaultServiceVersion
+            name: StorageServicePropertiesDefaultServiceVersion
             description: The default version to use for requests to the Blob service if an incoming request's version is not specified. Possible values include version 2008-10-27 and all more recent versions
         protocol: !<!Protocols> {}
       serializedName: DefaultServiceVersion
       language: !<!Languages> 
         default:
-          name: DefaultServiceVersion
+          name: defaultServiceVersion
           description: The default version to use for requests to the Blob service if an incoming request's version is not specified. Possible values include version 2008-10-27 and all more recent versions
-          originalName: DefaultServiceVersion
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: *ref_6
       serializedName: DeleteRetentionPolicy
       language: !<!Languages> 
         default:
-          name: DeleteRetentionPolicy
+          name: deleteRetentionPolicy
           description: the retention policy
-          originalName: DeleteRetentionPolicy
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -1396,16 +1339,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: SignedIdentifier-Id
+            name: SignedIdentifierId
             description: a unique id
         protocol: !<!Protocols> {}
       required: true
       serializedName: Id
       language: !<!Languages> 
         default:
-          name: Id
+          name: id
           description: a unique id
-          originalName: Id
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_10
@@ -1423,16 +1365,15 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: AccessPolicy-Start
+                name: AccessPolicyStart
                 description: the date-time the policy is active
             protocol: !<!Protocols> {}
           required: true
           serializedName: Start
           language: !<!Languages> 
             default:
-              name: Start
+              name: start
               description: the date-time the policy is active
-              originalName: Start
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!DateTimeSchema> &ref_45
@@ -1443,16 +1384,15 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: AccessPolicy-Expiry
+                name: AccessPolicyExpiry
                 description: the date-time the policy expires
             protocol: !<!Protocols> {}
           required: true
           serializedName: Expiry
           language: !<!Languages> 
             default:
-              name: Expiry
+              name: expiry
               description: the date-time the policy expires
-              originalName: Expiry
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!StringSchema> &ref_91
@@ -1462,16 +1402,15 @@ schemas: !<!Schemas>
               version: 1.0.0
             language: !<!Languages> 
               default:
-                name: AccessPolicy-Permission
+                name: AccessPolicyPermission
                 description: the permissions for the acl policy
             protocol: !<!Protocols> {}
           required: true
           serializedName: Permission
           language: !<!Languages> 
             default:
-              name: Permission
+              name: permission
               description: the permissions for the acl policy
-              originalName: Permission
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -1483,9 +1422,8 @@ schemas: !<!Schemas>
       serializedName: AccessPolicy
       language: !<!Languages> 
         default:
-          name: AccessPolicy
+          name: accessPolicy
           description: An Access policy
-          originalName: AccessPolicy
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -1517,16 +1455,15 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: ListBlobsResponse-ServiceEndpoint
+            name: ListBlobsResponseServiceEndpoint
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: ServiceEndpoint
       language: !<!Languages> 
         default:
-          name: ServiceEndpoint
+          name: serviceEndpoint
           description: ''
-          originalName: ServiceEndpoint
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_93
@@ -1540,16 +1477,15 @@ schemas: !<!Schemas>
             wrapped: false
         language: !<!Languages> 
           default:
-            name: ListBlobsResponse-ContainerName
+            name: ListBlobsResponseContainerName
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: ContainerName
       language: !<!Languages> 
         default:
-          name: ContainerName
+          name: containerName
           description: ''
-          originalName: ContainerName
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_94
@@ -1559,16 +1495,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ListBlobsResponse-Prefix
+            name: ListBlobsResponsePrefix
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: Prefix
       language: !<!Languages> 
         default:
-          name: Prefix
+          name: prefix
           description: ''
-          originalName: Prefix
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_95
@@ -1578,16 +1513,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ListBlobsResponse-Marker
+            name: ListBlobsResponseMarker
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: Marker
       language: !<!Languages> 
         default:
-          name: Marker
+          name: marker
           description: ''
-          originalName: Marker
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!NumberSchema> &ref_53
@@ -1595,16 +1529,15 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForMaxResults
+            name: TypeForMaxResults
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: MaxResults
       language: !<!Languages> 
         default:
-          name: MaxResults
+          name: maxResults
           description: ''
-          originalName: MaxResults
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_96
@@ -1614,16 +1547,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ListBlobsResponse-Delimiter
+            name: ListBlobsResponseDelimiter
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: Delimiter
       language: !<!Languages> 
         default:
-          name: Delimiter
+          name: delimiter
           description: ''
-          originalName: Delimiter
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_15
@@ -1652,16 +1584,15 @@ schemas: !<!Schemas>
                     version: 1.0.0
                   language: !<!Languages> 
                     default:
-                      name: BlobPrefix-Name
+                      name: BlobPrefixName
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Name
                 language: !<!Languages> 
                   default:
-                    name: Name
+                    name: name
                     description: ''
-                    originalName: Name
                 protocol: !<!Protocols> {}
               language: !<!Languages> 
                 default:
@@ -1671,15 +1602,14 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: Blobs-BlobPrefix
-                description: ''
+                name: BlobsBlobPrefix
+                description: Array of BlobPrefix
             protocol: !<!Protocols> {}
           serializedName: BlobPrefix
           language: !<!Languages> 
             default:
-              name: BlobPrefix
+              name: blobPrefix
               description: ''
-              originalName: BlobPrefix
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: !<!ArraySchema> &ref_31
@@ -1701,32 +1631,30 @@ schemas: !<!Schemas>
                     version: 1.0.0
                   language: !<!Languages> 
                     default:
-                      name: Blob-Name
+                      name: BlobName
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Name
                 language: !<!Languages> 
                   default:
-                    name: Name
+                    name: name
                     description: ''
-                    originalName: Name
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!BooleanSchema> &ref_38
                   type: boolean
                   language: !<!Languages> 
                     default:
-                      name: typeForDeleted
+                      name: TypeForDeleted
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Deleted
                 language: !<!Languages> 
                   default:
-                    name: Deleted
+                    name: deleted
                     description: ''
-                    originalName: Deleted
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!StringSchema> &ref_99
@@ -1736,16 +1664,15 @@ schemas: !<!Schemas>
                     version: 1.0.0
                   language: !<!Languages> 
                     default:
-                      name: Blob-Snapshot
+                      name: BlobSnapshot
                       description: ''
                   protocol: !<!Protocols> {}
                 required: true
                 serializedName: Snapshot
                 language: !<!Languages> 
                   default:
-                    name: Snapshot
+                    name: snapshot
                     description: ''
-                    originalName: Snapshot
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_18
@@ -1763,7 +1690,7 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Last-Modified
+                          name: BlobPropertiesLastModified
                           description: ''
                       protocol: !<!Protocols> {}
                     required: true
@@ -1772,7 +1699,6 @@ schemas: !<!Schemas>
                       default:
                         name: lastModified
                         description: ''
-                        originalName: Last-Modified
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_100
@@ -1782,16 +1708,15 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Etag
+                          name: BlobPropertiesEtag
                           description: ''
                       protocol: !<!Protocols> {}
                     required: true
                     serializedName: Etag
                     language: !<!Languages> 
                       default:
-                        name: Etag
+                        name: etag
                         description: ''
-                        originalName: Etag
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!NumberSchema> &ref_54
@@ -1799,7 +1724,7 @@ schemas: !<!Schemas>
                       precision: 64
                       language: !<!Languages> 
                         default:
-                          name: typeForContent-Length
+                          name: TypeForContentLength
                           description: Size in bytes
                       protocol: !<!Protocols> {}
                     required: false
@@ -1808,7 +1733,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentLength
                         description: Size in bytes
-                        originalName: Content-Length
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_101
@@ -1818,7 +1742,7 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-Type
+                          name: BlobPropertiesContentType
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1827,7 +1751,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentType
                         description: ''
-                        originalName: Content-Type
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_102
@@ -1837,7 +1760,7 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-Encoding
+                          name: BlobPropertiesContentEncoding
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1846,7 +1769,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentEncoding
                         description: ''
-                        originalName: Content-Encoding
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_103
@@ -1856,7 +1778,7 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-Language
+                          name: BlobPropertiesContentLanguage
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1865,7 +1787,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentLanguage
                         description: ''
-                        originalName: Content-Language
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_104
@@ -1875,7 +1796,7 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-MD5
+                          name: BlobPropertiesContentMd5
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1884,7 +1805,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentMd5
                         description: ''
-                        originalName: Content-MD5
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_105
@@ -1894,7 +1814,7 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Content-Disposition
+                          name: BlobPropertiesContentDisposition
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1903,7 +1823,6 @@ schemas: !<!Schemas>
                       default:
                         name: contentDisposition
                         description: ''
-                        originalName: Content-Disposition
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_106
@@ -1913,7 +1832,7 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-Cache-Control
+                          name: BlobPropertiesCacheControl
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1922,7 +1841,6 @@ schemas: !<!Schemas>
                       default:
                         name: cacheControl
                         description: ''
-                        originalName: Cache-Control
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!NumberSchema> &ref_55
@@ -1930,7 +1848,7 @@ schemas: !<!Schemas>
                       precision: 32
                       language: !<!Languages> 
                         default:
-                          name: blobSequenceNumber
+                          name: BlobSequenceNumber
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
@@ -1939,7 +1857,6 @@ schemas: !<!Schemas>
                       default:
                         name: blobSequenceNumber
                         description: ''
-                        originalName: blobSequenceNumber
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!SealedChoiceSchema> &ref_59
@@ -1976,9 +1893,8 @@ schemas: !<!Schemas>
                     serializedName: BlobType
                     language: !<!Languages> 
                       default:
-                        name: BlobType
+                        name: blobType
                         description: ''
-                        originalName: BlobType
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: *ref_11
@@ -1986,9 +1902,8 @@ schemas: !<!Schemas>
                     serializedName: LeaseStatus
                     language: !<!Languages> 
                       default:
-                        name: LeaseStatus
+                        name: leaseStatus
                         description: ''
-                        originalName: LeaseStatus
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: *ref_12
@@ -1996,9 +1911,8 @@ schemas: !<!Schemas>
                     serializedName: LeaseState
                     language: !<!Languages> 
                       default:
-                        name: LeaseState
+                        name: leaseState
                         description: ''
-                        originalName: LeaseState
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: *ref_13
@@ -2006,9 +1920,8 @@ schemas: !<!Schemas>
                     serializedName: LeaseDuration
                     language: !<!Languages> 
                       default:
-                        name: LeaseDuration
+                        name: leaseDuration
                         description: ''
-                        originalName: LeaseDuration
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_107
@@ -2018,16 +1931,15 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopyId
+                          name: BlobPropertiesCopyId
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopyId
                     language: !<!Languages> 
                       default:
-                        name: CopyId
+                        name: copyId
                         description: ''
-                        originalName: CopyId
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!SealedChoiceSchema> &ref_60
@@ -2036,25 +1948,25 @@ schemas: !<!Schemas>
                         value: pending
                         language:
                           default:
-                            name: pending
+                            name: Pending
                             description: ''
                       - !<!ChoiceValue> 
                         value: success
                         language:
                           default:
-                            name: success
+                            name: Success
                             description: ''
                       - !<!ChoiceValue> 
                         value: aborted
                         language:
                           default:
-                            name: aborted
+                            name: Aborted
                             description: ''
                       - !<!ChoiceValue> 
                         value: failed
                         language:
                           default:
-                            name: failed
+                            name: Failed
                             description: ''
                       type: sealed-choice
                       apiVersions:
@@ -2070,9 +1982,8 @@ schemas: !<!Schemas>
                     serializedName: CopyStatus
                     language: !<!Languages> 
                       default:
-                        name: CopyStatus
+                        name: copyStatus
                         description: ''
-                        originalName: CopyStatus
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_108
@@ -2082,16 +1993,15 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopySource
+                          name: BlobPropertiesCopySource
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopySource
                     language: !<!Languages> 
                       default:
-                        name: CopySource
+                        name: copySource
                         description: ''
-                        originalName: CopySource
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_109
@@ -2101,16 +2011,15 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopyProgress
+                          name: BlobPropertiesCopyProgress
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopyProgress
                     language: !<!Languages> 
                       default:
-                        name: CopyProgress
+                        name: copyProgress
                         description: ''
-                        originalName: CopyProgress
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!DateTimeSchema> &ref_47
@@ -2121,16 +2030,15 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopyCompletionTime
+                          name: BlobPropertiesCopyCompletionTime
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopyCompletionTime
                     language: !<!Languages> 
                       default:
-                        name: CopyCompletionTime
+                        name: copyCompletionTime
                         description: ''
-                        originalName: CopyCompletionTime
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_110
@@ -2140,48 +2048,45 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-CopyStatusDescription
+                          name: BlobPropertiesCopyStatusDescription
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: CopyStatusDescription
                     language: !<!Languages> 
                       default:
-                        name: CopyStatusDescription
+                        name: copyStatusDescription
                         description: ''
-                        originalName: CopyStatusDescription
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!BooleanSchema> &ref_39
                       type: boolean
                       language: !<!Languages> 
                         default:
-                          name: typeForServerEncrypted
+                          name: TypeForServerEncrypted
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: ServerEncrypted
                     language: !<!Languages> 
                       default:
-                        name: ServerEncrypted
+                        name: serverEncrypted
                         description: ''
-                        originalName: ServerEncrypted
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!BooleanSchema> &ref_40
                       type: boolean
                       language: !<!Languages> 
                         default:
-                          name: typeForIncrementalCopy
+                          name: TypeForIncrementalCopy
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: IncrementalCopy
                     language: !<!Languages> 
                       default:
-                        name: IncrementalCopy
+                        name: incrementalCopy
                         description: ''
-                        originalName: IncrementalCopy
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!StringSchema> &ref_111
@@ -2191,16 +2096,15 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-DestinationSnapshot
+                          name: BlobPropertiesDestinationSnapshot
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: DestinationSnapshot
                     language: !<!Languages> 
                       default:
-                        name: DestinationSnapshot
+                        name: destinationSnapshot
                         description: ''
-                        originalName: DestinationSnapshot
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!DateTimeSchema> &ref_48
@@ -2211,16 +2115,15 @@ schemas: !<!Schemas>
                         version: 1.0.0
                       language: !<!Languages> 
                         default:
-                          name: BlobProperties-DeletedTime
+                          name: BlobPropertiesDeletedTime
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: DeletedTime
                     language: !<!Languages> 
                       default:
-                        name: DeletedTime
+                        name: deletedTime
                         description: ''
-                        originalName: DeletedTime
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!NumberSchema> &ref_56
@@ -2228,16 +2131,15 @@ schemas: !<!Schemas>
                       precision: 32
                       language: !<!Languages> 
                         default:
-                          name: typeForRemainingRetentionDays
+                          name: TypeForRemainingRetentionDays
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: RemainingRetentionDays
                     language: !<!Languages> 
                       default:
-                        name: RemainingRetentionDays
+                        name: remainingRetentionDays
                         description: ''
-                        originalName: RemainingRetentionDays
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!ChoiceSchema> &ref_20
@@ -2316,25 +2218,23 @@ schemas: !<!Schemas>
                     serializedName: AccessTier
                     language: !<!Languages> 
                       default:
-                        name: AccessTier
+                        name: accessTier
                         description: ''
-                        originalName: AccessTier
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!BooleanSchema> &ref_41
                       type: boolean
                       language: !<!Languages> 
                         default:
-                          name: typeForAccessTierInferred
+                          name: TypeForAccessTierInferred
                           description: ''
                       protocol: !<!Protocols> {}
                     required: false
                     serializedName: AccessTierInferred
                     language: !<!Languages> 
                       default:
-                        name: AccessTierInferred
+                        name: accessTierInferred
                         description: ''
-                        originalName: AccessTierInferred
                     protocol: !<!Protocols> {}
                   - !<!Property> 
                     schema: !<!ChoiceSchema> &ref_21
@@ -2343,13 +2243,13 @@ schemas: !<!Schemas>
                         value: rehydrate-pending-to-hot
                         language:
                           default:
-                            name: rehydrate-pending-to-hot
+                            name: RehydratePendingToHot
                             description: ''
                       - !<!ChoiceValue> 
                         value: rehydrate-pending-to-cool
                         language:
                           default:
-                            name: rehydrate-pending-to-cool
+                            name: RehydratePendingToCool
                             description: ''
                       type: choice
                       apiVersions:
@@ -2365,9 +2265,8 @@ schemas: !<!Schemas>
                     serializedName: ArchiveStatus
                     language: !<!Languages> 
                       default:
-                        name: ArchiveStatus
+                        name: archiveStatus
                         description: ''
-                        originalName: ArchiveStatus
                     protocol: !<!Protocols> {}
                   language: !<!Languages> 
                     default:
@@ -2379,9 +2278,8 @@ schemas: !<!Schemas>
                 serializedName: Properties
                 language: !<!Languages> 
                   default:
-                    name: Properties
+                    name: properties
                     description: Properties of a blob
-                    originalName: Properties
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_14
@@ -2389,9 +2287,8 @@ schemas: !<!Schemas>
                 serializedName: Metadata
                 language: !<!Languages> 
                   default:
-                    name: Metadata
+                    name: metadata
                     description: Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
-                    originalName: Metadata
                 protocol: !<!Protocols> {}
               serialization:
                 xml:
@@ -2406,15 +2303,14 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
-                name: Blobs-Blob
-                description: ''
+                name: BlobsBlob
+                description: Array of Blob
             protocol: !<!Protocols> {}
           serializedName: Blob
           language: !<!Languages> 
             default:
-              name: Blob
+              name: blob
               description: ''
-              originalName: Blob
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -2426,9 +2322,8 @@ schemas: !<!Schemas>
       serializedName: Blobs
       language: !<!Languages> 
         default:
-          name: Blobs
+          name: blobs
           description: ''
-          originalName: Blobs
       protocol: !<!Protocols> {}
     - !<!Property> 
       schema: !<!StringSchema> &ref_112
@@ -2438,16 +2333,15 @@ schemas: !<!Schemas>
           version: 1.0.0
         language: !<!Languages> 
           default:
-            name: ListBlobsResponse-NextMarker
+            name: ListBlobsResponseNextMarker
             description: ''
         protocol: !<!Protocols> {}
       required: true
       serializedName: NextMarker
       language: !<!Languages> 
         default:
-          name: NextMarker
+          name: nextMarker
           description: ''
-          originalName: NextMarker
       protocol: !<!Protocols> {}
     serialization:
       xml:
@@ -2476,7 +2370,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       serializedName: id
@@ -2484,11 +2378,10 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: JSONInput
+        name: JsonInput
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -2504,7 +2397,7 @@ schemas: !<!Schemas>
         precision: 32
         language: !<!Languages> 
           default:
-            name: typeForid
+            name: TypeForid
             description: ''
         protocol: !<!Protocols> {}
       serializedName: id
@@ -2512,11 +2405,10 @@ schemas: !<!Schemas>
         default:
           name: id
           description: ''
-          originalName: id
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
-        name: JSONOutput
+        name: JsonOutput
         description: ''
         namespace: Api100
     protocol: !<!Protocols> {}
@@ -2544,8 +2436,8 @@ schemas: !<!Schemas>
         wrapped: false
     language: !<!Languages> 
       default:
-        name: Array of Banana
-        description: ''
+        name: ArrayOfBanana
+        description: Array of Banana
     protocol: !<!Protocols> {}
   - !<!ArraySchema> &ref_140
     type: array
@@ -2560,8 +2452,8 @@ schemas: !<!Schemas>
         wrapped: true
     language: !<!Languages> 
       default:
-        name: Array of Banana
-        description: ''
+        name: ArrayOfBanana
+        description: Array of Banana
     protocol: !<!Protocols> {}
   - *ref_27
   - *ref_28
@@ -2606,7 +2498,7 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant0
+        name: Constant8
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_147
@@ -2620,7 +2512,7 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant1
+        name: Constant9
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_148
@@ -2634,7 +2526,7 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant2
+        name: Constant10
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_151
@@ -2648,7 +2540,7 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant3
+        name: Constant11
         description: ''
     protocol: !<!Protocols> {}
   - !<!ConstantSchema> &ref_152
@@ -2662,7 +2554,7 @@ schemas: !<!Schemas>
     valueType: *ref_3
     language: !<!Languages> 
       default:
-        name: Constant4
+        name: Constant12
         description: ''
     protocol: !<!Protocols> {}
   dateTimes:
@@ -2800,7 +2692,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getComplexTypeRefNoMeta
+        name: GetComplexTypeRefNoMeta
         description: Get a complex type that has a ref to a complex type with no XML node
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2834,7 +2726,7 @@ operationGroups:
         targetProperty: *ref_116
         language: !<!Languages> 
           default:
-            name: RefToModel
+            name: refToModel
             description: I am a complex type with no XML node
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_119
@@ -2846,7 +2738,7 @@ operationGroups:
         targetProperty: *ref_117
         language: !<!Languages> 
           default:
-            name: Something
+            name: something
             description: Something else (just to avoid flattening)
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -2878,7 +2770,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putComplexTypeRefNoMeta
+        name: PutComplexTypeRefNoMeta
         description: Puts a complex type that has a ref to a complex type with no XML node
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2914,7 +2806,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getComplexTypeRefWithMeta
+        name: GetComplexTypeRefWithMeta
         description: Get a complex type that has a ref to a complex type with XML node
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -2948,7 +2840,7 @@ operationGroups:
         targetProperty: *ref_122
         language: !<!Languages> 
           default:
-            name: RefToModel
+            name: refToModel
             description: I am a complex type with XML node
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_125
@@ -2960,7 +2852,7 @@ operationGroups:
         targetProperty: *ref_123
         language: !<!Languages> 
           default:
-            name: Something
+            name: something
             description: Something else (just to avoid flattening)
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -2992,7 +2884,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putComplexTypeRefWithMeta
+        name: PutComplexTypeRefWithMeta
         description: Puts a complex type that has a ref to a complex type with XML node
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3042,7 +2934,7 @@ operationGroups:
           - default
     language: !<!Languages> 
       default:
-        name: getSimple
+        name: GetSimple
         description: Get a simple XML document
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3108,7 +3000,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putSimple
+        name: PutSimple
         description: Put a simple XML document
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3144,7 +3036,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getWrappedLists
+        name: GetWrappedLists
         description: Get an XML document with multiple wrapped lists
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3178,7 +3070,7 @@ operationGroups:
         targetProperty: *ref_131
         language: !<!Languages> 
           default:
-            name: GoodApples
+            name: goodApples
             description: ''
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_134
@@ -3190,7 +3082,7 @@ operationGroups:
         targetProperty: *ref_132
         language: !<!Languages> 
           default:
-            name: BadApples
+            name: badApples
             description: ''
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -3236,7 +3128,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putWrappedLists
+        name: PutWrappedLists
         description: Put an XML document with multiple wrapped lists
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3272,7 +3164,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getHeaders
+        name: GetHeaders
         description: Get strongly-typed response headers.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3308,7 +3200,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getEmptyList
+        name: GetEmptyList
         description: Get an empty list.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3360,7 +3252,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmptyList
+        name: PutEmptyList
         description: Puts an empty list.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3396,7 +3288,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getEmptyWrappedLists
+        name: GetEmptyWrappedLists
         description: Gets some empty wrapped lists.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3430,7 +3322,7 @@ operationGroups:
         targetProperty: *ref_131
         language: !<!Languages> 
           default:
-            name: GoodApples
+            name: goodApples
             description: ''
         protocol: !<!Protocols> {}
       - !<!Parameter> &ref_138
@@ -3442,7 +3334,7 @@ operationGroups:
         targetProperty: *ref_132
         language: !<!Languages> 
           default:
-            name: BadApples
+            name: badApples
             description: ''
         protocol: !<!Protocols> {}
       signatureParameters:
@@ -3474,7 +3366,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmptyWrappedLists
+        name: PutEmptyWrappedLists
         description: Puts some empty wrapped lists.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3510,7 +3402,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getRootList
+        name: GetRootList
         description: Gets a list as the root element.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3562,7 +3454,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putRootList
+        name: PutRootList
         description: Puts a list as the root element.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3598,7 +3490,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getRootListSingleItem
+        name: GetRootListSingleItem
         description: Gets a list with a single item.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3650,7 +3542,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putRootListSingleItem
+        name: PutRootListSingleItem
         description: Puts a list with a single item.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3686,7 +3578,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getEmptyRootList
+        name: GetEmptyRootList
         description: Gets an empty list as the root element.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3738,7 +3630,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmptyRootList
+        name: PutEmptyRootList
         description: Puts an empty list as the root element.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3774,7 +3666,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getEmptyChildElement
+        name: GetEmptyChildElement
         description: Gets an XML document with an empty child element.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3826,7 +3718,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: putEmptyChildElement
+        name: PutEmptyChildElement
         description: Puts a value with an empty child element.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3874,7 +3766,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: listContainers
+        name: ListContainers
         description: Lists containers in a storage account.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -3934,7 +3826,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getServiceProperties
+        name: GetServiceProperties
         description: Gets storage service properties.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4010,7 +3902,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: putServiceProperties
+        name: PutServiceProperties
         description: Puts storage service properties.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4070,7 +3962,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: getAcls
+        name: GetAcls
         description: Gets storage ACLs for a container.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4146,7 +4038,7 @@ operationGroups:
       x-ms-requestBody-index: 2
     language: !<!Languages> 
       default:
-        name: putAcls
+        name: PutAcls
         description: Puts storage ACLs for a container.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4206,7 +4098,7 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: listBlobs
+        name: ListBlobs
         description: Lists blobs in a storage container.
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4271,7 +4163,7 @@ operationGroups:
       x-ms-requestBody-index: 0
     language: !<!Languages> 
       default:
-        name: jsonInput
+        name: JsonInput
         description: A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42
     protocol: !<!Protocols> {}
   - !<!Operation> 
@@ -4307,12 +4199,12 @@ operationGroups:
           - '200'
     language: !<!Languages> 
       default:
-        name: jsonOutput
+        name: JsonOutput
         description: A Swagger with XML that has one operation that returns JSON. ID number 42
     protocol: !<!Protocols> {}
   language: !<!Languages> 
     default:
-      name: xml
+      name: Xml
       description: ''
   protocol: !<!Protocols> {}
 language: !<!Languages> 

--- a/modelerfour/test/scenarios/xms-error-responses/namer.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/namer.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
               version: 0.0.0
             language: !<!Languages> 
               default:
-                name: Pet-name
+                name: PetName
                 description: Gets the Pet by id.
             protocol: !<!Protocols> {}
           readOnly: true
@@ -36,7 +36,6 @@ schemas: !<!Schemas>
             default:
               name: name
               description: Gets the Pet by id.
-              originalName: name
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -55,7 +54,7 @@ schemas: !<!Schemas>
           version: 0.0.0
         language: !<!Languages> 
           default:
-            name: Animal-aniType
+            name: AnimalAniType
             description: ''
         protocol: !<!Protocols> {}
       serializedName: aniType
@@ -63,7 +62,6 @@ schemas: !<!Schemas>
         default:
           name: aniType
           description: ''
-          originalName: aniType
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -107,7 +105,7 @@ schemas: !<!Schemas>
                   version: 0.0.0
                 language: !<!Languages> 
                   default:
-                    name: LinkNotFound-whatSubAddress
+                    name: LinkNotFoundWhatSubAddress
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: whatSubAddress
@@ -115,7 +113,6 @@ schemas: !<!Schemas>
                 default:
                   name: whatSubAddress
                   description: ''
-                  originalName: whatSubAddress
               protocol: !<!Protocols> {}
             extensions:
               x-ms-discriminator-value: InvalidResourceLink
@@ -146,7 +143,7 @@ schemas: !<!Schemas>
                   version: 0.0.0
                 language: !<!Languages> 
                   default:
-                    name: AnimalNotFound-name
+                    name: AnimalNotFoundName
                     description: ''
                 protocol: !<!Protocols> {}
               serializedName: name
@@ -154,7 +151,6 @@ schemas: !<!Schemas>
                 default:
                   name: name
                   description: ''
-                  originalName: name
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -180,7 +176,7 @@ schemas: !<!Schemas>
                 version: 0.0.0
               language: !<!Languages> 
                 default:
-                  name: NotFoundErrorBase-whatNotFound
+                  name: NotFoundErrorBaseWhatNotFound
                   description: ''
               protocol: !<!Protocols> {}
             isDiscriminator: true
@@ -190,7 +186,6 @@ schemas: !<!Schemas>
               default:
                 name: whatNotFound
                 description: ''
-                originalName: whatNotFound
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
         parents: !<!Relations> 
@@ -207,7 +202,7 @@ schemas: !<!Schemas>
               version: 0.0.0
             language: !<!Languages> 
               default:
-                name: NotFoundErrorBase-reason
+                name: NotFoundErrorBaseReason
                 description: ''
             protocol: !<!Protocols> {}
           required: false
@@ -216,7 +211,6 @@ schemas: !<!Schemas>
             default:
               name: reason
               description: ''
-              originalName: reason
           protocol: !<!Protocols> {}
         - *ref_6
         language: !<!Languages> 
@@ -238,7 +232,7 @@ schemas: !<!Schemas>
           version: 0.0.0
         language: !<!Languages> 
           default:
-            name: BaseError-someBaseProp
+            name: BaseErrorSomeBaseProp
             description: ''
         protocol: !<!Protocols> {}
       serializedName: someBaseProp
@@ -246,7 +240,6 @@ schemas: !<!Schemas>
         default:
           name: someBaseProp
           description: ''
-          originalName: someBaseProp
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -269,7 +262,7 @@ schemas: !<!Schemas>
           version: 0.0.0
         language: !<!Languages> 
           default:
-            name: PetAction-actionResponse
+            name: PetActionResponse
             description: action feedback
         protocol: !<!Protocols> {}
       serializedName: actionResponse
@@ -277,7 +270,6 @@ schemas: !<!Schemas>
         default:
           name: actionResponse
           description: action feedback
-          originalName: actionResponse
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -320,7 +312,7 @@ schemas: !<!Schemas>
                   version: 0.0.0
                 language: !<!Languages> 
                   default:
-                    name: PetHungryOrThirstyError-hungryOrThirsty
+                    name: PetHungryOrThirstyErrorHungryOrThirsty
                     description: is the pet hungry or thirsty or both
                 protocol: !<!Protocols> {}
               serializedName: hungryOrThirsty
@@ -328,7 +320,6 @@ schemas: !<!Schemas>
                 default:
                   name: hungryOrThirsty
                   description: is the pet hungry or thirsty or both
-                  originalName: hungryOrThirsty
               protocol: !<!Protocols> {}
             language: !<!Languages> 
               default:
@@ -351,7 +342,7 @@ schemas: !<!Schemas>
                 version: 0.0.0
               language: !<!Languages> 
                 default:
-                  name: PetActionError-errorType
+                  name: PetActionErrorType
                   description: ''
               protocol: !<!Protocols> {}
             isDiscriminator: true
@@ -361,7 +352,6 @@ schemas: !<!Schemas>
               default:
                 name: errorType
                 description: ''
-                originalName: errorType
             protocol: !<!Protocols> {}
         discriminatorValue: PetSadError
         parents: !<!Relations> 
@@ -378,7 +368,7 @@ schemas: !<!Schemas>
               version: 0.0.0
             language: !<!Languages> 
               default:
-                name: PetSadError-reason
+                name: PetSadErrorReason
                 description: why is the pet sad
             protocol: !<!Protocols> {}
           serializedName: reason
@@ -386,7 +376,6 @@ schemas: !<!Schemas>
             default:
               name: reason
               description: why is the pet sad
-              originalName: reason
           protocol: !<!Protocols> {}
         language: !<!Languages> 
           default:
@@ -414,7 +403,7 @@ schemas: !<!Schemas>
           version: 0.0.0
         language: !<!Languages> 
           default:
-            name: PetActionError-errorMessage
+            name: PetActionErrorMessage
             description: the error message
         protocol: !<!Protocols> {}
       required: false
@@ -423,7 +412,6 @@ schemas: !<!Schemas>
         default:
           name: errorMessage
           description: the error message
-          originalName: errorMessage
       protocol: !<!Protocols> {}
     language: !<!Languages> 
       default:
@@ -444,7 +432,7 @@ schemas: !<!Schemas>
     precision: 32
     language: !<!Languages> 
       default:
-        name: integer
+        name: Integer
         description: ''
     protocol: !<!Protocols> {}
   strings:
@@ -452,7 +440,7 @@ schemas: !<!Schemas>
     type: string
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: simple string
     protocol: !<!Protocols> {}
   - !<!StringSchema> &ref_25
@@ -462,7 +450,7 @@ schemas: !<!Schemas>
       version: 0.0.0
     language: !<!Languages> 
       default:
-        name: string
+        name: String
         description: ''
     protocol: !<!Protocols> {}
   - *ref_11

--- a/modelerfour/test/test-modeler.ts
+++ b/modelerfour/test/test-modeler.ts
@@ -168,7 +168,15 @@ async function createPassThruSession(config: any, input: string, inputArtifactTy
       console.log(`Processing: ${each}`);
 
       const cfg = {
-        modelerfour: { 'flatten-models': true, 'flatten-payloads': true, 'group-parameters': true },
+        modelerfour: {
+          'flatten-models': true,
+          'flatten-payloads': true,
+          'group-parameters': true,
+          naming: {
+            // constant: 'uppercase',
+            //property: 'snakecase'
+          }
+        },
         'payload-flattening-threshold': 2
       }
 
@@ -195,7 +203,7 @@ async function createPassThruSession(config: any, input: string, inputArtifactTy
       const groupedYaml = serialize(grouped, codeModelSchema);
       await (writeFile(`${__dirname}/../../test/scenarios/${each}/grouped.yaml`, groupedYaml));
 
-      const namer = new PreNamer(await createPassThruSession(cfg, groupedYaml, 'code-model-v4'));
+      const namer = await new PreNamer(await createPassThruSession(cfg, groupedYaml, 'code-model-v4')).init();
       const named = await namer.process();
       const namedyaml = serialize(named, codeModelSchema);
       await (writeFile(`${__dirname}/../../test/scenarios/${each}/namer.yaml`, namedyaml));


### PR DESCRIPTION
adds formatting options in modelerfour/prenamer so that the names are normalized better.

configuration added:

``` yaml
  # customization of the identifier normalization and naming provided by the prenamer.
  # pascalcase - MultiWordIdentifier 
  # camelcase - multiWordIdentifier 
  # snakecase - multi_word_identifier
  # uppercase - MULTI_WORD_IDENTIFIER 
  # kebabcase - multi-word-identifier 
  # default is the first one in the list below:
modelerfour:
  naming: 
    parameter: camelcase|pascalcase|snakecase|uppercase|kebabcase
    property: camelcase|pascalcase|snakecase|uppercase|kebabcase
    operation: pascalcase|camelcase|snakecase|uppercase|kebabcase
    operationGroup:  pascalcase|camelcase|snakecase|uppercase|kebabcase
    choice:  pascalcase|camelcase|snakecase|uppercase|kebabcase
    choiceValue:  pascalcase|camelcase|snakecase|uppercase|kebabcase
    constant:  pascalcase|camelcase|snakecase|uppercase|kebabcase
    type:  pascalcase|camelcase|snakecase|uppercase|kebabcase
```