### PR TITLE
more updates to naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,4 @@ package-deps.json
 /tests/output
 /tests/before
 /tests/new
+!entrypoints/**

--- a/modelerfour/entrypoints/main.js
+++ b/modelerfour/entrypoints/main.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+// load modules from static linker filesystem.
+try {
+  if (process.argv.indexOf('--no-static-loader') === -1 && process.env['no-static-loader'] === undefined && require('fs').existsSync(`${__dirname}/../dist/static-loader.js`)) {
+    require(`${__dirname}/../dist/static-loader.js`).load(`${__dirname}/../dist/static_modules.fs`);
+  }
+  require(`${__dirname}/../dist/main.js`);
+
+} catch (e) {
+  console.error(e);
+}

--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/modelerfour",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "AutoRest Modeler Version Four (component)",
   "directories": {
     "doc": "docs"
@@ -11,13 +11,14 @@
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",
   "scripts": {
-    "start": "node --max_old_space_size=4096 ./dist/main.js",
-    "debug": "node --max_old_space_size=4096 --inspect-brk=localhost:19229 ./dist/main.js",
+    "start": "node --max_old_space_size=4096 ./entrypoints/main.js",
+    "debug": "node --max_old_space_size=4096 --inspect-brk=localhost:19229 ./entrypoints/main.js",
     "eslint-fix": "eslint  . --fix --ext .ts",
     "eslint": "eslint  . --ext .ts",
+    "static-link": "static-link --no-node-modules --debug",
     "watch": "tsc -p . --watch",
     "build": "tsc -p .",
-    "prepare": "npm run build",
+    "prepack": "npm run static-link && npm run build",
     "test": "npm run build && mocha dist/test  --timeout=200000"
   },
   "repository": {
@@ -48,9 +49,7 @@
     "@azure-tools/async-io": "~3.0.0",
     "source-map-support": "0.5.13",
     "@microsoft.azure/autorest.testserver": "~2.10.9",
-    "@azure-tools/uri": "~3.0.0"
-  },
-  "dependencies": {
+    "@azure-tools/uri": "~3.0.0",
     "js-yaml": "3.13.1",
     "@azure-tools/codegen": "~2.1.0",
     "@azure-tools/codegen-csharp": "~3.0.0",
@@ -60,6 +59,22 @@
     "@azure-tools/openapi": "~3.0.0",
     "@azure-tools/datastore": "~4.0.0",
     "@azure-tools/linq": "~3.1.0",
-    "source-map-support": "0.5.13"
-  }
+    "static-link": "^0.3.0"
+  },
+  "static-link": {
+    "entrypoints": [],
+    "dependencies": {
+      "js-yaml": "3.13.1",
+      "@azure-tools/codegen": "~2.1.0",
+      "@azure-tools/codegen-csharp": "~3.0.0",
+      "@azure-tools/autorest-extension-base": "~3.1.0",
+      "@azure-tools/codemodel": "~3.0.0",
+      "@azure-tools/tasks": "~3.0.0",
+      "@azure-tools/openapi": "~3.0.0",
+      "@azure-tools/datastore": "~4.0.0",
+      "@azure-tools/linq": "~3.1.0",
+      "source-map-support": "0.5.13"
+    }
+  },
+  "dependencies": {}
 }

--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -119,10 +119,12 @@ modelerfour:
     choiceValue:  pascal|camel|snake|upper|kebab|space
     constant:  pascal|camel|snake|upper|kebab|space
     type:  pascal|camel|snake|upper|kebab|space
+    client: pascal|camel|snake|upper|kebab|space
 
     override:  # a key/value mapping of names to force to a certain value 
       cmyk : CMYK
       $host: $host
+      LRO: LRO
 
 ```
 ~~~

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -1757,7 +1757,7 @@ globalParameters:
   required: true
   language: !<!Languages> 
     default:
-      name: apiVersion
+      name: ApiVersion
       description: Api Version
       serializedName: api-version
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -5348,7 +5348,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyComplex
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/additionalProperties/namer.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/namer.yaml
@@ -1093,7 +1093,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: AdditionalProperties
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
@@ -639,7 +639,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: AzureParameterGrouping
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/azure-report/namer.yaml
+++ b/modelerfour/test/scenarios/azure-report/namer.yaml
@@ -178,7 +178,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: AzureReport
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -754,7 +754,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: AzureResourceX
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -754,7 +754,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: AzureResource
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/azure-special-properties/namer.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/namer.yaml
@@ -390,7 +390,7 @@ globalParameters:
   required: true
   language: !<!Languages> 
     default:
-      name: apiVersion
+      name: ApiVersion
       description: Api Version
       serializedName: api-version
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/azure-special-properties/namer.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/namer.yaml
@@ -2121,7 +2121,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: AzureSpecialProperties
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -28906,7 +28906,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: AzureBlobStorage
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -17785,7 +17785,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17799,7 +17799,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17813,7 +17813,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17827,7 +17827,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17841,7 +17841,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17855,7 +17855,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17869,7 +17869,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17883,7 +17883,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17897,7 +17897,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17911,7 +17911,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17925,7 +17925,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17939,7 +17939,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17953,7 +17953,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17967,7 +17967,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17981,7 +17981,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -17995,7 +17995,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18009,7 +18009,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18023,7 +18023,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18037,7 +18037,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18051,7 +18051,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18065,7 +18065,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18079,7 +18079,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18093,7 +18093,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18107,7 +18107,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18121,7 +18121,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18135,7 +18135,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18149,7 +18149,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18163,7 +18163,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18177,7 +18177,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18191,7 +18191,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18205,7 +18205,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18219,7 +18219,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18233,7 +18233,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18247,7 +18247,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18261,7 +18261,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18275,7 +18275,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18289,7 +18289,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18303,7 +18303,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18317,7 +18317,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18331,7 +18331,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18345,7 +18345,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18359,7 +18359,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18373,7 +18373,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18387,7 +18387,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18401,7 +18401,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18415,7 +18415,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18429,7 +18429,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18443,7 +18443,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18457,7 +18457,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18471,7 +18471,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18485,7 +18485,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18499,7 +18499,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18513,7 +18513,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18527,7 +18527,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18541,7 +18541,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18555,7 +18555,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18569,7 +18569,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18583,7 +18583,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18597,7 +18597,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18611,7 +18611,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18625,7 +18625,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18639,7 +18639,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 
@@ -18653,7 +18653,7 @@ globalParameters:
     x-ms-priority: 1
   language: !<!Languages> 
     default:
-      name: version
+      name: Version
       description: Specifies the version of the operation to use for this request.
       serializedName: x-ms-version
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/body-array/namer.yaml
+++ b/modelerfour/test/scenarios/body-array/namer.yaml
@@ -4359,7 +4359,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyArray
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
@@ -429,7 +429,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyBooleanQuirks
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-boolean/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean/namer.yaml
@@ -469,7 +469,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyBoolean
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-byte/namer.yaml
+++ b/modelerfour/test/scenarios/body-byte/namer.yaml
@@ -421,7 +421,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyByte
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -1769,7 +1769,7 @@ globalParameters:
   required: true
   language: !<!Languages> 
     default:
-      name: apiVersion
+      name: ApiVersion
       description: Api Version
       serializedName: api-version
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -5360,7 +5360,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyComplex
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-date/namer.yaml
+++ b/modelerfour/test/scenarios/body-date/namer.yaml
@@ -557,7 +557,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyDate
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
@@ -609,7 +609,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyDatetimeRfc1123
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-datetime/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime/namer.yaml
@@ -1319,7 +1319,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyDatetime
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-dictionary/namer.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/namer.yaml
@@ -3952,7 +3952,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyDictionary
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-duration/namer.yaml
+++ b/modelerfour/test/scenarios/body-duration/namer.yaml
@@ -313,7 +313,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyDuration
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-file/namer.yaml
+++ b/modelerfour/test/scenarios/body-file/namer.yaml
@@ -236,7 +236,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyFile
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-integer/namer.yaml
+++ b/modelerfour/test/scenarios/body-integer/namer.yaml
@@ -910,7 +910,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyInteger
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-number.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/namer.yaml
@@ -1721,7 +1721,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyNumberQuirks
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-number/namer.yaml
+++ b/modelerfour/test/scenarios/body-number/namer.yaml
@@ -1767,7 +1767,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyNumber
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-string.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/namer.yaml
@@ -1377,7 +1377,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyStringQuirks
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-string/namer.yaml
+++ b/modelerfour/test/scenarios/body-string/namer.yaml
@@ -1373,7 +1373,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: BodyString
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -709,7 +709,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: ComplexModel
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -374,7 +374,7 @@ globalParameters:
     x-ms-priority: 0
   language: !<!Languages> 
     default:
-      name: subscriptionId
+      name: SubscriptionId
       description: Subscription ID.
       serializedName: subscriptionId
   protocol: !<!Protocols> 
@@ -401,7 +401,7 @@ globalParameters:
   required: true
   language: !<!Languages> 
     default:
-      name: apiVersion
+      name: ApiVersion
       description: Api Version
       serializedName: api-version
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
@@ -247,7 +247,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: CustomBaseUrlMoreOptions
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
@@ -452,7 +452,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: CustomBaseUrlPaging
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
@@ -167,7 +167,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: CustomBaseUrl
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/datalake-storage/namer.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/namer.yaml
@@ -6459,7 +6459,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: AzureDataLakeStorageRestApi
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
@@ -288,7 +288,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: ExtensibleEnumsSwagger
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/head-exceptions/namer.yaml
+++ b/modelerfour/test/scenarios/head-exceptions/namer.yaml
@@ -164,7 +164,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: HeadExceptions
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/head/namer.yaml
+++ b/modelerfour/test/scenarios/head/namer.yaml
@@ -191,7 +191,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: Head
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/header/namer.yaml
+++ b/modelerfour/test/scenarios/header/namer.yaml
@@ -2132,7 +2132,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: Header
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
@@ -6386,7 +6386,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: HttpInfrastructureQuirks
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
@@ -6374,7 +6374,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: HttpInfrastructure
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -19044,7 +19044,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: KeyVaultClient
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -8547,7 +8547,7 @@ globalParameters:
   required: true
   language: !<!Languages> 
     default:
-      name: apiVersion
+      name: ApiVersion
       description: Api Version
       serializedName: api-version
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -6286,7 +6286,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: Lro
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -1821,7 +1821,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: ModelFlattening
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/paging/namer.yaml
+++ b/modelerfour/test/scenarios/paging/namer.yaml
@@ -1694,7 +1694,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: Paging
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/parameter-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/namer.yaml
@@ -182,7 +182,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: ParameterFlattening
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/report/namer.yaml
+++ b/modelerfour/test/scenarios/report/namer.yaml
@@ -240,7 +240,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: Report
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/required-optional/namer.yaml
+++ b/modelerfour/test/scenarios/required-optional/namer.yaml
@@ -2457,7 +2457,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: RequiredOptional
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -2205,7 +2205,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: Storage
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -1469,7 +1469,7 @@ globalParameters:
   required: true
   language: !<!Languages> 
     default:
-      name: apiVersion
+      name: ApiVersion
       description: Api Version
       serializedName: api-version
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
@@ -250,7 +250,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: SubscriptionIdApiVersion
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
@@ -165,7 +165,7 @@ globalParameters:
   required: true
   language: !<!Languages> 
     default:
-      name: apiVersion
+      name: ApiVersion
       description: Api Version
       serializedName: api-version
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/text-analytics/namer.yaml
+++ b/modelerfour/test/scenarios/text-analytics/namer.yaml
@@ -3177,7 +3177,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: TextAnalyticsClient
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
@@ -306,7 +306,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: UrlMultiCollectionFormat
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/url/namer.yaml
+++ b/modelerfour/test/scenarios/url/namer.yaml
@@ -4911,7 +4911,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: Url
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/validation/namer.yaml
+++ b/modelerfour/test/scenarios/validation/namer.yaml
@@ -507,7 +507,7 @@ globalParameters:
   required: true
   language: !<!Languages> 
     default:
-      name: apiVersion
+      name: ApiVersion
       description: Api Version
       serializedName: apiVersion
   protocol: !<!Protocols> 

--- a/modelerfour/test/scenarios/validation/namer.yaml
+++ b/modelerfour/test/scenarios/validation/namer.yaml
@@ -815,7 +815,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: Validation
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -4209,7 +4209,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: XmlService
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/xms-error-responses/namer.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/namer.yaml
@@ -686,7 +686,7 @@ operationGroups:
   protocol: !<!Protocols> {}
 language: !<!Languages> 
   default:
-    name: ''
+    name: XmsErrorResponses
     description: ''
 protocol: !<!Protocols> 
   http: !<!HttpModel> {}

--- a/modelerfour/test/test-modeler.ts
+++ b/modelerfour/test/test-modeler.ts
@@ -178,6 +178,8 @@ async function createPassThruSession(config: any, input: string, inputArtifactTy
               'cmyk': 'CMYK'
             },
             /*
+            for when playing with python style settings :
+
             parameter: 'snakecase',
             property: 'snakecase',
             operation: 'snakecase',

--- a/modelerfour/test/test-modeler.ts
+++ b/modelerfour/test/test-modeler.ts
@@ -176,9 +176,17 @@ async function createPassThruSession(config: any, input: string, inputArtifactTy
             override: {
               '$host': '$host',
               'cmyk': 'CMYK'
-            }
-            // constant: 'uppercase',
-            //property: 'snakecase'
+            },
+            /*
+            parameter: 'snakecase',
+            property: 'snakecase',
+            operation: 'snakecase',
+            operationGroup: 'pascalcase',
+            choice: 'pascalcase',
+            choiceValue: 'uppercase',
+            constant: 'uppercase',
+            type: 'pascalcase',
+            */
           }
         },
         'payload-flattening-threshold': 2


### PR DESCRIPTION
- added group client for naming
- set client name in root `.language.default.name`
- added `LRO` as a override
- constant parameters are now formatted as constants 


plus: now, static-linked to avoid future dependency pickup problems