### PR TITLE
Track schema usage contexts and media types in code model

### DIFF
--- a/modelerfour/grouper/grouper.ts
+++ b/modelerfour/grouper/grouper.ts
@@ -1,4 +1,4 @@
-import { CodeModel, Schema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request } from '@azure-tools/codemodel';
+import { CodeModel, Schema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
 import { Session } from '@azure-tools/autorest-extension-base';
 import { values, items, length, Dictionary, refCount, clone } from '@azure-tools/linq';
 import { pascalCase, camelCase } from '@azure-tools/codegen';
@@ -76,6 +76,7 @@ export class Grouper {
         if (!this.groups[groupName]) {
           // create a new object schema for this group
           const schema = new GroupSchema(groupName, 'Parameter group');
+          schema.usage = [SchemaContext.Input];
           this.groups[groupName] = schema;
           this.codeModel.schemas.add(schema);
         }

--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -1,7 +1,7 @@
 import { Model as oai3, Dereferenced, dereference, Refable, JsonType, IntegerFormat, StringFormat, NumberFormat, MediaType, filterOutXDash } from '@azure-tools/openapi';
 import * as OpenAPI from '@azure-tools/openapi';
 import { items, values, Dictionary, length, keys } from '@azure-tools/linq';
-import { HttpMethod, HttpModel, CodeModel, Operation, SetType, HttpRequest, BooleanSchema, Schema, NumberSchema, ArraySchema, Parameter, ChoiceSchema, StringSchema, ObjectSchema, ByteArraySchema, CharSchema, DateSchema, DateTimeSchema, DurationSchema, UuidSchema, UriSchema, CredentialSchema, ODataQuerySchema, UnixTimeSchema, SchemaType, OrSchema, XorSchema, DictionarySchema, ParameterLocation, SerializationStyle, ImplementationLocation, Property, ComplexSchema, HttpWithBodyRequest, HttpBinaryRequest, HttpParameter, Response, HttpResponse, HttpBinaryResponse, SchemaResponse, SealedChoiceSchema, ExternalDocumentation, BinaryResponse, BinarySchema, Discriminator, Relations, AnySchema, ConstantSchema, ConstantValue, HttpHeader, ChoiceValue, Language, Request, OperationGroup } from '@azure-tools/codemodel';
+import { HttpMethod, HttpModel, CodeModel, Operation, SetType, HttpRequest, BooleanSchema, Schema, NumberSchema, ArraySchema, Parameter, ChoiceSchema, StringSchema, ObjectSchema, ByteArraySchema, CharSchema, DateSchema, DateTimeSchema, DurationSchema, UuidSchema, UriSchema, CredentialSchema, ODataQuerySchema, UnixTimeSchema, SchemaType, SchemaContext, OrSchema, XorSchema, DictionarySchema, ParameterLocation, SerializationStyle, ImplementationLocation, Property, ComplexSchema, HttpWithBodyRequest, HttpBinaryRequest, HttpParameter, Response, HttpResponse, HttpBinaryResponse, SchemaResponse, SealedChoiceSchema, ExternalDocumentation, BinaryResponse, BinarySchema, Discriminator, Relations, AnySchema, ConstantSchema, ConstantValue, HttpHeader, ChoiceValue, Language, Request, OperationGroup } from '@azure-tools/codemodel';
 import { Session } from '@azure-tools/autorest-extension-base';
 import { Interpretations, XMSEnum } from './interpretations';
 import { fail, minimum, pascalCase, knownMediaType, KnownMediaType } from '@azure-tools/codegen';
@@ -11,6 +11,49 @@ function is(value: any): asserts value is object | string | number | boolean {
   if (value === undefined || value === null) {
     throw new Error(`Intenral assertion failure -- value must not be null`);
   }
+}
+
+/**
+ * Contains usage information for one appearance of a schema.  Used to propagate
+ * context from the usage of a schema to all schemas it references.
+ */
+interface SchemaUsage {
+  context?: SchemaContext,
+  knownMediaType?: string
+}
+
+function pushIfMissing<T>(targetArray: T[], newValue: T): void {
+  if (targetArray.indexOf(newValue) === -1) {
+    targetArray.push(newValue);
+  }
+}
+
+function applySchemaUsage(schemaUsage: SchemaUsage, schema: Schema): void {
+  const processedSchemas = new Set<Schema>();
+
+  function innerApplySchemaUsage(schema: Schema) {
+    if (processedSchemas.has(schema)) {
+      return;
+    }
+
+    processedSchemas.add(schema);
+    if (schema instanceof ObjectSchema) {
+      if (schemaUsage.context) {
+        pushIfMissing(schema.contexts = (schema.contexts || []), schemaUsage.context);
+      }
+      if (schemaUsage.knownMediaType) {
+        pushIfMissing(schema.knownMediaTypes = (schema.knownMediaTypes || []), schemaUsage.knownMediaType);
+      }
+
+      schema.properties?.forEach(p => innerApplySchemaUsage(p.schema));
+    } else if (schema instanceof DictionarySchema) {
+      innerApplySchemaUsage(schema.elementType);
+    } else if (schema instanceof ArraySchema) {
+      innerApplySchemaUsage(schema.elementType);
+    }
+  }
+
+  innerApplySchemaUsage(schema);
 }
 
 export class ModelerFour {
@@ -42,7 +85,7 @@ export class ModelerFour {
   }
 
   async init() {
-    // grab override-client-name 
+    // grab override-client-name
     const newTitle = await this.session.getValue('override-client-name', '');
     if (newTitle) {
       this.codeModel.info.title = newTitle;
@@ -502,7 +545,7 @@ export class ModelerFour {
     const hasProperties = length(schema.properties) > 0;
 
     if (!isMoreThanObject && !hasProperties) {
-      // it's an empty object? 
+      // it's an empty object?
       this.session.warning(`Schema '${name}' is an empty object without properties or modifiers.`, ['Modeler', 'EmptyObject'], aSchema);
     }
 
@@ -635,7 +678,7 @@ export class ModelerFour {
         case undefined:
         case null:
           if (schema.properties) {
-            // if the model has properties, then we're going to assume they meant to say JsonType.object 
+            // if the model has properties, then we're going to assume they meant to say JsonType.object
             // but we're going to warn them anyway.
 
             this.session.warning(`The schema '${schema?.['x-ms-metadata']?.name || name}' with an undefined type and decalared properties is a bit ambigious. This has been auto-corrected to 'type:object'`, ['Modeler', 'MissingType'], schema);
@@ -652,7 +695,7 @@ export class ModelerFour {
           }
 
           if (schema.allOf || schema.anyOf || schema.oneOf) {
-            // if the model has properties, then we're going to assume they meant to say JsonType.object 
+            // if the model has properties, then we're going to assume they meant to say JsonType.object
             // but we're going to warn them anyway.
             this.session.warning(`The schema '${schema?.['x-ms-metadata']?.name || name}' with an undefined type and 'allOf'/'anyOf'/'oneOf' is a bit ambigious. This has been auto-corrected to 'type:object'`, ['Modeler', 'MissingType'], schema);
             schema.type = OpenAPI.JsonType.Object;
@@ -660,7 +703,7 @@ export class ModelerFour {
           }
 
           {
-            // no type info at all!? 
+            // no type info at all!?
             // const err = `The schema '${name}' has no type or format information whatsoever. ${this.location(schema)}`;
             this.session.warning(`The schema '${schema?.['x-ms-metadata']?.name || name}' has no type or format information whatsoever. ${this.location(schema)}`, ['Modeler', 'MissingType'], schema);
             // throw Error(err);
@@ -807,7 +850,7 @@ export class ModelerFour {
     //if (length(mediaTypeGroups.keys()) > 0) {
     // because the oai2-to-oai3 conversion doesn't have good logic to know
     // which produces type maps to each operation response,
-    // we have to go thru the possible combinations 
+    // we have to go thru the possible combinations
     // and eliminate ones that don't make sense.
     // (ie, a binary media type should have a binary response type, a json or xml media type should have a <not binary> type ).
     for (const [knownMediaType, mt] of [...mediaTypeGroups.entries()]) {
@@ -855,7 +898,7 @@ export class ModelerFour {
     });
 
     if (http.mediaTypes.length > 0) {
-      // we have multiple media types 
+      // we have multiple media types
       // make sure we have an enum for the content-type
       // and add a content type parameter to the request
       const choices = http.mediaTypes.sort().map(each => new ChoiceValue(each, `Content Type '${each}'`, each));
@@ -866,7 +909,7 @@ export class ModelerFour {
         new SealedChoiceSchema('ContentType', 'Content type for upload', { choices })
       );
 
-      // add the parameter for the binary upload. 
+      // add the parameter for the binary upload.
       httpRequest.addParameter(new Parameter('content-type', 'Upload file type', scs, {
         implementation: ImplementationLocation.Method
       }))
@@ -894,7 +937,7 @@ export class ModelerFour {
     return operation.addRequest(httpRequest);
   }
 
-  processSerializedObject(kmt: KnownMediaType, kmtObject: Array<{ mediaType: string; schema: Dereferenced<OpenAPI.Schema | undefined>; }>, operation: Operation, body: Dereferenced<OpenAPI.RequestBody | undefined>) {
+  processSerializedObject(kmt: KnownMediaType, kmtObject: Array<{ mediaType: string; schema: Dereferenced<OpenAPI.Schema | undefined>; }>, operation: Operation, body: Dereferenced<OpenAPI.RequestBody | undefined>, usage?: SchemaUsage) {
     if (!body?.instance) {
       throw new Error('NO BODY DUDE.');
 
@@ -914,6 +957,9 @@ export class ModelerFour {
 
     const requestSchema = values(kmtObject).first(each => !!each.schema.instance)?.schema;
     const pSchema = this.processSchema(requestSchema?.name || 'requestBody', requestSchema?.instance || <OpenAPI.Schema>{})
+
+    // Track the usage of this schema as an input with media type
+    applySchemaUsage({ context: SchemaContext.Input, knownMediaType: kmt }, pSchema);
 
     httpRequest.addParameter(new Parameter(
       body.instance?.['x-ms-requestBody-name'] ?? 'body',
@@ -970,13 +1016,13 @@ export class ModelerFour {
       // === Host Parameters ===
       const baseUri = this.processHostParameters(httpOperation, operation, path, pathItem);
 
-      // === Common Parameters === 
+      // === Common Parameters ===
       this.processParameters(httpOperation, operation, pathItem);
 
-      // === Requests === 
+      // === Requests ===
       this.processRequestBody(httpOperation, httpMethod, operationGroup, operation, path, baseUri);
 
-      // === Response === 
+      // === Response ===
       this.processResponses(httpOperation, operation);
     });
   }
@@ -1116,19 +1162,19 @@ export class ModelerFour {
       this.use(parameter.schema, (name, schema) => {
 
         if (this.interpret.isApiVersionParameter(parameter)) {
-          // use the API versions information for this operation to give the values that should be used 
-          // notes: 
+          // use the API versions information for this operation to give the values that should be used
+          // notes:
           // legal values for apiversion parameter, are the x-ms-metadata.apiversions values
 
           // if there is a single apiversion value, you'll see a constant parameter.
 
-          // if there are multiple apiversion values, 
+          // if there are multiple apiversion values,
           //  - and profile are provided, you'll get a sealed conditional parameter that has values dependent upon choosing a profile.
           //  - otherwise, you'll get a sealed choice parameter.
 
           const apiversions = this.interpret.getApiVersionValues(pathItem);
           if (apiversions.length === 0) {
-            // !!! 
+            // !!!
             throw new Error(`Operation ${pathItem?.['x-ms-metadata']?.path} has no apiversions but has an apiversion parameter.`);
           }
           if (apiversions.length === 1) {
@@ -1178,6 +1224,9 @@ export class ModelerFour {
           }
           const parameterSchema = this.processSchema(name || '', schema);
 
+          // Track the usage of this schema as an input with media type
+          applySchemaUsage({ context: SchemaContext.Input }, parameterSchema);
+
           const newParam = operation.addParameter(new Parameter(this.interpret.getPreferredName(parameter, schema['x-ms-client-name'] || parameter.name), this.interpret.getDescription('', parameter), parameterSchema, {
             required: parameter.required ? true : undefined,
             implementation,
@@ -1211,7 +1260,7 @@ export class ModelerFour {
   }
 
   processResponses(httpOperation: OpenAPI.HttpOperation, operation: Operation, ) {
-    // === Response === 
+    // === Response ===
     for (const { key: responseCode, value: response } of this.resolveDictionary(httpOperation.responses)) {
 
       const isErr = responseCode === 'default' || response['x-ms-error-response'];
@@ -1279,12 +1328,16 @@ export class ModelerFour {
           if (schema) {
             let s = this.processSchema('response', schema);
 
-            // response schemas should not be constant types. 
+            // response schemas should not be constant types.
             // this replaces the constant value with the value type itself.
 
             if (s.type === SchemaType.Constant) {
               s = (<ConstantSchema>s).valueType;
             }
+
+            // Track the usage of this schema as an output with media type
+            applySchemaUsage({ context: SchemaContext.Output, knownMediaType }, s);
+
             const rsp = new SchemaResponse(s, {
               extensions: this.interpret.getExtensionProperties(response)
             });
@@ -1340,17 +1393,17 @@ export class ModelerFour {
       }
       const kmtJSON = groupedMediaTypes.get(KnownMediaType.Json);
       if (kmtJSON) {
-        this.processSerializedObject(KnownMediaType.Json, kmtJSON, operation, requestBody);
+        this.processSerializedObject(KnownMediaType.Json, kmtJSON, operation, requestBody, { context: SchemaContext.Input });
       }
       const kmtXML = groupedMediaTypes.get(KnownMediaType.Xml);
       if (kmtXML && !kmtJSON) {
         // only do XML if there is not a JSON body
-        this.processSerializedObject(KnownMediaType.Xml, kmtXML, operation, requestBody);
+        this.processSerializedObject(KnownMediaType.Xml, kmtXML, operation, requestBody, { context: SchemaContext.Input });
       }
       const kmtForm = groupedMediaTypes.get(KnownMediaType.Form);
       if (kmtForm && !kmtXML && !kmtJSON) {
         // only do FORM if there is not an JSON or XML body
-        this.processSerializedObject(KnownMediaType.Form, kmtForm, operation, requestBody);
+        this.processSerializedObject(KnownMediaType.Form, kmtForm, operation, requestBody, { context: SchemaContext.Input });
       }
       const kmtMultipart = groupedMediaTypes.get(KnownMediaType.Multipart);
       if (kmtMultipart) {
@@ -1360,7 +1413,7 @@ export class ModelerFour {
         // create multipart form upload for this.
         this.processMultipart(kmtMultipart, operation, requestBody);
       }
-      // ensure the protocol information is set on the requests 
+      // ensure the protocol information is set on the requests
       for (const request of values(operation.requests)) {
         is(request.protocol.http);
         request.protocol.http.method = httpMethod;

--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/modelerfour",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "AutoRest Modeler Version Four (component)",
   "directories": {
     "doc": "docs"

--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -54,7 +54,7 @@
     "@azure-tools/codegen": "~2.4.0",
     "@azure-tools/codegen-csharp": "~3.0.0",
     "@azure-tools/autorest-extension-base": "~3.1.0",
-    "@azure-tools/codemodel": "~3.1.0",
+    "@azure-tools/codemodel": "~3.2.0",
     "@azure-tools/tasks": "~3.0.0",
     "@azure-tools/openapi": "~3.0.0",
     "@azure-tools/datastore": "~4.1.0",

--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -512,6 +512,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -548,6 +553,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -576,6 +585,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -604,6 +618,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -632,6 +651,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -660,6 +684,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -688,6 +717,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -716,6 +750,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -752,6 +791,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -780,6 +824,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -808,6 +857,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -836,6 +890,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -856,6 +915,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -876,6 +940,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -906,6 +975,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -965,6 +1039,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1102,6 +1181,9 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
+        contexts:
+        - output
+        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1118,6 +1200,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1287,6 +1371,9 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
+    contexts:
+    - output
+    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1299,6 +1386,8 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
+    knownMediaTypes:
+    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1356,7 +1445,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
         discriminatorValue: DotSalmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1387,6 +1480,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1402,6 +1497,8 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1424,6 +1521,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1490,6 +1591,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1551,6 +1657,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1566,6 +1674,8 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1600,6 +1710,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61

--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -512,11 +512,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -542,6 +537,11 @@ schemas: !<!Schemas>
           name: color
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: basic
@@ -553,10 +553,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -574,6 +570,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -585,11 +585,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -607,6 +602,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -618,11 +618,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -640,6 +635,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: long-wrapper
@@ -651,11 +651,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -673,6 +668,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: float-wrapper
@@ -684,11 +684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -706,6 +701,11 @@ schemas: !<!Schemas>
           name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: double-wrapper
@@ -717,11 +717,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -739,6 +734,11 @@ schemas: !<!Schemas>
           name: field_false
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: boolean-wrapper
@@ -750,11 +750,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -780,6 +775,11 @@ schemas: !<!Schemas>
           name: 'null'
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -791,11 +791,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -813,6 +808,11 @@ schemas: !<!Schemas>
           name: leap
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: date-wrapper
@@ -824,11 +824,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -846,6 +841,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetime-wrapper
@@ -857,11 +857,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -879,6 +874,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetimerfc1123-wrapper
@@ -890,11 +890,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -904,6 +899,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: duration-wrapper
@@ -915,11 +915,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -929,6 +924,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: byte-wrapper
@@ -940,11 +940,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -964,6 +959,11 @@ schemas: !<!Schemas>
           name: array
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -975,11 +975,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -989,6 +984,11 @@ schemas: !<!Schemas>
           name: defaultProgram
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: dictionary-wrapper
@@ -1021,6 +1021,11 @@ schemas: !<!Schemas>
               name: food
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: dog
@@ -1039,11 +1044,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1059,6 +1059,11 @@ schemas: !<!Schemas>
                   name: breed
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: siamese
@@ -1099,6 +1104,11 @@ schemas: !<!Schemas>
               name: hates
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: cat
@@ -1126,6 +1136,11 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: pet
@@ -1181,9 +1196,6 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
-        contexts:
-        - output
-        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1200,8 +1212,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1224,6 +1234,11 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: salmon
@@ -1371,9 +1386,6 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
-    contexts:
-    - output
-    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1386,8 +1398,6 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
-    knownMediaTypes:
-    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1427,6 +1437,11 @@ schemas: !<!Schemas>
           name: siblings
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Fish
@@ -1445,11 +1460,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
         discriminatorValue: DotSalmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1472,6 +1483,10 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DotSalmon
@@ -1480,8 +1495,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1497,8 +1510,6 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1510,6 +1521,10 @@ schemas: !<!Schemas>
           name: species
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFish
@@ -1521,10 +1536,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1578,6 +1589,10 @@ schemas: !<!Schemas>
           name: fishes
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFishMarket
@@ -1591,11 +1606,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1614,6 +1624,11 @@ schemas: !<!Schemas>
           name: size
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: readonly-obj
@@ -1657,8 +1672,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1674,8 +1687,6 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1699,6 +1710,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyBaseType
@@ -1710,10 +1725,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -1723,6 +1734,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -512,6 +512,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -548,6 +553,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -576,6 +585,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -604,6 +618,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -632,6 +651,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -660,6 +684,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -688,6 +717,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -716,6 +750,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -752,6 +791,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -780,6 +824,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -808,6 +857,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -836,6 +890,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -856,6 +915,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -876,6 +940,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -906,6 +975,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -965,6 +1039,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1102,6 +1181,9 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
+        contexts:
+        - output
+        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1118,6 +1200,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1287,6 +1371,9 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
+    contexts:
+    - output
+    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1299,6 +1386,8 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
+    knownMediaTypes:
+    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1356,7 +1445,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
         discriminatorValue: DotSalmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1387,6 +1480,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1402,6 +1497,8 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1424,6 +1521,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1490,6 +1591,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1551,6 +1657,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1566,6 +1674,8 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1600,6 +1710,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -512,11 +512,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -542,6 +537,11 @@ schemas: !<!Schemas>
           name: color
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: basic
@@ -553,10 +553,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -574,6 +570,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -585,11 +585,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -607,6 +602,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -618,11 +618,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -640,6 +635,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: long-wrapper
@@ -651,11 +651,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -673,6 +668,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: float-wrapper
@@ -684,11 +684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -706,6 +701,11 @@ schemas: !<!Schemas>
           name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: double-wrapper
@@ -717,11 +717,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -739,6 +734,11 @@ schemas: !<!Schemas>
           name: field_false
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: boolean-wrapper
@@ -750,11 +750,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -780,6 +775,11 @@ schemas: !<!Schemas>
           name: 'null'
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -791,11 +791,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -813,6 +808,11 @@ schemas: !<!Schemas>
           name: leap
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: date-wrapper
@@ -824,11 +824,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -846,6 +841,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetime-wrapper
@@ -857,11 +857,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -879,6 +874,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetimerfc1123-wrapper
@@ -890,11 +890,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -904,6 +899,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: duration-wrapper
@@ -915,11 +915,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -929,6 +924,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: byte-wrapper
@@ -940,11 +940,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -964,6 +959,11 @@ schemas: !<!Schemas>
           name: array
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -975,11 +975,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -989,6 +984,11 @@ schemas: !<!Schemas>
           name: defaultProgram
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: dictionary-wrapper
@@ -1021,6 +1021,11 @@ schemas: !<!Schemas>
               name: food
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: dog
@@ -1039,11 +1044,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1059,6 +1059,11 @@ schemas: !<!Schemas>
                   name: breed
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: siamese
@@ -1099,6 +1104,11 @@ schemas: !<!Schemas>
               name: hates
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: cat
@@ -1126,6 +1136,11 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: pet
@@ -1181,9 +1196,6 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
-        contexts:
-        - output
-        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1200,8 +1212,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1224,6 +1234,11 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: salmon
@@ -1371,9 +1386,6 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
-    contexts:
-    - output
-    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1386,8 +1398,6 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
-    knownMediaTypes:
-    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1427,6 +1437,11 @@ schemas: !<!Schemas>
           name: siblings
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Fish
@@ -1445,11 +1460,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
         discriminatorValue: DotSalmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1472,6 +1483,10 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DotSalmon
@@ -1480,8 +1495,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1497,8 +1510,6 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1510,6 +1521,10 @@ schemas: !<!Schemas>
           name: species
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFish
@@ -1521,10 +1536,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1578,6 +1589,10 @@ schemas: !<!Schemas>
           name: fishes
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFishMarket
@@ -1591,11 +1606,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1614,6 +1624,11 @@ schemas: !<!Schemas>
           name: size
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: readonly-obj
@@ -1657,8 +1672,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1674,8 +1687,6 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1699,6 +1710,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyBaseType
@@ -1710,10 +1725,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -1723,6 +1734,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 

--- a/modelerfour/test/scenarios/a-playground/modeler.yaml
+++ b/modelerfour/test/scenarios/a-playground/modeler.yaml
@@ -512,11 +512,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_48
@@ -542,6 +537,11 @@ schemas: !<!Schemas>
           name: color
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: basic
@@ -553,10 +553,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -574,6 +570,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -585,11 +585,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -607,6 +602,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -618,11 +618,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -640,6 +635,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: long-wrapper
@@ -651,11 +651,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -673,6 +668,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: float-wrapper
@@ -684,11 +684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -706,6 +701,11 @@ schemas: !<!Schemas>
           name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: double-wrapper
@@ -717,11 +717,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -739,6 +734,11 @@ schemas: !<!Schemas>
           name: field_false
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: boolean-wrapper
@@ -750,11 +750,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -780,6 +775,11 @@ schemas: !<!Schemas>
           name: 'null'
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -791,11 +791,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_52
@@ -813,6 +808,11 @@ schemas: !<!Schemas>
           name: leap
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: date-wrapper
@@ -824,11 +824,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -846,6 +841,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetime-wrapper
@@ -857,11 +857,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_56
@@ -879,6 +874,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetimerfc1123-wrapper
@@ -890,11 +890,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_59
@@ -904,6 +899,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: duration-wrapper
@@ -915,11 +915,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -929,6 +924,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: byte-wrapper
@@ -940,11 +940,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_62
@@ -964,6 +959,11 @@ schemas: !<!Schemas>
           name: array
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -975,11 +975,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_67
@@ -989,6 +984,11 @@ schemas: !<!Schemas>
           name: defaultProgram
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: dictionary-wrapper
@@ -1021,6 +1021,11 @@ schemas: !<!Schemas>
               name: food
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: dog
@@ -1039,11 +1044,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             parents: !<!Relations> 
               all:
               - *ref_19
@@ -1059,6 +1059,11 @@ schemas: !<!Schemas>
                   name: breed
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: siamese
@@ -1099,6 +1104,11 @@ schemas: !<!Schemas>
               name: hates
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: cat
@@ -1126,6 +1136,11 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: pet
@@ -1181,9 +1196,6 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_29
-        contexts:
-        - output
-        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_29
@@ -1200,8 +1212,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_23
@@ -1224,6 +1234,11 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: salmon
@@ -1371,9 +1386,6 @@ schemas: !<!Schemas>
       immediate:
       - *ref_27
       - *ref_30
-    contexts:
-    - output
-    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_33
@@ -1386,8 +1398,6 @@ schemas: !<!Schemas>
         salmon: *ref_27
         shark: *ref_30
       property: *ref_24
-    knownMediaTypes:
-    - json
     properties:
     - *ref_24
     - !<!Property> 
@@ -1427,6 +1437,11 @@ schemas: !<!Schemas>
           name: siblings
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Fish
@@ -1445,11 +1460,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
         discriminatorValue: DotSalmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_38
@@ -1472,6 +1483,10 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DotSalmon
@@ -1480,8 +1495,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_39
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_39
@@ -1497,8 +1510,6 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_36
     - !<!Property> 
@@ -1510,6 +1521,10 @@ schemas: !<!Schemas>
           name: species
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFish
@@ -1521,10 +1536,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_39
@@ -1578,6 +1589,10 @@ schemas: !<!Schemas>
           name: fishes
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFishMarket
@@ -1591,11 +1606,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_40
@@ -1614,6 +1624,11 @@ schemas: !<!Schemas>
           name: size
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: readonly-obj
@@ -1657,8 +1672,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_46
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_46
@@ -1674,8 +1687,6 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_43
     - !<!Property> 
@@ -1693,10 +1704,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_42
@@ -1706,6 +1713,10 @@ schemas: !<!Schemas>
               name: propBH1
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: MyBaseHelperType
@@ -1721,6 +1732,10 @@ schemas: !<!Schemas>
           name: helper
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyBaseType

--- a/modelerfour/test/scenarios/a-playground/modeler.yaml
+++ b/modelerfour/test/scenarios/a-playground/modeler.yaml
@@ -512,6 +512,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_48
@@ -548,6 +553,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -576,6 +585,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -604,6 +618,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -632,6 +651,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -660,6 +684,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -688,6 +717,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -716,6 +750,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -752,6 +791,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_52
@@ -780,6 +824,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -808,6 +857,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_56
@@ -836,6 +890,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_59
@@ -856,6 +915,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -876,6 +940,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_62
@@ -906,6 +975,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_67
@@ -965,6 +1039,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             parents: !<!Relations> 
               all:
               - *ref_19
@@ -1102,6 +1181,9 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_29
+        contexts:
+        - output
+        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_29
@@ -1118,6 +1200,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_23
@@ -1287,6 +1371,9 @@ schemas: !<!Schemas>
       immediate:
       - *ref_27
       - *ref_30
+    contexts:
+    - output
+    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_33
@@ -1299,6 +1386,8 @@ schemas: !<!Schemas>
         salmon: *ref_27
         shark: *ref_30
       property: *ref_24
+    knownMediaTypes:
+    - json
     properties:
     - *ref_24
     - !<!Property> 
@@ -1356,7 +1445,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
         discriminatorValue: DotSalmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_38
@@ -1387,6 +1480,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_39
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_39
@@ -1402,6 +1497,8 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_36
     - !<!Property> 
@@ -1424,6 +1521,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_39
@@ -1490,6 +1591,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_40
@@ -1551,6 +1657,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_46
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_46
@@ -1566,6 +1674,8 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_43
     - !<!Property> 
@@ -1583,6 +1693,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_42

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -512,11 +512,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -542,6 +537,11 @@ schemas: !<!Schemas>
           name: color
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Basic
@@ -553,10 +553,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -574,6 +570,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -585,11 +585,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -607,6 +602,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: IntWrapper
@@ -618,11 +618,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -640,6 +635,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: LongWrapper
@@ -651,11 +651,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -673,6 +668,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: FloatWrapper
@@ -684,11 +684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -706,6 +701,11 @@ schemas: !<!Schemas>
           name: field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DoubleWrapper
@@ -717,11 +717,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -739,6 +734,11 @@ schemas: !<!Schemas>
           name: fieldFalse
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: BooleanWrapper
@@ -750,11 +750,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -780,6 +775,11 @@ schemas: !<!Schemas>
           name: 'null'
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: StringWrapper
@@ -791,11 +791,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -813,6 +808,11 @@ schemas: !<!Schemas>
           name: leap
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DateWrapper
@@ -824,11 +824,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -846,6 +841,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DatetimeWrapper
@@ -857,11 +857,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -879,6 +874,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Datetimerfc1123Wrapper
@@ -890,11 +890,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -904,6 +899,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DurationWrapper
@@ -915,11 +915,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -929,6 +924,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: ByteWrapper
@@ -940,11 +940,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -964,6 +959,11 @@ schemas: !<!Schemas>
           name: array
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: ArrayWrapper
@@ -975,11 +975,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -989,6 +984,11 @@ schemas: !<!Schemas>
           name: defaultProgram
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DictionaryWrapper
@@ -1021,6 +1021,11 @@ schemas: !<!Schemas>
               name: food
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Dog
@@ -1039,11 +1044,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1059,6 +1059,11 @@ schemas: !<!Schemas>
                   name: breed
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: Siamese
@@ -1099,6 +1104,11 @@ schemas: !<!Schemas>
               name: hates
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Cat
@@ -1126,6 +1136,11 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Pet
@@ -1181,9 +1196,6 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
-        contexts:
-        - output
-        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1200,8 +1212,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1224,6 +1234,11 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Salmon
@@ -1371,9 +1386,6 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
-    contexts:
-    - output
-    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1386,8 +1398,6 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
-    knownMediaTypes:
-    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1427,6 +1437,11 @@ schemas: !<!Schemas>
           name: siblings
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Fish
@@ -1445,11 +1460,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
         discriminatorValue: DotSalmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1472,6 +1483,10 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DotSalmon
@@ -1480,8 +1495,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1497,8 +1510,6 @@ schemas: !<!Schemas>
             name: fishType
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1510,6 +1521,10 @@ schemas: !<!Schemas>
           name: species
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFish
@@ -1521,10 +1536,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1578,6 +1589,10 @@ schemas: !<!Schemas>
           name: fishes
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFishMarket
@@ -1591,11 +1606,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1614,6 +1624,11 @@ schemas: !<!Schemas>
           name: size
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: ReadonlyObj
@@ -1657,8 +1672,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1674,8 +1687,6 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1699,6 +1710,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyBaseType
@@ -1710,10 +1725,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -1723,6 +1734,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -512,6 +512,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -548,6 +553,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -576,6 +585,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -604,6 +618,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -632,6 +651,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -660,6 +684,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -688,6 +717,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -716,6 +750,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -752,6 +791,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -780,6 +824,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -808,6 +857,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -836,6 +890,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -856,6 +915,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -876,6 +940,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -906,6 +975,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -965,6 +1039,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1102,6 +1181,9 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
+        contexts:
+        - output
+        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1118,6 +1200,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1287,6 +1371,9 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
+    contexts:
+    - output
+    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1299,6 +1386,8 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
+    knownMediaTypes:
+    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1356,7 +1445,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
         discriminatorValue: DotSalmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1387,6 +1480,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1402,6 +1497,8 @@ schemas: !<!Schemas>
             name: fishType
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1424,6 +1521,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1490,6 +1591,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1551,6 +1657,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1566,6 +1674,8 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1600,6 +1710,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61

--- a/modelerfour/test/scenarios/additionalProperties/flattened.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/flattened.yaml
@@ -187,6 +187,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_3
@@ -210,6 +215,11 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_4
@@ -255,6 +265,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -284,6 +298,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_10
@@ -329,6 +348,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_12
@@ -374,6 +398,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -423,6 +452,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_16

--- a/modelerfour/test/scenarios/additionalProperties/flattened.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/flattened.yaml
@@ -187,11 +187,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_3
@@ -207,6 +202,11 @@ schemas: !<!Schemas>
               name: friendly
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: CatAPTrue
@@ -215,11 +215,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_4
@@ -254,6 +249,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPTrue
@@ -265,10 +265,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -286,6 +282,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -298,11 +298,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_10
@@ -337,6 +332,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPObject
@@ -348,11 +348,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_12
@@ -387,6 +382,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPString
@@ -398,11 +398,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -441,6 +436,11 @@ schemas: !<!Schemas>
           name: additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPInProperties
@@ -452,11 +452,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_16
@@ -509,6 +504,11 @@ schemas: !<!Schemas>
           name: additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPInPropertiesWithAPString

--- a/modelerfour/test/scenarios/additionalProperties/grouped.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/grouped.yaml
@@ -187,6 +187,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_3
@@ -210,6 +215,11 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_4
@@ -255,6 +265,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -284,6 +298,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_10
@@ -329,6 +348,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_12
@@ -374,6 +398,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -423,6 +452,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_16

--- a/modelerfour/test/scenarios/additionalProperties/grouped.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/grouped.yaml
@@ -187,11 +187,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_3
@@ -207,6 +202,11 @@ schemas: !<!Schemas>
               name: friendly
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: CatAPTrue
@@ -215,11 +215,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_4
@@ -254,6 +249,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPTrue
@@ -265,10 +265,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -286,6 +282,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -298,11 +298,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_10
@@ -337,6 +332,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPObject
@@ -348,11 +348,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_12
@@ -387,6 +382,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPString
@@ -398,11 +398,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -441,6 +436,11 @@ schemas: !<!Schemas>
           name: additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPInProperties
@@ -452,11 +452,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_16
@@ -509,6 +504,11 @@ schemas: !<!Schemas>
           name: additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPInPropertiesWithAPString

--- a/modelerfour/test/scenarios/additionalProperties/modeler.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/modeler.yaml
@@ -187,6 +187,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_6
@@ -210,6 +215,11 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_7
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_4
@@ -255,6 +265,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -284,6 +298,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_11
@@ -329,6 +348,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_13
@@ -374,6 +398,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -423,6 +452,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_19

--- a/modelerfour/test/scenarios/additionalProperties/modeler.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/modeler.yaml
@@ -187,11 +187,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_6
@@ -207,6 +202,11 @@ schemas: !<!Schemas>
               name: friendly
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: CatAPTrue
@@ -215,11 +215,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_7
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_4
@@ -254,6 +249,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPTrue
@@ -265,10 +265,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -286,6 +282,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -298,11 +298,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_11
@@ -337,6 +332,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPObject
@@ -348,11 +348,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_13
@@ -387,6 +382,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPString
@@ -398,11 +398,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -441,6 +436,11 @@ schemas: !<!Schemas>
           name: additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPInProperties
@@ -452,11 +452,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_19
@@ -509,6 +504,11 @@ schemas: !<!Schemas>
           name: additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPInPropertiesWithAPString

--- a/modelerfour/test/scenarios/additionalProperties/namer.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/namer.yaml
@@ -187,6 +187,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_3
@@ -210,6 +215,11 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_4
@@ -255,6 +265,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -284,6 +298,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_10
@@ -329,6 +348,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_12
@@ -374,6 +398,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -423,6 +452,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     parents: !<!Relations> 
       all:
       - *ref_16

--- a/modelerfour/test/scenarios/additionalProperties/namer.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/namer.yaml
@@ -187,11 +187,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_3
@@ -207,6 +202,11 @@ schemas: !<!Schemas>
               name: friendly
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: CatAPTrue
@@ -215,11 +215,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_4
@@ -254,6 +249,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPTrue
@@ -265,10 +265,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -286,6 +282,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -298,11 +298,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_10
@@ -337,6 +332,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPObject
@@ -348,11 +348,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_12
@@ -387,6 +382,11 @@ schemas: !<!Schemas>
           name: status
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPString
@@ -398,11 +398,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -441,6 +436,11 @@ schemas: !<!Schemas>
           name: additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPInProperties
@@ -452,11 +452,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     parents: !<!Relations> 
       all:
       - *ref_16
@@ -509,6 +504,11 @@ schemas: !<!Schemas>
           name: additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: PetAPInPropertiesWithAPString

--- a/modelerfour/test/scenarios/azure-parameter-grouping/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/flattened.yaml
@@ -69,10 +69,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -90,6 +86,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-parameter-grouping/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/flattened.yaml
@@ -69,6 +69,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
@@ -376,10 +376,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -397,6 +393,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
@@ -376,6 +376,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
@@ -163,6 +163,8 @@ schemas: !<!Schemas>
           name: body
           description: ''
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ParameterGroupingPostRequiredParameters
@@ -220,6 +222,8 @@ schemas: !<!Schemas>
           name: query
           description: Query parameter with default
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ParameterGroupingPostOptionalParameters
@@ -308,6 +312,8 @@ schemas: !<!Schemas>
           name: query-one
           description: Query parameter with default
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: first-parameter-group
@@ -365,6 +371,8 @@ schemas: !<!Schemas>
           name: query-two
           description: Query parameter with default
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ParameterGroupingPostMultiParamGroupsSecondParamGroup

--- a/modelerfour/test/scenarios/azure-parameter-grouping/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/modeler.yaml
@@ -69,10 +69,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -90,6 +86,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-parameter-grouping/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/modeler.yaml
@@ -69,6 +69,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
@@ -376,6 +376,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_12

--- a/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
@@ -163,6 +163,8 @@ schemas: !<!Schemas>
           name: body
           description: ''
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ParameterGroupingPostRequiredParameters
@@ -220,6 +222,8 @@ schemas: !<!Schemas>
           name: query
           description: Query parameter with default
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ParameterGroupingPostOptionalParameters
@@ -308,6 +312,8 @@ schemas: !<!Schemas>
           name: queryOne
           description: Query parameter with default
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: FirstParameterGroup
@@ -365,6 +371,8 @@ schemas: !<!Schemas>
           name: queryTwo
           description: Query parameter with default
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ParameterGroupingPostMultiParamGroupsSecondParamGroup

--- a/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
@@ -376,10 +376,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_12
@@ -397,6 +393,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-report/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-report/flattened.yaml
@@ -66,10 +66,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -87,6 +83,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-report/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-report/flattened.yaml
@@ -66,6 +66,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-report/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-report/grouped.yaml
@@ -66,10 +66,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -87,6 +83,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-report/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-report/grouped.yaml
@@ -66,6 +66,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-report/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-report/modeler.yaml
@@ -66,10 +66,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -87,6 +83,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-report/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-report/modeler.yaml
@@ -66,6 +66,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-report/namer.yaml
+++ b/modelerfour/test/scenarios/azure-report/namer.yaml
@@ -66,10 +66,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -87,6 +83,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-report/namer.yaml
+++ b/modelerfour/test/scenarios/azure-report/namer.yaml
@@ -66,6 +66,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
@@ -116,11 +116,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -133,10 +128,6 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -181,6 +172,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           extensions:
             x-ms-azure-resource: true
           language: !<!Languages> 
@@ -225,6 +221,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -251,10 +252,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -272,6 +269,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -284,11 +285,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -314,6 +310,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -327,11 +328,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -367,6 +363,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection

--- a/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
@@ -116,6 +116,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -128,6 +133,10 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -242,6 +251,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -271,6 +284,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -309,6 +327,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
@@ -116,11 +116,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -133,10 +128,6 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -181,6 +172,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           extensions:
             x-ms-azure-resource: true
           language: !<!Languages> 
@@ -225,6 +221,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -251,10 +252,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -272,6 +269,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -284,11 +285,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -314,6 +310,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -327,11 +328,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -367,6 +363,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection

--- a/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
@@ -116,6 +116,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -128,6 +133,10 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -242,6 +251,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -271,6 +284,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -309,6 +327,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
@@ -116,6 +116,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -128,6 +133,10 @@ schemas: !<!Schemas>
             - *ref_8
             immediate:
             - *ref_8
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_0
@@ -189,6 +198,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_5
@@ -254,6 +268,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -284,6 +302,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8

--- a/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
@@ -116,11 +116,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -133,10 +128,6 @@ schemas: !<!Schemas>
             - *ref_8
             immediate:
             - *ref_8
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_0
@@ -181,6 +172,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           extensions:
             x-ms-azure-resource: true
           language: !<!Languages> 
@@ -198,11 +194,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_5
@@ -228,6 +219,11 @@ schemas: !<!Schemas>
                 name: provisioningState
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: FlattenedResourceProperties
@@ -242,6 +238,11 @@ schemas: !<!Schemas>
             name: properties
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -268,10 +269,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -289,6 +286,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -302,11 +303,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -342,6 +338,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -116,11 +116,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -133,10 +128,6 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -181,6 +172,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           extensions:
             x-ms-azure-resource: true
           language: !<!Languages> 
@@ -225,6 +221,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -251,10 +252,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -272,6 +269,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -284,11 +285,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -314,6 +310,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -327,11 +328,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -367,6 +363,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -116,6 +116,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -128,6 +133,10 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -242,6 +251,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -271,6 +284,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -309,6 +327,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-resource/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource/flattened.yaml
@@ -116,11 +116,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -133,10 +128,6 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -181,6 +172,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           extensions:
             x-ms-azure-resource: true
           language: !<!Languages> 
@@ -225,6 +221,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -251,10 +252,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -272,6 +269,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -284,11 +285,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -314,6 +310,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -327,11 +328,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -367,6 +363,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection

--- a/modelerfour/test/scenarios/azure-resource/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource/flattened.yaml
@@ -116,6 +116,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -128,6 +133,10 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -242,6 +251,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -271,6 +284,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -309,6 +327,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-resource/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource/grouped.yaml
@@ -116,11 +116,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -133,10 +128,6 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -181,6 +172,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           extensions:
             x-ms-azure-resource: true
           language: !<!Languages> 
@@ -225,6 +221,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -251,10 +252,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -272,6 +269,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -284,11 +285,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -314,6 +310,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -327,11 +328,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -367,6 +363,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection

--- a/modelerfour/test/scenarios/azure-resource/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource/grouped.yaml
@@ -116,6 +116,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -128,6 +133,10 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -242,6 +251,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -271,6 +284,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -309,6 +327,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-resource/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource/modeler.yaml
@@ -116,6 +116,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -128,6 +133,10 @@ schemas: !<!Schemas>
             - *ref_8
             immediate:
             - *ref_8
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_0
@@ -189,6 +198,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_5
@@ -254,6 +268,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -284,6 +302,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8

--- a/modelerfour/test/scenarios/azure-resource/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource/modeler.yaml
@@ -116,11 +116,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -133,10 +128,6 @@ schemas: !<!Schemas>
             - *ref_8
             immediate:
             - *ref_8
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_0
@@ -181,6 +172,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           extensions:
             x-ms-azure-resource: true
           language: !<!Languages> 
@@ -198,11 +194,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_5
@@ -228,6 +219,11 @@ schemas: !<!Schemas>
                 name: provisioningState
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: FlattenedResourceProperties
@@ -242,6 +238,11 @@ schemas: !<!Schemas>
             name: properties
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -268,10 +269,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -289,6 +286,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -302,11 +303,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -342,6 +338,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -116,11 +116,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -133,10 +128,6 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -181,6 +172,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           extensions:
             x-ms-azure-resource: true
           language: !<!Languages> 
@@ -225,6 +221,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -251,10 +252,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -272,6 +269,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -284,11 +285,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -314,6 +310,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -327,11 +328,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -367,6 +363,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -116,6 +116,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_7
@@ -128,6 +133,10 @@ schemas: !<!Schemas>
             - *ref_1
             immediate:
             - *ref_1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -242,6 +251,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -271,6 +284,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -309,6 +327,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-special-properties/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/flattened.yaml
@@ -117,6 +117,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-07-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/azure-special-properties/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/flattened.yaml
@@ -117,10 +117,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-07-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -149,6 +145,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
@@ -159,10 +159,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-07-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -191,6 +187,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
@@ -159,6 +159,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-07-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
@@ -148,6 +148,8 @@ schemas: !<!Schemas>
           name: foo-client-request-id
           description: The fooRequestId
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: HeaderCustomNamedRequestIdParamGroupingParameters

--- a/modelerfour/test/scenarios/azure-special-properties/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/modeler.yaml
@@ -117,10 +117,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-07-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -149,6 +145,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/azure-special-properties/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/modeler.yaml
@@ -117,6 +117,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-07-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/azure-special-properties/namer.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/namer.yaml
@@ -159,6 +159,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-07-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4

--- a/modelerfour/test/scenarios/azure-special-properties/namer.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/namer.yaml
@@ -148,6 +148,8 @@ schemas: !<!Schemas>
           name: fooClientRequestId
           description: The fooRequestId
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: HeaderCustomNamedRequestIdParamGroupingParameters

--- a/modelerfour/test/scenarios/azure-special-properties/namer.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/namer.yaml
@@ -159,10 +159,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-07-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -191,6 +187,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/blob-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/blob-storage/flattened.yaml
@@ -9313,6 +9313,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_23
@@ -9320,6 +9325,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_3
@@ -9363,6 +9373,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2019-02-02'
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - xml
             properties:
             - !<!Property> 
               schema: *ref_7
@@ -9413,6 +9428,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_9
@@ -9481,6 +9501,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - input
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_14
@@ -9574,6 +9599,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_20
@@ -9630,6 +9660,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_26
@@ -9650,6 +9684,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_29
@@ -9657,6 +9695,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_27
@@ -9702,6 +9744,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -9750,6 +9796,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_34
@@ -9766,6 +9816,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_35
@@ -9916,6 +9970,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_183
       schema: *ref_46
@@ -9946,6 +10004,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_48
@@ -10021,6 +10083,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -10037,6 +10104,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -10095,6 +10167,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -10147,6 +10223,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_123
@@ -10159,6 +10239,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_64
@@ -10193,6 +10277,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_66
@@ -10497,6 +10585,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   parents: !<!Relations> 
                     all:
                     - *ref_90
@@ -10599,6 +10691,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_97
@@ -10660,6 +10756,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_124
@@ -10672,6 +10772,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_102
@@ -10764,6 +10868,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_108
@@ -10771,6 +10879,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_106
@@ -10812,6 +10924,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_126
@@ -10883,6 +10999,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_129
@@ -10895,6 +11015,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_112
@@ -10969,6 +11093,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_131
@@ -10981,6 +11109,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_115
@@ -11033,6 +11165,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_115

--- a/modelerfour/test/scenarios/blob-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/blob-storage/flattened.yaml
@@ -9313,11 +9313,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_23
@@ -9325,11 +9320,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_3
@@ -9373,11 +9363,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2019-02-02'
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - xml
             properties:
             - !<!Property> 
               schema: *ref_7
@@ -9397,6 +9382,11 @@ schemas: !<!Schemas>
                   name: Days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - xml
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: RetentionPolicy
@@ -9410,6 +9400,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy which determines how long the associated data should persist
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Logging
@@ -9428,11 +9423,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_9
@@ -9470,6 +9460,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy which determines how long the associated data should persist
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Metrics
@@ -9501,11 +9496,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - input
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_14
@@ -9554,6 +9544,11 @@ schemas: !<!Schemas>
                 name: MaxAgeInSeconds
                 description: The maximum amount time that a browser should cache the preflight OPTIONS request.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: CorsRule
@@ -9599,11 +9594,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_20
@@ -9632,6 +9622,11 @@ schemas: !<!Schemas>
               name: ErrorDocument404Path
               description: The absolute path of the custom 404 page
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StaticWebsite
@@ -9644,6 +9639,11 @@ schemas: !<!Schemas>
           name: StaticWebsite
           description: The properties that enable an account to host a static website
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: StorageServiceProperties
@@ -9660,10 +9660,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_26
@@ -9673,6 +9669,10 @@ schemas: !<!Schemas>
           name: Message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageError
@@ -9684,10 +9684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_29
@@ -9695,10 +9691,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_27
@@ -9720,6 +9712,10 @@ schemas: !<!Schemas>
                 A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for
                 reads.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: GeoReplication
@@ -9732,6 +9728,10 @@ schemas: !<!Schemas>
           name: GeoReplication
           description: Geo-Replication information for the Secondary Storage Service
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageServiceStats
@@ -9744,10 +9744,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -9796,10 +9792,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_34
@@ -9816,10 +9808,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_35
@@ -9893,6 +9881,10 @@ schemas: !<!Schemas>
                     name: HasLegalHold
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ContainerProperties
@@ -9920,6 +9912,10 @@ schemas: !<!Schemas>
               name: Container
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: ContainerItem
@@ -9957,6 +9953,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListContainersSegmentResponse
@@ -9970,10 +9970,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_183
       schema: *ref_46
@@ -9993,6 +9989,10 @@ schemas: !<!Schemas>
           name: Expiry
           description: The date-time the key expires in ISO 8601 UTC time
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyInfo
@@ -10004,10 +10004,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_48
@@ -10072,6 +10068,10 @@ schemas: !<!Schemas>
           name: Value
           description: The key as a base64 string
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: UserDelegationKey
@@ -10083,11 +10083,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -10104,11 +10099,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -10137,6 +10127,11 @@ schemas: !<!Schemas>
               name: Permission
               description: the permissions for the acl policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: AccessPolicy
@@ -10155,6 +10150,11 @@ schemas: !<!Schemas>
         name: SignedIdentifier
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: SignedIdentifier
@@ -10167,10 +10167,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -10223,10 +10219,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_123
@@ -10239,10 +10231,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_64
@@ -10277,10 +10265,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_66
@@ -10566,6 +10550,10 @@ schemas: !<!Schemas>
                       name: Properties
                       attribute: false
                       wrapped: false
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobProperties
@@ -10585,10 +10573,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   parents: !<!Relations> 
                     all:
                     - *ref_90
@@ -10608,6 +10592,10 @@ schemas: !<!Schemas>
                       name: Metadata
                       attribute: false
                       wrapped: false
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobMetadata
@@ -10626,6 +10614,10 @@ schemas: !<!Schemas>
                   name: Blob
                   attribute: false
                   wrapped: false
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobItem
@@ -10649,6 +10641,10 @@ schemas: !<!Schemas>
             name: Blobs
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: BlobFlatListSegment
@@ -10676,6 +10672,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsFlatSegmentResponse
@@ -10691,10 +10691,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_97
@@ -10756,10 +10752,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_124
@@ -10772,10 +10764,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_102
@@ -10786,6 +10774,10 @@ schemas: !<!Schemas>
                     name: Name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobPrefix
@@ -10828,6 +10820,10 @@ schemas: !<!Schemas>
             name: Blobs
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: BlobHierarchyListSegment
@@ -10855,6 +10851,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsHierarchySegmentResponse
@@ -10868,10 +10868,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_108
@@ -10879,10 +10875,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_106
@@ -10900,6 +10892,10 @@ schemas: !<!Schemas>
               name: Message
               description: The service error message.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DataLakeStorageErrorProps
@@ -10912,6 +10908,10 @@ schemas: !<!Schemas>
           name: error
           description: The service error response object.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DataLakeStorageError
@@ -10924,10 +10924,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_126
@@ -10988,6 +10984,10 @@ schemas: !<!Schemas>
         name: BlockList
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: BlockLookupList
@@ -10999,10 +10999,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_129
@@ -11015,10 +11011,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_112
@@ -11038,6 +11030,10 @@ schemas: !<!Schemas>
                 name: Size
                 description: The block size in bytes.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Block
@@ -11081,6 +11077,10 @@ schemas: !<!Schemas>
           name: UncommittedBlocks
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BlockList
@@ -11093,10 +11093,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_131
@@ -11109,10 +11105,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_115
@@ -11137,6 +11129,10 @@ schemas: !<!Schemas>
               name: PageRange
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: PageRange
@@ -11165,10 +11161,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_115
@@ -11193,6 +11185,10 @@ schemas: !<!Schemas>
               name: ClearRange
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: ClearRange
@@ -11210,6 +11206,10 @@ schemas: !<!Schemas>
           name: ClearRange
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PageList

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -10050,6 +10050,8 @@ schemas: !<!Schemas>
           name: leaseId
           description: 'If specified, the operation only succeeds if the resource''s lease is active and matches this ID.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: lease-access-conditions
@@ -12255,6 +12257,8 @@ schemas: !<!Schemas>
           name: ifNoneMatch
           description: Specify an ETag value to operate only on blobs without a matching value.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: modified-access-conditions
@@ -12509,6 +12513,8 @@ schemas: !<!Schemas>
           name: contentDisposition
           description: Content disposition for given resource
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: directory-http-headers
@@ -12938,6 +12944,8 @@ schemas: !<!Schemas>
           name: sourceIfNoneMatch
           description: Specify an ETag value to operate only on blobs without a matching value.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: source-modified-access-conditions
@@ -13494,6 +13502,8 @@ schemas: !<!Schemas>
           name: encryptionKeySha256
           description: The SHA-256 hash of the provided encryption key. Must be provided if the x-ms-encryption-key header is provided.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: cpk-info
@@ -13951,6 +13961,8 @@ schemas: !<!Schemas>
           name: blobContentDisposition
           description: Optional. Sets the blob's Content-Disposition header.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: blob-HTTP-headers
@@ -14115,6 +14127,8 @@ schemas: !<!Schemas>
           name: ifSequenceNumberEqualTo
           description: Specify this header value to operate only on a blob if it has the specified sequence number.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: sequence-number-access-conditions
@@ -14215,6 +14229,8 @@ schemas: !<!Schemas>
             Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare. Append Block will succeed only if the append position is equal to this number. If it is not, the request will
             fail with the AppendPositionConditionNotMet error (HTTP status code 412 - Precondition Failed).
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: append-position-access-conditions

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -14237,6 +14237,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_23
@@ -14244,6 +14249,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_3
@@ -14287,6 +14297,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2019-02-02'
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - xml
             properties:
             - !<!Property> 
               schema: *ref_7
@@ -14337,6 +14352,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_9
@@ -14405,6 +14425,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - input
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_14
@@ -14498,6 +14523,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_20
@@ -14554,6 +14584,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_26
@@ -14574,6 +14608,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_29
@@ -14581,6 +14619,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_27
@@ -14626,6 +14668,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -14674,6 +14720,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_34
@@ -14690,6 +14740,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_35
@@ -14840,6 +14894,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_279
       schema: *ref_46
@@ -14870,6 +14928,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_48
@@ -14945,6 +15007,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -14961,6 +15028,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -15019,6 +15091,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -15071,6 +15147,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_123
@@ -15083,6 +15163,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_64
@@ -15117,6 +15201,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_66
@@ -15421,6 +15509,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   parents: !<!Relations> 
                     all:
                     - *ref_90
@@ -15523,6 +15615,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_97
@@ -15584,6 +15680,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_124
@@ -15596,6 +15696,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_102
@@ -15688,6 +15792,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_108
@@ -15695,6 +15803,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_106
@@ -15736,6 +15848,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_126
@@ -15807,6 +15923,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_129
@@ -15819,6 +15939,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_112
@@ -15893,6 +16017,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_131
@@ -15905,6 +16033,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_115
@@ -15957,6 +16089,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_115

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -14237,11 +14237,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_23
@@ -14249,11 +14244,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_3
@@ -14297,11 +14287,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2019-02-02'
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - xml
             properties:
             - !<!Property> 
               schema: *ref_7
@@ -14321,6 +14306,11 @@ schemas: !<!Schemas>
                   name: Days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - xml
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: RetentionPolicy
@@ -14334,6 +14324,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy which determines how long the associated data should persist
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Logging
@@ -14352,11 +14347,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_9
@@ -14394,6 +14384,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy which determines how long the associated data should persist
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Metrics
@@ -14425,11 +14420,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - input
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_14
@@ -14478,6 +14468,11 @@ schemas: !<!Schemas>
                 name: MaxAgeInSeconds
                 description: The maximum amount time that a browser should cache the preflight OPTIONS request.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: CorsRule
@@ -14523,11 +14518,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_20
@@ -14556,6 +14546,11 @@ schemas: !<!Schemas>
               name: ErrorDocument404Path
               description: The absolute path of the custom 404 page
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StaticWebsite
@@ -14568,6 +14563,11 @@ schemas: !<!Schemas>
           name: StaticWebsite
           description: The properties that enable an account to host a static website
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: StorageServiceProperties
@@ -14584,10 +14584,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_26
@@ -14597,6 +14593,10 @@ schemas: !<!Schemas>
           name: Message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageError
@@ -14608,10 +14608,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_29
@@ -14619,10 +14615,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_27
@@ -14644,6 +14636,10 @@ schemas: !<!Schemas>
                 A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for
                 reads.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: GeoReplication
@@ -14656,6 +14652,10 @@ schemas: !<!Schemas>
           name: GeoReplication
           description: Geo-Replication information for the Secondary Storage Service
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageServiceStats
@@ -14668,10 +14668,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -14720,10 +14716,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_34
@@ -14740,10 +14732,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_35
@@ -14817,6 +14805,10 @@ schemas: !<!Schemas>
                     name: HasLegalHold
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ContainerProperties
@@ -14844,6 +14836,10 @@ schemas: !<!Schemas>
               name: Container
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: ContainerItem
@@ -14881,6 +14877,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListContainersSegmentResponse
@@ -14894,10 +14894,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_279
       schema: *ref_46
@@ -14917,6 +14913,10 @@ schemas: !<!Schemas>
           name: Expiry
           description: The date-time the key expires in ISO 8601 UTC time
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyInfo
@@ -14928,10 +14928,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_48
@@ -14996,6 +14992,10 @@ schemas: !<!Schemas>
           name: Value
           description: The key as a base64 string
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: UserDelegationKey
@@ -15007,11 +15007,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -15028,11 +15023,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -15061,6 +15051,11 @@ schemas: !<!Schemas>
               name: Permission
               description: the permissions for the acl policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: AccessPolicy
@@ -15079,6 +15074,11 @@ schemas: !<!Schemas>
         name: SignedIdentifier
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: SignedIdentifier
@@ -15091,10 +15091,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -15147,10 +15143,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_123
@@ -15163,10 +15155,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_64
@@ -15201,10 +15189,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_66
@@ -15490,6 +15474,10 @@ schemas: !<!Schemas>
                       name: Properties
                       attribute: false
                       wrapped: false
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobProperties
@@ -15509,10 +15497,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   parents: !<!Relations> 
                     all:
                     - *ref_90
@@ -15532,6 +15516,10 @@ schemas: !<!Schemas>
                       name: Metadata
                       attribute: false
                       wrapped: false
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobMetadata
@@ -15550,6 +15538,10 @@ schemas: !<!Schemas>
                   name: Blob
                   attribute: false
                   wrapped: false
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobItem
@@ -15573,6 +15565,10 @@ schemas: !<!Schemas>
             name: Blobs
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: BlobFlatListSegment
@@ -15600,6 +15596,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsFlatSegmentResponse
@@ -15615,10 +15615,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_97
@@ -15680,10 +15676,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_124
@@ -15696,10 +15688,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_102
@@ -15710,6 +15698,10 @@ schemas: !<!Schemas>
                     name: Name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobPrefix
@@ -15752,6 +15744,10 @@ schemas: !<!Schemas>
             name: Blobs
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: BlobHierarchyListSegment
@@ -15779,6 +15775,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsHierarchySegmentResponse
@@ -15792,10 +15792,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_108
@@ -15803,10 +15799,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_106
@@ -15824,6 +15816,10 @@ schemas: !<!Schemas>
               name: Message
               description: The service error message.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DataLakeStorageErrorProps
@@ -15836,6 +15832,10 @@ schemas: !<!Schemas>
           name: error
           description: The service error response object.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DataLakeStorageError
@@ -15848,10 +15848,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_126
@@ -15912,6 +15908,10 @@ schemas: !<!Schemas>
         name: BlockList
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: BlockLookupList
@@ -15923,10 +15923,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_129
@@ -15939,10 +15935,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_112
@@ -15962,6 +15954,10 @@ schemas: !<!Schemas>
                 name: Size
                 description: The block size in bytes.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Block
@@ -16005,6 +16001,10 @@ schemas: !<!Schemas>
           name: UncommittedBlocks
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BlockList
@@ -16017,10 +16017,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_131
@@ -16033,10 +16029,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_115
@@ -16061,6 +16053,10 @@ schemas: !<!Schemas>
               name: PageRange
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: PageRange
@@ -16089,10 +16085,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_115
@@ -16117,6 +16109,10 @@ schemas: !<!Schemas>
               name: ClearRange
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: ClearRange
@@ -16134,6 +16130,10 @@ schemas: !<!Schemas>
           name: ClearRange
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PageList

--- a/modelerfour/test/scenarios/blob-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/blob-storage/modeler.yaml
@@ -9313,11 +9313,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_14
@@ -9325,11 +9320,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -9373,11 +9363,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2019-02-02'
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - xml
             properties:
             - !<!Property> 
               schema: *ref_96
@@ -9397,6 +9382,11 @@ schemas: !<!Schemas>
                   name: Days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - xml
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: RetentionPolicy
@@ -9410,6 +9400,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy which determines how long the associated data should persist
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Logging
@@ -9428,11 +9423,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_3
@@ -9470,6 +9460,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy which determines how long the associated data should persist
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Metrics
@@ -9501,11 +9496,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - input
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_6
@@ -9554,6 +9544,11 @@ schemas: !<!Schemas>
                 name: MaxAgeInSeconds
                 description: The maximum amount time that a browser should cache the preflight OPTIONS request.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: CorsRule
@@ -9599,11 +9594,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_99
@@ -9632,6 +9622,11 @@ schemas: !<!Schemas>
               name: ErrorDocument404Path
               description: The absolute path of the custom 404 page
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StaticWebsite
@@ -9644,6 +9639,11 @@ schemas: !<!Schemas>
           name: StaticWebsite
           description: The properties that enable an account to host a static website
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: StorageServiceProperties
@@ -9660,10 +9660,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_17
@@ -9673,6 +9669,10 @@ schemas: !<!Schemas>
           name: Message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageError
@@ -9684,10 +9684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_18
@@ -9695,10 +9691,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_124
@@ -9720,6 +9712,10 @@ schemas: !<!Schemas>
                 A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for
                 reads.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: GeoReplication
@@ -9732,6 +9728,10 @@ schemas: !<!Schemas>
           name: GeoReplication
           description: Geo-Replication information for the Secondary Storage Service
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageServiceStats
@@ -9744,10 +9744,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -9796,10 +9792,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_23
@@ -9816,10 +9808,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_114
@@ -9893,6 +9881,10 @@ schemas: !<!Schemas>
                     name: HasLegalHold
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ContainerProperties
@@ -9920,6 +9912,10 @@ schemas: !<!Schemas>
               name: Container
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: ContainerItem
@@ -9957,6 +9953,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListContainersSegmentResponse
@@ -9970,10 +9970,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -9993,6 +9989,10 @@ schemas: !<!Schemas>
           name: Expiry
           description: The date-time the key expires in ISO 8601 UTC time
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyInfo
@@ -10004,10 +10004,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -10072,6 +10068,10 @@ schemas: !<!Schemas>
           name: Value
           description: The key as a base64 string
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: UserDelegationKey
@@ -10083,11 +10083,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_37
@@ -10104,11 +10099,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_117
@@ -10137,6 +10127,11 @@ schemas: !<!Schemas>
               name: Permission
               description: the permissions for the acl policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: AccessPolicy
@@ -10155,6 +10150,11 @@ schemas: !<!Schemas>
         name: SignedIdentifier
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: SignedIdentifier
@@ -10167,10 +10167,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_40
@@ -10223,10 +10219,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_103
@@ -10239,10 +10231,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_44
@@ -10277,10 +10265,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_119
@@ -10566,6 +10550,10 @@ schemas: !<!Schemas>
                       name: Properties
                       attribute: false
                       wrapped: false
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobProperties
@@ -10585,10 +10573,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   parents: !<!Relations> 
                     all:
                     - *ref_65
@@ -10608,6 +10592,10 @@ schemas: !<!Schemas>
                       name: Metadata
                       attribute: false
                       wrapped: false
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobMetadata
@@ -10626,6 +10614,10 @@ schemas: !<!Schemas>
                   name: Blob
                   attribute: false
                   wrapped: false
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobItem
@@ -10649,6 +10641,10 @@ schemas: !<!Schemas>
             name: Blobs
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: BlobFlatListSegment
@@ -10676,6 +10672,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsFlatSegmentResponse
@@ -10691,10 +10691,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_71
@@ -10756,10 +10752,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_104
@@ -10772,10 +10764,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_76
@@ -10786,6 +10774,10 @@ schemas: !<!Schemas>
                     name: Name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobPrefix
@@ -10828,6 +10820,10 @@ schemas: !<!Schemas>
             name: Blobs
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: BlobHierarchyListSegment
@@ -10855,6 +10851,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsHierarchySegmentResponse
@@ -10868,10 +10868,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_82
@@ -10879,10 +10875,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_80
@@ -10900,6 +10892,10 @@ schemas: !<!Schemas>
               name: Message
               description: The service error message.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DataLakeStorageErrorProps
@@ -10912,6 +10908,10 @@ schemas: !<!Schemas>
           name: error
           description: The service error response object.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DataLakeStorageError
@@ -10924,10 +10924,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_106
@@ -10988,6 +10984,10 @@ schemas: !<!Schemas>
         name: BlockList
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: BlockLookupList
@@ -10999,10 +10999,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_109
@@ -11015,10 +11011,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_86
@@ -11038,6 +11030,10 @@ schemas: !<!Schemas>
                 name: Size
                 description: The block size in bytes.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Block
@@ -11081,6 +11077,10 @@ schemas: !<!Schemas>
           name: UncommittedBlocks
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BlockList
@@ -11093,10 +11093,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_111
@@ -11109,10 +11105,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_89
@@ -11137,6 +11129,10 @@ schemas: !<!Schemas>
               name: PageRange
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: PageRange
@@ -11165,10 +11161,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_89
@@ -11193,6 +11185,10 @@ schemas: !<!Schemas>
               name: ClearRange
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: ClearRange
@@ -11210,6 +11206,10 @@ schemas: !<!Schemas>
           name: ClearRange
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PageList

--- a/modelerfour/test/scenarios/blob-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/blob-storage/modeler.yaml
@@ -9313,6 +9313,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_14
@@ -9320,6 +9325,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -9363,6 +9373,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2019-02-02'
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - xml
             properties:
             - !<!Property> 
               schema: *ref_96
@@ -9413,6 +9428,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_3
@@ -9481,6 +9501,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - input
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_6
@@ -9574,6 +9599,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_99
@@ -9630,6 +9660,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_17
@@ -9650,6 +9684,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_18
@@ -9657,6 +9695,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_124
@@ -9702,6 +9744,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -9750,6 +9796,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_23
@@ -9766,6 +9816,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_114
@@ -9916,6 +9970,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -9946,6 +10004,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -10021,6 +10083,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_37
@@ -10037,6 +10104,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_117
@@ -10095,6 +10167,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_40
@@ -10147,6 +10223,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_103
@@ -10159,6 +10239,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_44
@@ -10193,6 +10277,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_119
@@ -10497,6 +10585,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   parents: !<!Relations> 
                     all:
                     - *ref_65
@@ -10599,6 +10691,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_71
@@ -10660,6 +10756,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_104
@@ -10672,6 +10772,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_76
@@ -10764,6 +10868,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_82
@@ -10771,6 +10879,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_80
@@ -10812,6 +10924,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_106
@@ -10883,6 +10999,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_109
@@ -10895,6 +11015,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_86
@@ -10969,6 +11093,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_111
@@ -10981,6 +11109,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_89
@@ -11033,6 +11165,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_89

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -14237,11 +14237,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_119
@@ -14249,11 +14244,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_99
@@ -14297,11 +14287,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2019-02-02'
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - xml
             properties:
             - !<!Property> 
               schema: *ref_103
@@ -14321,6 +14306,11 @@ schemas: !<!Schemas>
                   name: days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - xml
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: RetentionPolicy
@@ -14334,6 +14324,11 @@ schemas: !<!Schemas>
               name: retentionPolicy
               description: the retention policy which determines how long the associated data should persist
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Logging
@@ -14352,11 +14347,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_105
@@ -14394,6 +14384,11 @@ schemas: !<!Schemas>
               name: retentionPolicy
               description: the retention policy which determines how long the associated data should persist
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Metrics
@@ -14425,11 +14420,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - input
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_110
@@ -14478,6 +14468,11 @@ schemas: !<!Schemas>
                 name: maxAgeInSeconds
                 description: The maximum amount time that a browser should cache the preflight OPTIONS request.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: CorsRule
@@ -14523,11 +14518,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_116
@@ -14556,6 +14546,11 @@ schemas: !<!Schemas>
               name: errorDocument404Path
               description: The absolute path of the custom 404 page
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StaticWebsite
@@ -14568,6 +14563,11 @@ schemas: !<!Schemas>
           name: staticWebsite
           description: The properties that enable an account to host a static website
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: StorageServiceProperties
@@ -14584,10 +14584,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_122
@@ -14597,6 +14593,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageError
@@ -14608,10 +14608,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_125
@@ -14619,10 +14615,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_123
@@ -14644,6 +14636,10 @@ schemas: !<!Schemas>
                 A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for
                 reads.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: GeoReplication
@@ -14656,6 +14652,10 @@ schemas: !<!Schemas>
           name: geoReplication
           description: Geo-Replication information for the Secondary Storage Service
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageServiceStats
@@ -14668,10 +14668,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_126
@@ -14720,10 +14716,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_130
@@ -14740,10 +14732,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_131
@@ -14817,6 +14805,10 @@ schemas: !<!Schemas>
                     name: hasLegalHold
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ContainerProperties
@@ -14844,6 +14836,10 @@ schemas: !<!Schemas>
               name: Container
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: ContainerItem
@@ -14881,6 +14877,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListContainersSegmentResponse
@@ -14894,10 +14894,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_279
       schema: *ref_142
@@ -14917,6 +14913,10 @@ schemas: !<!Schemas>
           name: expiry
           description: The date-time the key expires in ISO 8601 UTC time
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyInfo
@@ -14928,10 +14928,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_144
@@ -14996,6 +14992,10 @@ schemas: !<!Schemas>
           name: value
           description: The key as a base64 string
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: UserDelegationKey
@@ -15007,11 +15007,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_151
@@ -15028,11 +15023,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_152
@@ -15061,6 +15051,11 @@ schemas: !<!Schemas>
               name: permission
               description: the permissions for the acl policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: AccessPolicy
@@ -15079,6 +15074,11 @@ schemas: !<!Schemas>
         name: SignedIdentifier
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: SignedIdentifier
@@ -15091,10 +15091,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_156
@@ -15147,10 +15143,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_219
@@ -15163,10 +15155,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_160
@@ -15201,10 +15189,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_162
@@ -15490,6 +15474,10 @@ schemas: !<!Schemas>
                       name: Properties
                       attribute: false
                       wrapped: false
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobProperties
@@ -15509,10 +15497,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   parents: !<!Relations> 
                     all:
                     - *ref_186
@@ -15532,6 +15516,10 @@ schemas: !<!Schemas>
                       name: Metadata
                       attribute: false
                       wrapped: false
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobMetadata
@@ -15550,6 +15538,10 @@ schemas: !<!Schemas>
                   name: Blob
                   attribute: false
                   wrapped: false
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobItem
@@ -15573,6 +15565,10 @@ schemas: !<!Schemas>
             name: Blobs
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: BlobFlatListSegment
@@ -15600,6 +15596,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsFlatSegmentResponse
@@ -15615,10 +15615,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_193
@@ -15680,10 +15676,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_220
@@ -15696,10 +15688,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_198
@@ -15710,6 +15698,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobPrefix
@@ -15752,6 +15744,10 @@ schemas: !<!Schemas>
             name: Blobs
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: BlobHierarchyListSegment
@@ -15779,6 +15775,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsHierarchySegmentResponse
@@ -15792,10 +15792,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_204
@@ -15803,10 +15799,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_202
@@ -15824,6 +15816,10 @@ schemas: !<!Schemas>
               name: message
               description: The service error message.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DataLakeStorageErrorProps
@@ -15836,6 +15832,10 @@ schemas: !<!Schemas>
           name: error
           description: The service error response object.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DataLakeStorageError
@@ -15848,10 +15848,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_222
@@ -15912,6 +15908,10 @@ schemas: !<!Schemas>
         name: BlockList
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: BlockLookupList
@@ -15923,10 +15923,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_225
@@ -15939,10 +15935,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_208
@@ -15962,6 +15954,10 @@ schemas: !<!Schemas>
                 name: size
                 description: The block size in bytes.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Block
@@ -16005,6 +16001,10 @@ schemas: !<!Schemas>
           name: uncommittedBlocks
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BlockList
@@ -16017,10 +16017,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_227
@@ -16033,10 +16029,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -16061,6 +16053,10 @@ schemas: !<!Schemas>
               name: PageRange
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: PageRange
@@ -16089,10 +16085,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -16117,6 +16109,10 @@ schemas: !<!Schemas>
               name: ClearRange
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: ClearRange
@@ -16134,6 +16130,10 @@ schemas: !<!Schemas>
           name: clearRange
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PageList

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -10050,6 +10050,8 @@ schemas: !<!Schemas>
           name: leaseId
           description: 'If specified, the operation only succeeds if the resource''s lease is active and matches this ID.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: LeaseAccessConditions
@@ -12255,6 +12257,8 @@ schemas: !<!Schemas>
           name: ifNoneMatch
           description: Specify an ETag value to operate only on blobs without a matching value.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ModifiedAccessConditions
@@ -12509,6 +12513,8 @@ schemas: !<!Schemas>
           name: contentDisposition
           description: Content disposition for given resource
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: DirectoryHttpHeaders
@@ -12938,6 +12944,8 @@ schemas: !<!Schemas>
           name: sourceIfNoneMatch
           description: Specify an ETag value to operate only on blobs without a matching value.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SourceModifiedAccessConditions
@@ -13494,6 +13502,8 @@ schemas: !<!Schemas>
           name: encryptionKeySha256
           description: The SHA-256 hash of the provided encryption key. Must be provided if the x-ms-encryption-key header is provided.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CpkInfo
@@ -13951,6 +13961,8 @@ schemas: !<!Schemas>
           name: blobContentDisposition
           description: Optional. Sets the blob's Content-Disposition header.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: BlobHttpHeaders
@@ -14115,6 +14127,8 @@ schemas: !<!Schemas>
           name: ifSequenceNumberEqualTo
           description: Specify this header value to operate only on a blob if it has the specified sequence number.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SequenceNumberAccessConditions
@@ -14215,6 +14229,8 @@ schemas: !<!Schemas>
             Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare. Append Block will succeed only if the append position is equal to this number. If it is not, the request will
             fail with the AppendPositionConditionNotMet error (HTTP status code 412 - Precondition Failed).
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AppendPositionAccessConditions

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -14237,6 +14237,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_119
@@ -14244,6 +14249,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_99
@@ -14287,6 +14297,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2019-02-02'
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - xml
             properties:
             - !<!Property> 
               schema: *ref_103
@@ -14337,6 +14352,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_105
@@ -14405,6 +14425,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - input
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_110
@@ -14498,6 +14523,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_116
@@ -14554,6 +14584,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_122
@@ -14574,6 +14608,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_125
@@ -14581,6 +14619,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_123
@@ -14626,6 +14668,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_126
@@ -14674,6 +14720,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_130
@@ -14690,6 +14740,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_131
@@ -14840,6 +14894,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_279
       schema: *ref_142
@@ -14870,6 +14928,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_144
@@ -14945,6 +15007,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_151
@@ -14961,6 +15028,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_152
@@ -15019,6 +15091,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_156
@@ -15071,6 +15147,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_219
@@ -15083,6 +15163,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_160
@@ -15117,6 +15201,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_162
@@ -15421,6 +15509,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2019-02-02'
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   parents: !<!Relations> 
                     all:
                     - *ref_186
@@ -15523,6 +15615,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_193
@@ -15584,6 +15680,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_220
@@ -15596,6 +15696,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: '2019-02-02'
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_198
@@ -15688,6 +15792,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_204
@@ -15695,6 +15803,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_202
@@ -15736,6 +15848,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_222
@@ -15807,6 +15923,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_225
@@ -15819,6 +15939,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_208
@@ -15893,6 +16017,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-02-02'
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_227
@@ -15905,6 +16033,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -15957,6 +16089,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-02-02'
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_211

--- a/modelerfour/test/scenarios/body-array/flattened.yaml
+++ b/modelerfour/test/scenarios/body-array/flattened.yaml
@@ -292,10 +292,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -313,6 +309,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -324,11 +324,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -346,6 +341,11 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Product

--- a/modelerfour/test/scenarios/body-array/flattened.yaml
+++ b/modelerfour/test/scenarios/body-array/flattened.yaml
@@ -292,6 +292,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -320,6 +324,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-array/grouped.yaml
+++ b/modelerfour/test/scenarios/body-array/grouped.yaml
@@ -292,10 +292,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -313,6 +309,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -324,11 +324,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -346,6 +341,11 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Product

--- a/modelerfour/test/scenarios/body-array/grouped.yaml
+++ b/modelerfour/test/scenarios/body-array/grouped.yaml
@@ -292,6 +292,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -320,6 +324,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-array/modeler.yaml
+++ b/modelerfour/test/scenarios/body-array/modeler.yaml
@@ -292,6 +292,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -320,6 +324,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8

--- a/modelerfour/test/scenarios/body-array/modeler.yaml
+++ b/modelerfour/test/scenarios/body-array/modeler.yaml
@@ -292,10 +292,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -313,6 +309,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -324,11 +324,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -346,6 +341,11 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Product

--- a/modelerfour/test/scenarios/body-array/namer.yaml
+++ b/modelerfour/test/scenarios/body-array/namer.yaml
@@ -292,10 +292,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -313,6 +309,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -324,11 +324,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -346,6 +341,11 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Product

--- a/modelerfour/test/scenarios/body-array/namer.yaml
+++ b/modelerfour/test/scenarios/body-array/namer.yaml
@@ -292,6 +292,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -320,6 +324,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-boolean.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/flattened.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-boolean.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/flattened.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-boolean.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/grouped.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-boolean.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/grouped.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-boolean.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/modeler.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-boolean.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/modeler.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-boolean/flattened.yaml
+++ b/modelerfour/test/scenarios/body-boolean/flattened.yaml
@@ -81,10 +81,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -102,6 +98,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-boolean/flattened.yaml
+++ b/modelerfour/test/scenarios/body-boolean/flattened.yaml
@@ -81,6 +81,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-boolean/grouped.yaml
+++ b/modelerfour/test/scenarios/body-boolean/grouped.yaml
@@ -81,10 +81,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -102,6 +98,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-boolean/grouped.yaml
+++ b/modelerfour/test/scenarios/body-boolean/grouped.yaml
@@ -81,6 +81,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-boolean/modeler.yaml
+++ b/modelerfour/test/scenarios/body-boolean/modeler.yaml
@@ -81,6 +81,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-boolean/modeler.yaml
+++ b/modelerfour/test/scenarios/body-boolean/modeler.yaml
@@ -81,10 +81,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -102,6 +98,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-boolean/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean/namer.yaml
@@ -81,10 +81,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -102,6 +98,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-boolean/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean/namer.yaml
@@ -81,6 +81,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-byte/flattened.yaml
+++ b/modelerfour/test/scenarios/body-byte/flattened.yaml
@@ -97,6 +97,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-byte/flattened.yaml
+++ b/modelerfour/test/scenarios/body-byte/flattened.yaml
@@ -97,10 +97,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -118,6 +114,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-byte/grouped.yaml
+++ b/modelerfour/test/scenarios/body-byte/grouped.yaml
@@ -97,6 +97,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-byte/grouped.yaml
+++ b/modelerfour/test/scenarios/body-byte/grouped.yaml
@@ -97,10 +97,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -118,6 +114,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-byte/modeler.yaml
+++ b/modelerfour/test/scenarios/body-byte/modeler.yaml
@@ -97,10 +97,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -118,6 +114,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-byte/modeler.yaml
+++ b/modelerfour/test/scenarios/body-byte/modeler.yaml
@@ -97,6 +97,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-byte/namer.yaml
+++ b/modelerfour/test/scenarios/body-byte/namer.yaml
@@ -97,6 +97,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-byte/namer.yaml
+++ b/modelerfour/test/scenarios/body-byte/namer.yaml
@@ -97,10 +97,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -118,6 +114,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -524,11 +524,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -554,6 +549,11 @@ schemas: !<!Schemas>
           name: color
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: basic
@@ -565,10 +565,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -586,6 +582,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -597,11 +597,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -619,6 +614,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -630,11 +630,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -652,6 +647,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: long-wrapper
@@ -663,11 +663,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -685,6 +680,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: float-wrapper
@@ -696,11 +696,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -718,6 +713,11 @@ schemas: !<!Schemas>
           name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: double-wrapper
@@ -729,11 +729,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -751,6 +746,11 @@ schemas: !<!Schemas>
           name: field_false
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: boolean-wrapper
@@ -762,11 +762,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -792,6 +787,11 @@ schemas: !<!Schemas>
           name: 'null'
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -803,11 +803,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -825,6 +820,11 @@ schemas: !<!Schemas>
           name: leap
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: date-wrapper
@@ -836,11 +836,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -858,6 +853,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetime-wrapper
@@ -869,11 +869,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -891,6 +886,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetimerfc1123-wrapper
@@ -902,11 +902,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -916,6 +911,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: duration-wrapper
@@ -927,11 +927,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -941,6 +936,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: byte-wrapper
@@ -952,11 +952,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -976,6 +971,11 @@ schemas: !<!Schemas>
           name: array
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -987,11 +987,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -1001,6 +996,11 @@ schemas: !<!Schemas>
           name: defaultProgram
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: dictionary-wrapper
@@ -1033,6 +1033,11 @@ schemas: !<!Schemas>
               name: food
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: dog
@@ -1051,11 +1056,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1071,6 +1071,11 @@ schemas: !<!Schemas>
                   name: breed
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: siamese
@@ -1111,6 +1116,11 @@ schemas: !<!Schemas>
               name: hates
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: cat
@@ -1138,6 +1148,11 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: pet
@@ -1193,9 +1208,6 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
-        contexts:
-        - output
-        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1212,8 +1224,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1236,6 +1246,11 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: salmon
@@ -1383,9 +1398,6 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
-    contexts:
-    - output
-    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1398,8 +1410,6 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
-    knownMediaTypes:
-    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1439,6 +1449,11 @@ schemas: !<!Schemas>
           name: siblings
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Fish
@@ -1457,11 +1472,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
         discriminatorValue: DotSalmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1484,6 +1495,10 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DotSalmon
@@ -1492,8 +1507,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1509,8 +1522,6 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1522,6 +1533,10 @@ schemas: !<!Schemas>
           name: species
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFish
@@ -1533,10 +1548,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1590,6 +1601,10 @@ schemas: !<!Schemas>
           name: fishes
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFishMarket
@@ -1603,11 +1618,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1626,6 +1636,11 @@ schemas: !<!Schemas>
           name: size
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: readonly-obj
@@ -1669,8 +1684,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1686,8 +1699,6 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1711,6 +1722,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyBaseType
@@ -1722,10 +1737,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -1735,6 +1746,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -524,6 +524,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -560,6 +565,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -588,6 +597,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -616,6 +630,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -644,6 +663,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -672,6 +696,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -700,6 +729,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -728,6 +762,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -764,6 +803,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -792,6 +836,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -820,6 +869,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -848,6 +902,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -868,6 +927,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -888,6 +952,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -918,6 +987,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -977,6 +1051,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1114,6 +1193,9 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
+        contexts:
+        - output
+        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1130,6 +1212,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1299,6 +1383,9 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
+    contexts:
+    - output
+    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1311,6 +1398,8 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
+    knownMediaTypes:
+    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1368,7 +1457,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
         discriminatorValue: DotSalmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1399,6 +1492,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1414,6 +1509,8 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1436,6 +1533,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1502,6 +1603,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1563,6 +1669,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1578,6 +1686,8 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1612,6 +1722,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -524,11 +524,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -554,6 +549,11 @@ schemas: !<!Schemas>
           name: color
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: basic
@@ -565,10 +565,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -586,6 +582,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -597,11 +597,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -619,6 +614,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -630,11 +630,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -652,6 +647,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: long-wrapper
@@ -663,11 +663,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -685,6 +680,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: float-wrapper
@@ -696,11 +696,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -718,6 +713,11 @@ schemas: !<!Schemas>
           name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: double-wrapper
@@ -729,11 +729,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -751,6 +746,11 @@ schemas: !<!Schemas>
           name: field_false
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: boolean-wrapper
@@ -762,11 +762,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -792,6 +787,11 @@ schemas: !<!Schemas>
           name: 'null'
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -803,11 +803,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -825,6 +820,11 @@ schemas: !<!Schemas>
           name: leap
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: date-wrapper
@@ -836,11 +836,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -858,6 +853,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetime-wrapper
@@ -869,11 +869,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -891,6 +886,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetimerfc1123-wrapper
@@ -902,11 +902,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -916,6 +911,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: duration-wrapper
@@ -927,11 +927,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -941,6 +936,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: byte-wrapper
@@ -952,11 +952,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -976,6 +971,11 @@ schemas: !<!Schemas>
           name: array
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -987,11 +987,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -1001,6 +996,11 @@ schemas: !<!Schemas>
           name: defaultProgram
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: dictionary-wrapper
@@ -1033,6 +1033,11 @@ schemas: !<!Schemas>
               name: food
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: dog
@@ -1051,11 +1056,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1071,6 +1071,11 @@ schemas: !<!Schemas>
                   name: breed
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: siamese
@@ -1111,6 +1116,11 @@ schemas: !<!Schemas>
               name: hates
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: cat
@@ -1138,6 +1148,11 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: pet
@@ -1193,9 +1208,6 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
-        contexts:
-        - output
-        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1212,8 +1224,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1236,6 +1246,11 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: salmon
@@ -1383,9 +1398,6 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
-    contexts:
-    - output
-    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1398,8 +1410,6 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
-    knownMediaTypes:
-    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1439,6 +1449,11 @@ schemas: !<!Schemas>
           name: siblings
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Fish
@@ -1457,11 +1472,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
         discriminatorValue: DotSalmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1484,6 +1495,10 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DotSalmon
@@ -1492,8 +1507,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1509,8 +1522,6 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1522,6 +1533,10 @@ schemas: !<!Schemas>
           name: species
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFish
@@ -1533,10 +1548,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1590,6 +1601,10 @@ schemas: !<!Schemas>
           name: fishes
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFishMarket
@@ -1603,11 +1618,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1626,6 +1636,11 @@ schemas: !<!Schemas>
           name: size
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: readonly-obj
@@ -1669,8 +1684,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1686,8 +1699,6 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1711,6 +1722,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyBaseType
@@ -1722,10 +1737,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -1735,6 +1746,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -524,6 +524,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -560,6 +565,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -588,6 +597,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -616,6 +630,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -644,6 +663,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -672,6 +696,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -700,6 +729,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -728,6 +762,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -764,6 +803,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -792,6 +836,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -820,6 +869,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -848,6 +902,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -868,6 +927,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -888,6 +952,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -918,6 +987,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -977,6 +1051,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1114,6 +1193,9 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
+        contexts:
+        - output
+        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1130,6 +1212,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1299,6 +1383,9 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
+    contexts:
+    - output
+    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1311,6 +1398,8 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
+    knownMediaTypes:
+    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1368,7 +1457,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
         discriminatorValue: DotSalmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1399,6 +1492,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1414,6 +1509,8 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1436,6 +1533,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1502,6 +1603,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1563,6 +1669,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1578,6 +1686,8 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1612,6 +1722,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61

--- a/modelerfour/test/scenarios/body-complex/modeler.yaml
+++ b/modelerfour/test/scenarios/body-complex/modeler.yaml
@@ -524,11 +524,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_48
@@ -554,6 +549,11 @@ schemas: !<!Schemas>
           name: color
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: basic
@@ -565,10 +565,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -586,6 +582,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -597,11 +597,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -619,6 +614,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -630,11 +630,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -652,6 +647,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: long-wrapper
@@ -663,11 +663,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -685,6 +680,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: float-wrapper
@@ -696,11 +696,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -718,6 +713,11 @@ schemas: !<!Schemas>
           name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: double-wrapper
@@ -729,11 +729,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -751,6 +746,11 @@ schemas: !<!Schemas>
           name: field_false
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: boolean-wrapper
@@ -762,11 +762,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -792,6 +787,11 @@ schemas: !<!Schemas>
           name: 'null'
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -803,11 +803,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_52
@@ -825,6 +820,11 @@ schemas: !<!Schemas>
           name: leap
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: date-wrapper
@@ -836,11 +836,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -858,6 +853,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetime-wrapper
@@ -869,11 +869,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_56
@@ -891,6 +886,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: datetimerfc1123-wrapper
@@ -902,11 +902,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_59
@@ -916,6 +911,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: duration-wrapper
@@ -927,11 +927,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -941,6 +936,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: byte-wrapper
@@ -952,11 +952,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_62
@@ -976,6 +971,11 @@ schemas: !<!Schemas>
           name: array
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -987,11 +987,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_67
@@ -1001,6 +996,11 @@ schemas: !<!Schemas>
           name: defaultProgram
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: dictionary-wrapper
@@ -1033,6 +1033,11 @@ schemas: !<!Schemas>
               name: food
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: dog
@@ -1051,11 +1056,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             parents: !<!Relations> 
               all:
               - *ref_19
@@ -1071,6 +1071,11 @@ schemas: !<!Schemas>
                   name: breed
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: siamese
@@ -1111,6 +1116,11 @@ schemas: !<!Schemas>
               name: hates
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: cat
@@ -1138,6 +1148,11 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: pet
@@ -1193,9 +1208,6 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_29
-        contexts:
-        - output
-        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_29
@@ -1212,8 +1224,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_23
@@ -1236,6 +1246,11 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: salmon
@@ -1383,9 +1398,6 @@ schemas: !<!Schemas>
       immediate:
       - *ref_27
       - *ref_30
-    contexts:
-    - output
-    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_33
@@ -1398,8 +1410,6 @@ schemas: !<!Schemas>
         salmon: *ref_27
         shark: *ref_30
       property: *ref_24
-    knownMediaTypes:
-    - json
     properties:
     - *ref_24
     - !<!Property> 
@@ -1439,6 +1449,11 @@ schemas: !<!Schemas>
           name: siblings
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Fish
@@ -1457,11 +1472,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
         discriminatorValue: DotSalmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_38
@@ -1484,6 +1495,10 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DotSalmon
@@ -1492,8 +1507,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_39
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_39
@@ -1509,8 +1522,6 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_36
     - !<!Property> 
@@ -1522,6 +1533,10 @@ schemas: !<!Schemas>
           name: species
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFish
@@ -1533,10 +1548,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_39
@@ -1590,6 +1601,10 @@ schemas: !<!Schemas>
           name: fishes
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFishMarket
@@ -1603,11 +1618,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_40
@@ -1626,6 +1636,11 @@ schemas: !<!Schemas>
           name: size
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: readonly-obj
@@ -1669,8 +1684,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_46
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_46
@@ -1686,8 +1699,6 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_43
     - !<!Property> 
@@ -1705,10 +1716,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_42
@@ -1718,6 +1725,10 @@ schemas: !<!Schemas>
               name: propBH1
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: MyBaseHelperType
@@ -1733,6 +1744,10 @@ schemas: !<!Schemas>
           name: helper
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyBaseType

--- a/modelerfour/test/scenarios/body-complex/modeler.yaml
+++ b/modelerfour/test/scenarios/body-complex/modeler.yaml
@@ -524,6 +524,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_48
@@ -560,6 +565,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -588,6 +597,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -616,6 +630,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -644,6 +663,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -672,6 +696,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -700,6 +729,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -728,6 +762,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -764,6 +803,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_52
@@ -792,6 +836,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -820,6 +869,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_56
@@ -848,6 +902,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_59
@@ -868,6 +927,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -888,6 +952,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_62
@@ -918,6 +987,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_67
@@ -977,6 +1051,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             parents: !<!Relations> 
               all:
               - *ref_19
@@ -1114,6 +1193,9 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_29
+        contexts:
+        - output
+        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_29
@@ -1130,6 +1212,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_23
@@ -1299,6 +1383,9 @@ schemas: !<!Schemas>
       immediate:
       - *ref_27
       - *ref_30
+    contexts:
+    - output
+    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_33
@@ -1311,6 +1398,8 @@ schemas: !<!Schemas>
         salmon: *ref_27
         shark: *ref_30
       property: *ref_24
+    knownMediaTypes:
+    - json
     properties:
     - *ref_24
     - !<!Property> 
@@ -1368,7 +1457,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
         discriminatorValue: DotSalmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_38
@@ -1399,6 +1492,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_39
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_39
@@ -1414,6 +1509,8 @@ schemas: !<!Schemas>
             name: fish.type
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_36
     - !<!Property> 
@@ -1436,6 +1533,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_39
@@ -1502,6 +1603,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_40
@@ -1563,6 +1669,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_46
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_46
@@ -1578,6 +1686,8 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_43
     - !<!Property> 
@@ -1595,6 +1705,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_42

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -524,6 +524,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -560,6 +565,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -588,6 +597,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -616,6 +630,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -644,6 +663,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -672,6 +696,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -700,6 +729,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -728,6 +762,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -764,6 +803,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -792,6 +836,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -820,6 +869,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -848,6 +902,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -868,6 +927,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -888,6 +952,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -918,6 +987,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -977,6 +1051,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1114,6 +1193,9 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
+        contexts:
+        - output
+        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1130,6 +1212,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1299,6 +1383,9 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
+    contexts:
+    - output
+    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1311,6 +1398,8 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
+    knownMediaTypes:
+    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1368,7 +1457,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
+        contexts:
+        - output
         discriminatorValue: DotSalmon
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1399,6 +1492,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1414,6 +1509,8 @@ schemas: !<!Schemas>
             name: fishType
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1436,6 +1533,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1502,6 +1603,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1563,6 +1669,8 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1578,6 +1686,8 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
+    knownMediaTypes:
+    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1612,6 +1722,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -524,11 +524,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -554,6 +549,11 @@ schemas: !<!Schemas>
           name: color
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Basic
@@ -565,10 +565,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -586,6 +582,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -597,11 +597,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_75
       schema: *ref_5
@@ -619,6 +614,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: IntWrapper
@@ -630,11 +630,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_81
       schema: *ref_7
@@ -652,6 +647,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: LongWrapper
@@ -663,11 +663,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_87
       schema: *ref_8
@@ -685,6 +680,11 @@ schemas: !<!Schemas>
           name: field2
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: FloatWrapper
@@ -696,11 +696,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_93
       schema: *ref_9
@@ -718,6 +713,11 @@ schemas: !<!Schemas>
           name: field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DoubleWrapper
@@ -729,11 +729,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: *ref_10
@@ -751,6 +746,11 @@ schemas: !<!Schemas>
           name: fieldFalse
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: BooleanWrapper
@@ -762,11 +762,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -792,6 +787,11 @@ schemas: !<!Schemas>
           name: 'null'
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: StringWrapper
@@ -803,11 +803,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_107
       schema: *ref_14
@@ -825,6 +820,11 @@ schemas: !<!Schemas>
           name: leap
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DateWrapper
@@ -836,11 +836,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_113
       schema: *ref_16
@@ -858,6 +853,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DatetimeWrapper
@@ -869,11 +869,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_119
       schema: *ref_18
@@ -891,6 +886,11 @@ schemas: !<!Schemas>
           name: now
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Datetimerfc1123Wrapper
@@ -902,11 +902,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_125
       schema: *ref_20
@@ -916,6 +911,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DurationWrapper
@@ -927,11 +927,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_129
       schema: *ref_21
@@ -941,6 +936,11 @@ schemas: !<!Schemas>
           name: field
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: ByteWrapper
@@ -952,11 +952,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_133
       schema: !<!ArraySchema> &ref_62
@@ -976,6 +971,11 @@ schemas: !<!Schemas>
           name: array
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: ArrayWrapper
@@ -987,11 +987,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_139
       schema: *ref_23
@@ -1001,6 +996,11 @@ schemas: !<!Schemas>
           name: defaultProgram
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: DictionaryWrapper
@@ -1033,6 +1033,11 @@ schemas: !<!Schemas>
               name: food
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Dog
@@ -1051,11 +1056,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: '2016-02-29'
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             parents: !<!Relations> 
               all:
               - *ref_26
@@ -1071,6 +1071,11 @@ schemas: !<!Schemas>
                   name: breed
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: Siamese
@@ -1111,6 +1116,11 @@ schemas: !<!Schemas>
               name: hates
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Cat
@@ -1138,6 +1148,11 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Pet
@@ -1193,9 +1208,6 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           immediate:
           - *ref_36
-        contexts:
-        - output
-        - input
         discriminator: !<!Discriminator> 
           all:
             smart_salmon: *ref_36
@@ -1212,8 +1224,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: salmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_34
@@ -1236,6 +1246,11 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Salmon
@@ -1383,9 +1398,6 @@ schemas: !<!Schemas>
       immediate:
       - *ref_32
       - *ref_39
-    contexts:
-    - output
-    - input
     discriminator: !<!Discriminator> 
       all:
         cookiecuttershark: *ref_44
@@ -1398,8 +1410,6 @@ schemas: !<!Schemas>
         salmon: *ref_32
         shark: *ref_39
       property: *ref_45
-    knownMediaTypes:
-    - json
     properties:
     - *ref_45
     - !<!Property> 
@@ -1439,6 +1449,11 @@ schemas: !<!Schemas>
           name: siblings
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Fish
@@ -1457,11 +1472,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-        contexts:
-        - output
         discriminatorValue: DotSalmon
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_48
@@ -1484,6 +1495,10 @@ schemas: !<!Schemas>
               name: iswild
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DotSalmon
@@ -1492,8 +1507,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_50
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         DotSalmon: *ref_50
@@ -1509,8 +1522,6 @@ schemas: !<!Schemas>
             name: fishType
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_52
     - !<!Property> 
@@ -1522,6 +1533,10 @@ schemas: !<!Schemas>
           name: species
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFish
@@ -1533,10 +1548,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_50
@@ -1590,6 +1601,10 @@ schemas: !<!Schemas>
           name: fishes
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DotFishMarket
@@ -1603,11 +1618,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1626,6 +1636,11 @@ schemas: !<!Schemas>
           name: size
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: ReadonlyObj
@@ -1669,8 +1684,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_57
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         Kind1: *ref_57
@@ -1686,8 +1699,6 @@ schemas: !<!Schemas>
             name: kind
             description: ''
         protocol: !<!Protocols> {}
-    knownMediaTypes:
-    - json
     properties:
     - *ref_59
     - !<!Property> 
@@ -1711,6 +1722,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyBaseType
@@ -1722,10 +1737,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-02-29'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -1735,6 +1746,10 @@ schemas: !<!Schemas>
           name: propBH1
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-date/flattened.yaml
+++ b/modelerfour/test/scenarios/body-date/flattened.yaml
@@ -61,6 +61,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-date/flattened.yaml
+++ b/modelerfour/test/scenarios/body-date/flattened.yaml
@@ -61,10 +61,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -82,6 +78,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-date/grouped.yaml
+++ b/modelerfour/test/scenarios/body-date/grouped.yaml
@@ -61,6 +61,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-date/grouped.yaml
+++ b/modelerfour/test/scenarios/body-date/grouped.yaml
@@ -61,10 +61,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -82,6 +78,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-date/modeler.yaml
+++ b/modelerfour/test/scenarios/body-date/modeler.yaml
@@ -61,6 +61,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-date/modeler.yaml
+++ b/modelerfour/test/scenarios/body-date/modeler.yaml
@@ -61,10 +61,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -82,6 +78,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-date/namer.yaml
+++ b/modelerfour/test/scenarios/body-date/namer.yaml
@@ -61,6 +61,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-date/namer.yaml
+++ b/modelerfour/test/scenarios/body-date/namer.yaml
@@ -61,10 +61,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -82,6 +78,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/flattened.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/flattened.yaml
@@ -62,6 +62,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/flattened.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/flattened.yaml
@@ -62,10 +62,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -83,6 +79,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/grouped.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/grouped.yaml
@@ -62,6 +62,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/grouped.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/grouped.yaml
@@ -62,10 +62,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -83,6 +79,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/modeler.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/modeler.yaml
@@ -62,6 +62,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/modeler.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/modeler.yaml
@@ -62,10 +62,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -83,6 +79,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
@@ -62,6 +62,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
@@ -62,10 +62,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -83,6 +79,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime/flattened.yaml
+++ b/modelerfour/test/scenarios/body-datetime/flattened.yaml
@@ -75,10 +75,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -96,6 +92,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime/flattened.yaml
+++ b/modelerfour/test/scenarios/body-datetime/flattened.yaml
@@ -75,6 +75,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-datetime/grouped.yaml
+++ b/modelerfour/test/scenarios/body-datetime/grouped.yaml
@@ -75,10 +75,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -96,6 +92,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime/grouped.yaml
+++ b/modelerfour/test/scenarios/body-datetime/grouped.yaml
@@ -75,6 +75,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-datetime/modeler.yaml
+++ b/modelerfour/test/scenarios/body-datetime/modeler.yaml
@@ -75,10 +75,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -96,6 +92,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime/modeler.yaml
+++ b/modelerfour/test/scenarios/body-datetime/modeler.yaml
@@ -75,6 +75,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-datetime/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime/namer.yaml
@@ -75,10 +75,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -96,6 +92,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-datetime/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime/namer.yaml
@@ -75,6 +75,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-dictionary/flattened.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/flattened.yaml
@@ -287,6 +287,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       properties:
       - !<!Property> 
         schema: *ref_6
@@ -399,6 +404,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_6

--- a/modelerfour/test/scenarios/body-dictionary/flattened.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/flattened.yaml
@@ -287,11 +287,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       properties:
       - !<!Property> 
         schema: *ref_6
@@ -309,6 +304,11 @@ schemas: !<!Schemas>
             name: string
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: Widget
@@ -404,10 +404,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -425,6 +421,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-dictionary/grouped.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/grouped.yaml
@@ -287,6 +287,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       properties:
       - !<!Property> 
         schema: *ref_6
@@ -399,6 +404,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_6

--- a/modelerfour/test/scenarios/body-dictionary/grouped.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/grouped.yaml
@@ -287,11 +287,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       properties:
       - !<!Property> 
         schema: *ref_6
@@ -309,6 +304,11 @@ schemas: !<!Schemas>
             name: string
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: Widget
@@ -404,10 +404,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -425,6 +421,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-dictionary/modeler.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/modeler.yaml
@@ -287,6 +287,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       properties:
       - !<!Property> 
         schema: *ref_5
@@ -399,6 +404,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5

--- a/modelerfour/test/scenarios/body-dictionary/modeler.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/modeler.yaml
@@ -287,11 +287,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       properties:
       - !<!Property> 
         schema: *ref_5
@@ -309,6 +304,11 @@ schemas: !<!Schemas>
             name: string
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: Widget
@@ -404,10 +404,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -425,6 +421,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-dictionary/namer.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/namer.yaml
@@ -287,6 +287,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       properties:
       - !<!Property> 
         schema: *ref_6
@@ -399,6 +404,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_6

--- a/modelerfour/test/scenarios/body-dictionary/namer.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/namer.yaml
@@ -287,11 +287,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       properties:
       - !<!Property> 
         schema: *ref_6
@@ -309,6 +304,11 @@ schemas: !<!Schemas>
             name: string
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: Widget
@@ -404,10 +404,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -425,6 +421,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-duration/flattened.yaml
+++ b/modelerfour/test/scenarios/body-duration/flattened.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-duration/flattened.yaml
+++ b/modelerfour/test/scenarios/body-duration/flattened.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-duration/grouped.yaml
+++ b/modelerfour/test/scenarios/body-duration/grouped.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-duration/grouped.yaml
+++ b/modelerfour/test/scenarios/body-duration/grouped.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-duration/modeler.yaml
+++ b/modelerfour/test/scenarios/body-duration/modeler.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-duration/modeler.yaml
+++ b/modelerfour/test/scenarios/body-duration/modeler.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-duration/namer.yaml
+++ b/modelerfour/test/scenarios/body-duration/namer.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-duration/namer.yaml
+++ b/modelerfour/test/scenarios/body-duration/namer.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-file/flattened.yaml
+++ b/modelerfour/test/scenarios/body-file/flattened.yaml
@@ -36,6 +36,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-file/flattened.yaml
+++ b/modelerfour/test/scenarios/body-file/flattened.yaml
@@ -36,10 +36,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -57,6 +53,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-file/grouped.yaml
+++ b/modelerfour/test/scenarios/body-file/grouped.yaml
@@ -36,6 +36,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-file/grouped.yaml
+++ b/modelerfour/test/scenarios/body-file/grouped.yaml
@@ -36,10 +36,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -57,6 +53,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-file/modeler.yaml
+++ b/modelerfour/test/scenarios/body-file/modeler.yaml
@@ -36,10 +36,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -57,6 +53,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-file/modeler.yaml
+++ b/modelerfour/test/scenarios/body-file/modeler.yaml
@@ -36,6 +36,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/body-file/namer.yaml
+++ b/modelerfour/test/scenarios/body-file/namer.yaml
@@ -36,6 +36,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-file/namer.yaml
+++ b/modelerfour/test/scenarios/body-file/namer.yaml
@@ -36,10 +36,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -57,6 +53,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-integer/flattened.yaml
+++ b/modelerfour/test/scenarios/body-integer/flattened.yaml
@@ -69,10 +69,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -90,6 +86,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-integer/flattened.yaml
+++ b/modelerfour/test/scenarios/body-integer/flattened.yaml
@@ -69,6 +69,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-integer/grouped.yaml
+++ b/modelerfour/test/scenarios/body-integer/grouped.yaml
@@ -69,10 +69,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -90,6 +86,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-integer/grouped.yaml
+++ b/modelerfour/test/scenarios/body-integer/grouped.yaml
@@ -69,6 +69,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-integer/modeler.yaml
+++ b/modelerfour/test/scenarios/body-integer/modeler.yaml
@@ -69,10 +69,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -90,6 +86,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-integer/modeler.yaml
+++ b/modelerfour/test/scenarios/body-integer/modeler.yaml
@@ -69,6 +69,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-integer/namer.yaml
+++ b/modelerfour/test/scenarios/body-integer/namer.yaml
@@ -69,10 +69,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -90,6 +86,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-integer/namer.yaml
+++ b/modelerfour/test/scenarios/body-integer/namer.yaml
@@ -69,6 +69,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-number.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/flattened.yaml
@@ -200,6 +200,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-number.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/flattened.yaml
@@ -200,10 +200,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -221,6 +217,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-number.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/grouped.yaml
@@ -200,6 +200,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-number.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/grouped.yaml
@@ -200,10 +200,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -221,6 +217,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-number.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/modeler.yaml
@@ -200,10 +200,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -221,6 +217,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-number.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/modeler.yaml
@@ -200,6 +200,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-number.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/namer.yaml
@@ -200,6 +200,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-number.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/namer.yaml
@@ -200,10 +200,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -221,6 +217,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-number/flattened.yaml
+++ b/modelerfour/test/scenarios/body-number/flattened.yaml
@@ -200,6 +200,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-number/flattened.yaml
+++ b/modelerfour/test/scenarios/body-number/flattened.yaml
@@ -200,10 +200,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -221,6 +217,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-number/grouped.yaml
+++ b/modelerfour/test/scenarios/body-number/grouped.yaml
@@ -200,6 +200,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-number/grouped.yaml
+++ b/modelerfour/test/scenarios/body-number/grouped.yaml
@@ -200,10 +200,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -221,6 +217,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-number/modeler.yaml
+++ b/modelerfour/test/scenarios/body-number/modeler.yaml
@@ -200,10 +200,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -221,6 +217,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-number/modeler.yaml
+++ b/modelerfour/test/scenarios/body-number/modeler.yaml
@@ -200,6 +200,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/body-number/namer.yaml
+++ b/modelerfour/test/scenarios/body-number/namer.yaml
@@ -200,6 +200,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-number/namer.yaml
+++ b/modelerfour/test/scenarios/body-number/namer.yaml
@@ -200,10 +200,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -221,6 +217,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/body-string.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/flattened.yaml
@@ -165,10 +165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -186,6 +182,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -197,11 +197,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3
@@ -221,6 +216,11 @@ schemas: !<!Schemas>
           name: field1
           description: Sample string.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RefColorConstant

--- a/modelerfour/test/scenarios/body-string.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/flattened.yaml
@@ -165,6 +165,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -193,6 +197,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-string.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/grouped.yaml
@@ -165,10 +165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -186,6 +182,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -197,11 +197,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3
@@ -221,6 +216,11 @@ schemas: !<!Schemas>
           name: field1
           description: Sample string.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RefColorConstant

--- a/modelerfour/test/scenarios/body-string.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/grouped.yaml
@@ -165,6 +165,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -193,6 +197,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-string.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/modeler.yaml
@@ -165,6 +165,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -193,6 +197,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-string.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/modeler.yaml
@@ -165,10 +165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -186,6 +182,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -197,11 +197,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -221,6 +216,11 @@ schemas: !<!Schemas>
           name: field1
           description: Sample string.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RefColorConstant

--- a/modelerfour/test/scenarios/body-string.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/namer.yaml
@@ -165,10 +165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -186,6 +182,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -197,11 +197,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3
@@ -221,6 +216,11 @@ schemas: !<!Schemas>
           name: field1
           description: Sample string.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RefColorConstant

--- a/modelerfour/test/scenarios/body-string.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/namer.yaml
@@ -165,6 +165,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -193,6 +197,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-string/flattened.yaml
+++ b/modelerfour/test/scenarios/body-string/flattened.yaml
@@ -165,10 +165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -186,6 +182,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -197,11 +197,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3
@@ -221,6 +216,11 @@ schemas: !<!Schemas>
           name: field1
           description: Sample string.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RefColorConstant

--- a/modelerfour/test/scenarios/body-string/flattened.yaml
+++ b/modelerfour/test/scenarios/body-string/flattened.yaml
@@ -165,6 +165,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -193,6 +197,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-string/grouped.yaml
+++ b/modelerfour/test/scenarios/body-string/grouped.yaml
@@ -165,10 +165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -186,6 +182,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -197,11 +197,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3
@@ -221,6 +216,11 @@ schemas: !<!Schemas>
           name: field1
           description: Sample string.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RefColorConstant

--- a/modelerfour/test/scenarios/body-string/grouped.yaml
+++ b/modelerfour/test/scenarios/body-string/grouped.yaml
@@ -165,6 +165,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -193,6 +197,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3

--- a/modelerfour/test/scenarios/body-string/modeler.yaml
+++ b/modelerfour/test/scenarios/body-string/modeler.yaml
@@ -165,6 +165,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -193,6 +197,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2

--- a/modelerfour/test/scenarios/body-string/modeler.yaml
+++ b/modelerfour/test/scenarios/body-string/modeler.yaml
@@ -165,10 +165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -186,6 +182,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -197,11 +197,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -221,6 +216,11 @@ schemas: !<!Schemas>
           name: field1
           description: Sample string.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RefColorConstant

--- a/modelerfour/test/scenarios/body-string/namer.yaml
+++ b/modelerfour/test/scenarios/body-string/namer.yaml
@@ -165,10 +165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -186,6 +182,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -197,11 +197,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3
@@ -221,6 +216,11 @@ schemas: !<!Schemas>
           name: field1
           description: Sample string.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RefColorConstant

--- a/modelerfour/test/scenarios/body-string/namer.yaml
+++ b/modelerfour/test/scenarios/body-string/namer.yaml
@@ -165,6 +165,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -193,6 +197,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_19
       schema: *ref_3

--- a/modelerfour/test/scenarios/cognitive-search/flattened.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/flattened.yaml
@@ -795,10 +795,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_1
@@ -814,6 +810,10 @@ schemas: !<!Schemas>
               name: count
               description: The approximate count of documents falling within the bucket described by this facet.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: FacetResult
@@ -889,10 +889,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -929,11 +925,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_8
@@ -1106,6 +1097,11 @@ schemas: !<!Schemas>
                 The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a
                 continuation token that can be used to issue another Search request for the next page of results.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: SearchRequest
@@ -1130,10 +1126,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_25
@@ -1159,6 +1151,10 @@ schemas: !<!Schemas>
                 name: Highlights
                 description: 'Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SearchResult
@@ -1188,6 +1184,10 @@ schemas: !<!Schemas>
             Continuation URL returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this URL to formulate another GET or POST Search request to get the next part of the search
             response. Make sure to use the same verb (GET or POST) as the request that produced this response.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SearchDocumentsResult
@@ -1202,10 +1202,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
+    serializationFormats:
     - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: paths·1y7tjlf·docs-key·get·responses·200·content·application-json·schema
@@ -1217,10 +1217,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_83
@@ -1233,10 +1229,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_32
@@ -1252,6 +1244,10 @@ schemas: !<!Schemas>
                 name: Text
                 description: The text of the suggestion result.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SuggestResult
@@ -1279,6 +1275,10 @@ schemas: !<!Schemas>
           name: Coverage
           description: 'A value indicating the percentage of the index that was included in the query, or null if minimumCoverage was not set in the request.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SuggestDocumentsResult
@@ -1291,10 +1291,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_36
@@ -1391,6 +1387,10 @@ schemas: !<!Schemas>
           name: top
           description: The number of suggestions to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SuggestRequest
@@ -1402,10 +1402,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_152
       schema: !<!ArraySchema> &ref_84
@@ -1418,10 +1414,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_46
@@ -1436,6 +1428,10 @@ schemas: !<!Schemas>
                 name: ActionType
                 description: The operation to perform on a document in an indexing batch.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: IndexAction
@@ -1454,6 +1450,10 @@ schemas: !<!Schemas>
           name: Actions
           description: The actions in the batch.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: IndexBatch
@@ -1466,10 +1466,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -1482,10 +1478,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -1527,6 +1519,10 @@ schemas: !<!Schemas>
                   The status code of the indexing operation. Possible values include: 200 for a successful update or delete, 201 for successful document creation, 400 for a malformed input document, 404 for document not found, 409 for a
                   version conflict, 422 when the index is temporarily unavailable, or 503 for when the service is too busy.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: IndexingResult
@@ -1545,6 +1541,10 @@ schemas: !<!Schemas>
           name: Results
           description: The list of status information for each document in the indexing request.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: IndexDocumentsResult
@@ -1557,10 +1557,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1582,10 +1578,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_55
@@ -1605,6 +1597,10 @@ schemas: !<!Schemas>
                 name: queryPlusText
                 description: The query along with the completed term.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: AutocompleteItem
@@ -1623,6 +1619,10 @@ schemas: !<!Schemas>
           name: Results
           description: The list of returned Autocompleted items.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: AutocompleteResult
@@ -1635,10 +1635,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_58
@@ -1724,6 +1720,10 @@ schemas: !<!Schemas>
           name: top
           description: The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AutocompleteRequest

--- a/modelerfour/test/scenarios/cognitive-search/flattened.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/flattened.yaml
@@ -795,6 +795,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_1
@@ -885,6 +889,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -921,6 +929,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_8
@@ -1117,6 +1130,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_25
@@ -1185,6 +1202,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     language: !<!Languages> 
       default:
         name: paths·1y7tjlf·docs-key·get·responses·200·content·application-json·schema
@@ -1196,6 +1217,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_83
@@ -1208,6 +1233,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_32
@@ -1262,6 +1291,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_36
@@ -1369,6 +1402,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_152
       schema: !<!ArraySchema> &ref_84
@@ -1381,6 +1418,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_46
@@ -1425,6 +1466,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -1437,6 +1482,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -1508,6 +1557,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -1529,6 +1582,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_55
@@ -1578,6 +1635,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_58

--- a/modelerfour/test/scenarios/cognitive-search/grouped.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/grouped.yaml
@@ -1083,6 +1083,8 @@ schemas: !<!Schemas>
           name: client-request-id
           description: The tracking ID sent with the request to help with debugging.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: request-options
@@ -1522,6 +1524,8 @@ schemas: !<!Schemas>
             The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation
             token that can be used to issue another Search request for the next page of results.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SearchOptions
@@ -1770,6 +1774,8 @@ schemas: !<!Schemas>
           name: $top
           description: The number of suggestions to retrieve. The value must be a number between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SuggestOptions
@@ -1971,6 +1977,8 @@ schemas: !<!Schemas>
           name: $top
           description: The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AutocompleteOptions

--- a/modelerfour/test/scenarios/cognitive-search/grouped.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/grouped.yaml
@@ -795,6 +795,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_1
@@ -1980,6 +1984,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -2016,6 +2024,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_8
@@ -2212,6 +2225,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_25
@@ -2280,6 +2297,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     language: !<!Languages> 
       default:
         name: paths·1y7tjlf·docs-key·get·responses·200·content·application-json·schema
@@ -2291,6 +2312,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_83
@@ -2303,6 +2328,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_32
@@ -2357,6 +2386,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_36
@@ -2464,6 +2497,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_166
       schema: !<!ArraySchema> &ref_84
@@ -2476,6 +2513,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_46
@@ -2520,6 +2561,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -2532,6 +2577,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -2603,6 +2652,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -2624,6 +2677,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_55
@@ -2673,6 +2730,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_58

--- a/modelerfour/test/scenarios/cognitive-search/grouped.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/grouped.yaml
@@ -795,10 +795,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_1
@@ -814,6 +810,10 @@ schemas: !<!Schemas>
               name: count
               description: The approximate count of documents falling within the bucket described by this facet.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: FacetResult
@@ -1984,10 +1984,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -2024,11 +2020,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_8
@@ -2201,6 +2192,11 @@ schemas: !<!Schemas>
                 The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a
                 continuation token that can be used to issue another Search request for the next page of results.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: SearchRequest
@@ -2225,10 +2221,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_25
@@ -2254,6 +2246,10 @@ schemas: !<!Schemas>
                 name: Highlights
                 description: 'Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SearchResult
@@ -2283,6 +2279,10 @@ schemas: !<!Schemas>
             Continuation URL returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this URL to formulate another GET or POST Search request to get the next part of the search
             response. Make sure to use the same verb (GET or POST) as the request that produced this response.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SearchDocumentsResult
@@ -2297,10 +2297,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
+    serializationFormats:
     - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: paths·1y7tjlf·docs-key·get·responses·200·content·application-json·schema
@@ -2312,10 +2312,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_83
@@ -2328,10 +2324,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_32
@@ -2347,6 +2339,10 @@ schemas: !<!Schemas>
                 name: Text
                 description: The text of the suggestion result.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SuggestResult
@@ -2374,6 +2370,10 @@ schemas: !<!Schemas>
           name: Coverage
           description: 'A value indicating the percentage of the index that was included in the query, or null if minimumCoverage was not set in the request.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SuggestDocumentsResult
@@ -2386,10 +2386,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_36
@@ -2486,6 +2482,10 @@ schemas: !<!Schemas>
           name: top
           description: The number of suggestions to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SuggestRequest
@@ -2497,10 +2497,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_166
       schema: !<!ArraySchema> &ref_84
@@ -2513,10 +2509,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_46
@@ -2531,6 +2523,10 @@ schemas: !<!Schemas>
                 name: ActionType
                 description: The operation to perform on a document in an indexing batch.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: IndexAction
@@ -2549,6 +2545,10 @@ schemas: !<!Schemas>
           name: Actions
           description: The actions in the batch.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: IndexBatch
@@ -2561,10 +2561,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -2577,10 +2573,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -2622,6 +2614,10 @@ schemas: !<!Schemas>
                   The status code of the indexing operation. Possible values include: 200 for a successful update or delete, 201 for successful document creation, 400 for a malformed input document, 404 for document not found, 409 for a
                   version conflict, 422 when the index is temporarily unavailable, or 503 for when the service is too busy.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: IndexingResult
@@ -2640,6 +2636,10 @@ schemas: !<!Schemas>
           name: Results
           description: The list of status information for each document in the indexing request.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: IndexDocumentsResult
@@ -2652,10 +2652,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -2677,10 +2673,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_55
@@ -2700,6 +2692,10 @@ schemas: !<!Schemas>
                 name: queryPlusText
                 description: The query along with the completed term.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: AutocompleteItem
@@ -2718,6 +2714,10 @@ schemas: !<!Schemas>
           name: Results
           description: The list of returned Autocompleted items.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: AutocompleteResult
@@ -2730,10 +2730,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_58
@@ -2819,6 +2815,10 @@ schemas: !<!Schemas>
           name: top
           description: The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AutocompleteRequest

--- a/modelerfour/test/scenarios/cognitive-search/modeler.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/modeler.yaml
@@ -795,10 +795,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_8
@@ -814,6 +810,10 @@ schemas: !<!Schemas>
               name: count
               description: The approximate count of documents falling within the bucket described by this facet.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: FacetResult
@@ -889,10 +889,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -929,11 +925,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_33
@@ -1106,6 +1097,11 @@ schemas: !<!Schemas>
                 The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a
                 continuation token that can be used to issue another Search request for the next page of results.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: SearchRequest
@@ -1130,10 +1126,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_15
@@ -1159,6 +1151,10 @@ schemas: !<!Schemas>
                 name: Highlights
                 description: 'Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SearchResult
@@ -1188,6 +1184,10 @@ schemas: !<!Schemas>
             Continuation URL returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this URL to formulate another GET or POST Search request to get the next part of the search
             response. Make sure to use the same verb (GET or POST) as the request that produced this response.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SearchDocumentsResult
@@ -1202,10 +1202,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
+    serializationFormats:
     - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: paths·1y7tjlf·docs-key·get·responses·200·content·application-json·schema
@@ -1217,10 +1217,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_55
@@ -1233,10 +1229,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_21
@@ -1252,6 +1244,10 @@ schemas: !<!Schemas>
                 name: Text
                 description: The text of the suggestion result.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SuggestResult
@@ -1279,6 +1275,10 @@ schemas: !<!Schemas>
           name: Coverage
           description: 'A value indicating the percentage of the index that was included in the query, or null if minimumCoverage was not set in the request.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SuggestDocumentsResult
@@ -1291,10 +1291,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_58
@@ -1391,6 +1387,10 @@ schemas: !<!Schemas>
           name: top
           description: The number of suggestions to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SuggestRequest
@@ -1402,10 +1402,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_68
@@ -1418,10 +1414,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_22
@@ -1436,6 +1428,10 @@ schemas: !<!Schemas>
                 name: ActionType
                 description: The operation to perform on a document in an indexing batch.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: IndexAction
@@ -1454,6 +1450,10 @@ schemas: !<!Schemas>
           name: Actions
           description: The actions in the batch.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: IndexBatch
@@ -1466,10 +1466,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_70
@@ -1482,10 +1478,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_23
@@ -1527,6 +1519,10 @@ schemas: !<!Schemas>
                   The status code of the indexing operation. Possible values include: 200 for a successful update or delete, 201 for successful document creation, 400 for a malformed input document, 404 for document not found, 409 for a
                   version conflict, 422 when the index is temporarily unavailable, or 503 for when the service is too busy.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: IndexingResult
@@ -1545,6 +1541,10 @@ schemas: !<!Schemas>
           name: Results
           description: The list of status information for each document in the indexing request.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: IndexDocumentsResult
@@ -1557,10 +1557,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_72
@@ -1582,10 +1578,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_27
@@ -1605,6 +1597,10 @@ schemas: !<!Schemas>
                 name: queryPlusText
                 description: The query along with the completed term.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: AutocompleteItem
@@ -1623,6 +1619,10 @@ schemas: !<!Schemas>
           name: Results
           description: The list of returned Autocompleted items.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: AutocompleteResult
@@ -1635,10 +1635,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_75
@@ -1724,6 +1720,10 @@ schemas: !<!Schemas>
           name: top
           description: The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AutocompleteRequest

--- a/modelerfour/test/scenarios/cognitive-search/modeler.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/modeler.yaml
@@ -795,6 +795,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_8
@@ -885,6 +889,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -921,6 +929,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_33
@@ -1117,6 +1130,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_15
@@ -1185,6 +1202,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     language: !<!Languages> 
       default:
         name: paths·1y7tjlf·docs-key·get·responses·200·content·application-json·schema
@@ -1196,6 +1217,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_55
@@ -1208,6 +1233,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_21
@@ -1262,6 +1291,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_58
@@ -1369,6 +1402,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_68
@@ -1381,6 +1418,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_22
@@ -1425,6 +1466,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_70
@@ -1437,6 +1482,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_23
@@ -1508,6 +1557,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_72
@@ -1529,6 +1582,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_27
@@ -1578,6 +1635,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_75

--- a/modelerfour/test/scenarios/cognitive-search/namer.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/namer.yaml
@@ -795,10 +795,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_1
@@ -814,6 +810,10 @@ schemas: !<!Schemas>
               name: count
               description: The approximate count of documents falling within the bucket described by this facet.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: FacetResult
@@ -1984,10 +1984,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_38
@@ -2024,11 +2020,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_41
@@ -2201,6 +2192,11 @@ schemas: !<!Schemas>
                 The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a
                 continuation token that can be used to issue another Search request for the next page of results.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: SearchRequest
@@ -2225,10 +2221,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_56
@@ -2254,6 +2246,10 @@ schemas: !<!Schemas>
                 name: highlights
                 description: 'Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SearchResult
@@ -2283,6 +2279,10 @@ schemas: !<!Schemas>
             Continuation URL returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this URL to formulate another GET or POST Search request to get the next part of the search
             response. Make sure to use the same verb (GET or POST) as the request that produced this response.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SearchDocumentsResult
@@ -2297,10 +2297,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
+    serializationFormats:
     - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Paths1Y7TjlfDocsKeyGetResponses200ContentApplicationJsonSchema
@@ -2312,10 +2312,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_104
@@ -2328,10 +2324,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_63
@@ -2347,6 +2339,10 @@ schemas: !<!Schemas>
                 name: text
                 description: The text of the suggestion result.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SuggestResult
@@ -2374,6 +2370,10 @@ schemas: !<!Schemas>
           name: coverage
           description: 'A value indicating the percentage of the index that was included in the query, or null if minimumCoverage was not set in the request.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SuggestDocumentsResult
@@ -2386,10 +2386,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_67
@@ -2486,6 +2482,10 @@ schemas: !<!Schemas>
           name: top
           description: The number of suggestions to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SuggestRequest
@@ -2497,10 +2497,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_166
       schema: !<!ArraySchema> &ref_105
@@ -2513,10 +2509,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           parents: !<!Relations> 
             all:
             - *ref_77
@@ -2531,6 +2523,10 @@ schemas: !<!Schemas>
                 name: actionType
                 description: The operation to perform on a document in an indexing batch.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: IndexAction
@@ -2549,6 +2545,10 @@ schemas: !<!Schemas>
           name: actions
           description: The actions in the batch.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: IndexBatch
@@ -2561,10 +2561,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_106
@@ -2577,10 +2573,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_80
@@ -2622,6 +2614,10 @@ schemas: !<!Schemas>
                   The status code of the indexing operation. Possible values include: 200 for a successful update or delete, 201 for successful document creation, 400 for a malformed input document, 404 for document not found, 409 for a
                   version conflict, 422 when the index is temporarily unavailable, or 503 for when the service is too busy.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: IndexingResult
@@ -2640,6 +2636,10 @@ schemas: !<!Schemas>
           name: results
           description: The list of status information for each document in the indexing request.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: IndexDocumentsResult
@@ -2652,10 +2652,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_85
@@ -2677,10 +2673,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_86
@@ -2700,6 +2692,10 @@ schemas: !<!Schemas>
                 name: queryPlusText
                 description: The query along with the completed term.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: AutocompleteItem
@@ -2718,6 +2714,10 @@ schemas: !<!Schemas>
           name: results
           description: The list of returned Autocompleted items.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: AutocompleteResult
@@ -2730,10 +2730,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_89
@@ -2819,6 +2815,10 @@ schemas: !<!Schemas>
           name: top
           description: The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AutocompleteRequest

--- a/modelerfour/test/scenarios/cognitive-search/namer.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/namer.yaml
@@ -795,6 +795,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_1
@@ -1980,6 +1984,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_38
@@ -2016,6 +2024,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_41
@@ -2212,6 +2225,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_56
@@ -2280,6 +2297,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     language: !<!Languages> 
       default:
         name: Paths1Y7TjlfDocsKeyGetResponses200ContentApplicationJsonSchema
@@ -2291,6 +2312,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_104
@@ -2303,6 +2328,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_63
@@ -2357,6 +2386,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_67
@@ -2464,6 +2497,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_166
       schema: !<!ArraySchema> &ref_105
@@ -2476,6 +2513,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           parents: !<!Relations> 
             all:
             - *ref_77
@@ -2520,6 +2561,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_106
@@ -2532,6 +2577,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_80
@@ -2603,6 +2652,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_85
@@ -2624,6 +2677,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-05-06'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_86
@@ -2673,6 +2730,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-05-06'
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_89

--- a/modelerfour/test/scenarios/cognitive-search/namer.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/namer.yaml
@@ -1083,6 +1083,8 @@ schemas: !<!Schemas>
           name: clientRequestId
           description: The tracking ID sent with the request to help with debugging.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: RequestOptions
@@ -1522,6 +1524,8 @@ schemas: !<!Schemas>
             The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation
             token that can be used to issue another Search request for the next page of results.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SearchOptions
@@ -1770,6 +1774,8 @@ schemas: !<!Schemas>
           name: top
           description: The number of suggestions to retrieve. The value must be a number between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SuggestOptions
@@ -1971,6 +1977,8 @@ schemas: !<!Schemas>
           name: top
           description: The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AutocompleteOptions

--- a/modelerfour/test/scenarios/complex-model/flattened.yaml
+++ b/modelerfour/test/scenarios/complex-model/flattened.yaml
@@ -125,6 +125,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -204,6 +209,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_12
@@ -235,6 +244,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -263,6 +276,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_26
       schema: *ref_9
@@ -283,6 +300,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_10
@@ -303,6 +324,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_33
       schema: !<!ArraySchema> &ref_14

--- a/modelerfour/test/scenarios/complex-model/flattened.yaml
+++ b/modelerfour/test/scenarios/complex-model/flattened.yaml
@@ -125,11 +125,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -171,6 +166,11 @@ schemas: !<!Schemas>
               name: image
               description: Image URL representing the product.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Product
@@ -209,10 +209,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_12
@@ -232,6 +228,10 @@ schemas: !<!Schemas>
           name: productArray
           description: Array of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CatalogArray
@@ -244,10 +244,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -265,6 +261,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -276,10 +276,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_26
       schema: *ref_9
@@ -289,6 +285,10 @@ schemas: !<!Schemas>
           name: productDictionaryOfArray
           description: Dictionary of Array of product
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CatalogDictionaryOfArray
@@ -300,10 +300,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_10
@@ -313,6 +309,10 @@ schemas: !<!Schemas>
           name: productDictionary
           description: Dictionary of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CatalogDictionary
@@ -324,10 +324,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_33
       schema: !<!ArraySchema> &ref_14
@@ -347,6 +343,10 @@ schemas: !<!Schemas>
           name: productArrayOfDictionary
           description: Array of dictionary of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CatalogArrayOfDictionary

--- a/modelerfour/test/scenarios/complex-model/grouped.yaml
+++ b/modelerfour/test/scenarios/complex-model/grouped.yaml
@@ -125,6 +125,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -204,6 +209,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_12
@@ -235,6 +244,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -263,6 +276,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_26
       schema: *ref_9
@@ -283,6 +300,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_10
@@ -303,6 +324,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_33
       schema: !<!ArraySchema> &ref_14

--- a/modelerfour/test/scenarios/complex-model/grouped.yaml
+++ b/modelerfour/test/scenarios/complex-model/grouped.yaml
@@ -125,11 +125,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -171,6 +166,11 @@ schemas: !<!Schemas>
               name: image
               description: Image URL representing the product.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Product
@@ -209,10 +209,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_12
@@ -232,6 +228,10 @@ schemas: !<!Schemas>
           name: productArray
           description: Array of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CatalogArray
@@ -244,10 +244,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -265,6 +261,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -276,10 +276,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_26
       schema: *ref_9
@@ -289,6 +285,10 @@ schemas: !<!Schemas>
           name: productDictionaryOfArray
           description: Dictionary of Array of product
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CatalogDictionaryOfArray
@@ -300,10 +300,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_10
@@ -313,6 +309,10 @@ schemas: !<!Schemas>
           name: productDictionary
           description: Dictionary of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CatalogDictionary
@@ -324,10 +324,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_33
       schema: !<!ArraySchema> &ref_14
@@ -347,6 +343,10 @@ schemas: !<!Schemas>
           name: productArrayOfDictionary
           description: Array of dictionary of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CatalogArrayOfDictionary

--- a/modelerfour/test/scenarios/complex-model/modeler.yaml
+++ b/modelerfour/test/scenarios/complex-model/modeler.yaml
@@ -125,11 +125,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -171,6 +166,11 @@ schemas: !<!Schemas>
               name: image
               description: Image URL representing the product.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Product
@@ -209,10 +209,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_8
@@ -232,6 +228,10 @@ schemas: !<!Schemas>
           name: productArray
           description: Array of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CatalogArray
@@ -244,10 +244,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -265,6 +261,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -276,10 +276,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_12
@@ -289,6 +285,10 @@ schemas: !<!Schemas>
           name: productDictionaryOfArray
           description: Dictionary of Array of product
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CatalogDictionaryOfArray
@@ -300,10 +300,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_13
@@ -313,6 +309,10 @@ schemas: !<!Schemas>
           name: productDictionary
           description: Dictionary of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CatalogDictionary
@@ -324,10 +324,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10
@@ -347,6 +343,10 @@ schemas: !<!Schemas>
           name: productArrayOfDictionary
           description: Array of dictionary of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CatalogArrayOfDictionary

--- a/modelerfour/test/scenarios/complex-model/modeler.yaml
+++ b/modelerfour/test/scenarios/complex-model/modeler.yaml
@@ -125,6 +125,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -204,6 +209,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_8
@@ -235,6 +244,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -263,6 +276,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_12
@@ -283,6 +300,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_13
@@ -303,6 +324,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -125,6 +125,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -204,6 +209,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_12
@@ -235,6 +244,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -263,6 +276,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_26
       schema: *ref_9
@@ -283,6 +300,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_10
@@ -303,6 +324,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_33
       schema: !<!ArraySchema> &ref_14

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -125,11 +125,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_1
@@ -171,6 +166,11 @@ schemas: !<!Schemas>
               name: image
               description: Image URL representing the product.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Product
@@ -209,10 +209,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_12
@@ -232,6 +228,10 @@ schemas: !<!Schemas>
           name: productArray
           description: Array of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CatalogArray
@@ -244,10 +244,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -265,6 +261,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -276,10 +276,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_26
       schema: *ref_9
@@ -289,6 +285,10 @@ schemas: !<!Schemas>
           name: productDictionaryOfArray
           description: Dictionary of Array of product
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CatalogDictionaryOfArray
@@ -300,10 +300,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_10
@@ -313,6 +309,10 @@ schemas: !<!Schemas>
           name: productDictionary
           description: Dictionary of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CatalogDictionary
@@ -324,10 +324,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_33
       schema: !<!ArraySchema> &ref_14
@@ -347,6 +343,10 @@ schemas: !<!Schemas>
           name: productArrayOfDictionary
           description: Array of dictionary of products
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CatalogArrayOfDictionary

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/flattened.yaml
@@ -68,10 +68,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -89,6 +85,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/flattened.yaml
@@ -68,6 +68,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/grouped.yaml
@@ -68,10 +68,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -89,6 +85,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/grouped.yaml
@@ -68,6 +68,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/modeler.yaml
@@ -68,6 +68,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/modeler.yaml
@@ -68,10 +68,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -89,6 +85,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
@@ -68,10 +68,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -89,6 +85,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
@@ -68,6 +68,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/flattened.yaml
@@ -77,6 +77,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_6
@@ -89,6 +93,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_4
@@ -96,6 +104,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_0

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/flattened.yaml
@@ -77,10 +77,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_6
@@ -93,10 +89,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_4
@@ -104,10 +96,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_0
@@ -125,6 +113,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Product-properties
@@ -137,6 +129,10 @@ schemas: !<!Schemas>
                 name: properties
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Product
@@ -162,6 +158,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResult

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/grouped.yaml
@@ -77,6 +77,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_6
@@ -89,6 +93,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_4
@@ -96,6 +104,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_0

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/grouped.yaml
@@ -77,10 +77,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_6
@@ -93,10 +89,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_4
@@ -104,10 +96,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_0
@@ -125,6 +113,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Product-properties
@@ -137,6 +129,10 @@ schemas: !<!Schemas>
                 name: properties
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Product
@@ -162,6 +158,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResult

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/modeler.yaml
@@ -77,6 +77,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_6
@@ -89,6 +93,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_3
@@ -96,6 +104,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_4

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/modeler.yaml
@@ -77,10 +77,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_6
@@ -93,10 +89,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_3
@@ -104,10 +96,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_4
@@ -125,6 +113,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Product-properties
@@ -137,6 +129,10 @@ schemas: !<!Schemas>
                 name: properties
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Product
@@ -162,6 +158,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResult

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
@@ -77,6 +77,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_6
@@ -89,6 +93,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_4
@@ -96,6 +104,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_0

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
@@ -77,10 +77,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_6
@@ -93,10 +89,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_4
@@ -104,10 +96,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_0
@@ -125,6 +113,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ProductProperties
@@ -137,6 +129,10 @@ schemas: !<!Schemas>
                 name: properties
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Product
@@ -162,6 +158,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResult

--- a/modelerfour/test/scenarios/custom-baseUrl/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/flattened.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/flattened.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/custom-baseUrl/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/grouped.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/grouped.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/custom-baseUrl/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/modeler.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/custom-baseUrl/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/modeler.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -68,6 +64,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/datalake-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/flattened.yaml
@@ -2058,6 +2058,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -2070,6 +2074,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_1
@@ -2124,6 +2132,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -2131,6 +2143,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -2172,6 +2188,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_18
@@ -2184,6 +2204,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_8

--- a/modelerfour/test/scenarios/datalake-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/flattened.yaml
@@ -2058,10 +2058,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -2074,10 +2070,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_1
@@ -2103,6 +2095,10 @@ schemas: !<!Schemas>
                 name: eTag
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Filesystem
@@ -2120,6 +2116,10 @@ schemas: !<!Schemas>
           name: filesystems
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: FilesystemList
@@ -2132,10 +2132,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -2143,10 +2139,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -2164,6 +2156,10 @@ schemas: !<!Schemas>
               name: message
               description: The service error message.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DataLakeStorageErrorProps
@@ -2176,6 +2172,10 @@ schemas: !<!Schemas>
           name: error
           description: The service error response object.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DataLakeStorageError
@@ -2188,10 +2188,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_18
@@ -2204,10 +2200,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_8
@@ -2273,6 +2265,10 @@ schemas: !<!Schemas>
                 name: permissions
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Path
@@ -2290,6 +2286,10 @@ schemas: !<!Schemas>
           name: paths
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PathList

--- a/modelerfour/test/scenarios/datalake-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/grouped.yaml
@@ -2058,6 +2058,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -2070,6 +2074,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_1
@@ -2124,6 +2132,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -2131,6 +2143,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -2172,6 +2188,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_18
@@ -2184,6 +2204,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_8

--- a/modelerfour/test/scenarios/datalake-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/grouped.yaml
@@ -2058,10 +2058,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -2074,10 +2070,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_1
@@ -2103,6 +2095,10 @@ schemas: !<!Schemas>
                 name: eTag
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Filesystem
@@ -2120,6 +2116,10 @@ schemas: !<!Schemas>
           name: filesystems
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: FilesystemList
@@ -2132,10 +2132,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -2143,10 +2139,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -2164,6 +2156,10 @@ schemas: !<!Schemas>
               name: message
               description: The service error message.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DataLakeStorageErrorProps
@@ -2176,6 +2172,10 @@ schemas: !<!Schemas>
           name: error
           description: The service error response object.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DataLakeStorageError
@@ -2188,10 +2188,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_18
@@ -2204,10 +2200,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_8
@@ -2273,6 +2265,10 @@ schemas: !<!Schemas>
                 name: permissions
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Path
@@ -2290,6 +2286,10 @@ schemas: !<!Schemas>
           name: paths
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PathList

--- a/modelerfour/test/scenarios/datalake-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/modeler.yaml
@@ -2058,10 +2058,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_16
@@ -2074,10 +2070,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_1
@@ -2103,6 +2095,10 @@ schemas: !<!Schemas>
                 name: eTag
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Filesystem
@@ -2120,6 +2116,10 @@ schemas: !<!Schemas>
           name: filesystems
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: FilesystemList
@@ -2132,10 +2132,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -2143,10 +2139,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -2164,6 +2156,10 @@ schemas: !<!Schemas>
               name: message
               description: The service error message.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DataLakeStorageErrorProps
@@ -2176,6 +2172,10 @@ schemas: !<!Schemas>
           name: error
           description: The service error response object.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DataLakeStorageError
@@ -2188,10 +2188,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -2204,10 +2200,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_8
@@ -2273,6 +2265,10 @@ schemas: !<!Schemas>
                 name: permissions
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Path
@@ -2290,6 +2286,10 @@ schemas: !<!Schemas>
           name: paths
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PathList

--- a/modelerfour/test/scenarios/datalake-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/modeler.yaml
@@ -2058,6 +2058,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_16
@@ -2070,6 +2074,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_1
@@ -2124,6 +2132,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -2131,6 +2143,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -2172,6 +2188,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -2184,6 +2204,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_8

--- a/modelerfour/test/scenarios/datalake-storage/namer.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/namer.yaml
@@ -2058,6 +2058,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -2070,6 +2074,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_1
@@ -2124,6 +2132,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -2131,6 +2143,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -2172,6 +2188,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_18
@@ -2184,6 +2204,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_8

--- a/modelerfour/test/scenarios/datalake-storage/namer.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/namer.yaml
@@ -2058,10 +2058,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -2074,10 +2070,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_1
@@ -2103,6 +2095,10 @@ schemas: !<!Schemas>
                 name: eTag
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Filesystem
@@ -2120,6 +2116,10 @@ schemas: !<!Schemas>
           name: filesystems
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: FilesystemList
@@ -2132,10 +2132,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_7
@@ -2143,10 +2139,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -2164,6 +2156,10 @@ schemas: !<!Schemas>
               name: message
               description: The service error message.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DataLakeStorageErrorProps
@@ -2176,6 +2172,10 @@ schemas: !<!Schemas>
           name: error
           description: The service error response object.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DataLakeStorageError
@@ -2188,10 +2188,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2019-10-31'
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_18
@@ -2204,10 +2200,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: '2019-10-31'
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_8
@@ -2273,6 +2265,10 @@ schemas: !<!Schemas>
                 name: permissions
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Path
@@ -2290,6 +2286,10 @@ schemas: !<!Schemas>
           name: paths
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PathList

--- a/modelerfour/test/scenarios/extensible-enums-swagger/flattened.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/flattened.yaml
@@ -123,6 +123,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-07-07'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/extensible-enums-swagger/flattened.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/flattened.yaml
@@ -123,11 +123,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-07-07'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -156,6 +151,11 @@ schemas: !<!Schemas>
           name: IntEnum
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Pet

--- a/modelerfour/test/scenarios/extensible-enums-swagger/grouped.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/grouped.yaml
@@ -123,6 +123,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-07-07'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/extensible-enums-swagger/grouped.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/grouped.yaml
@@ -123,11 +123,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-07-07'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -156,6 +151,11 @@ schemas: !<!Schemas>
           name: IntEnum
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Pet

--- a/modelerfour/test/scenarios/extensible-enums-swagger/modeler.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/modeler.yaml
@@ -123,11 +123,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-07-07'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -156,6 +151,11 @@ schemas: !<!Schemas>
           name: IntEnum
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Pet

--- a/modelerfour/test/scenarios/extensible-enums-swagger/modeler.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/modeler.yaml
@@ -123,6 +123,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-07-07'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
@@ -123,11 +123,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-07-07'
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -156,6 +151,11 @@ schemas: !<!Schemas>
           name: intEnum
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Pet

--- a/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
@@ -123,6 +123,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: '2016-07-07'
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/header/flattened.yaml
+++ b/modelerfour/test/scenarios/header/flattened.yaml
@@ -201,6 +201,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/header/flattened.yaml
+++ b/modelerfour/test/scenarios/header/flattened.yaml
@@ -201,10 +201,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -222,6 +218,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/header/grouped.yaml
+++ b/modelerfour/test/scenarios/header/grouped.yaml
@@ -201,6 +201,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/header/grouped.yaml
+++ b/modelerfour/test/scenarios/header/grouped.yaml
@@ -201,10 +201,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -222,6 +218,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/header/modeler.yaml
+++ b/modelerfour/test/scenarios/header/modeler.yaml
@@ -201,6 +201,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/header/modeler.yaml
+++ b/modelerfour/test/scenarios/header/modeler.yaml
@@ -201,10 +201,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -222,6 +218,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/header/namer.yaml
+++ b/modelerfour/test/scenarios/header/namer.yaml
@@ -201,6 +201,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/header/namer.yaml
+++ b/modelerfour/test/scenarios/header/namer.yaml
@@ -201,10 +201,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -222,6 +218,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/flattened.yaml
@@ -230,10 +230,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -251,6 +247,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -269,10 +269,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -287,6 +283,10 @@ schemas: !<!Schemas>
               name: textStatusCode
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: B
@@ -295,10 +295,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -308,6 +304,10 @@ schemas: !<!Schemas>
           name: statusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyException
@@ -320,10 +320,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -333,6 +329,10 @@ schemas: !<!Schemas>
           name: httpCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: C
@@ -344,10 +344,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -357,6 +353,10 @@ schemas: !<!Schemas>
           name: httpStatusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: D

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/flattened.yaml
@@ -230,6 +230,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -265,6 +269,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -287,6 +295,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -308,6 +320,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -328,6 +344,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/grouped.yaml
@@ -230,10 +230,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -251,6 +247,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -269,10 +269,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -287,6 +283,10 @@ schemas: !<!Schemas>
               name: textStatusCode
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: B
@@ -295,10 +295,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -308,6 +304,10 @@ schemas: !<!Schemas>
           name: statusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyException
@@ -320,10 +320,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -333,6 +329,10 @@ schemas: !<!Schemas>
           name: httpCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: C
@@ -344,10 +344,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -357,6 +353,10 @@ schemas: !<!Schemas>
           name: httpStatusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: D

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/grouped.yaml
@@ -230,6 +230,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -265,6 +269,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -287,6 +295,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -308,6 +320,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -328,6 +344,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/modeler.yaml
@@ -230,10 +230,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -251,6 +247,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -269,10 +269,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -287,6 +283,10 @@ schemas: !<!Schemas>
               name: textStatusCode
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: B
@@ -295,10 +295,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -308,6 +304,10 @@ schemas: !<!Schemas>
           name: statusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyException
@@ -320,10 +320,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -333,6 +329,10 @@ schemas: !<!Schemas>
           name: httpCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: C
@@ -344,10 +344,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -357,6 +353,10 @@ schemas: !<!Schemas>
           name: httpStatusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: D

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/modeler.yaml
@@ -230,6 +230,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -265,6 +269,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -287,6 +295,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -308,6 +320,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -328,6 +344,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
@@ -230,10 +230,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -251,6 +247,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -269,10 +269,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -287,6 +283,10 @@ schemas: !<!Schemas>
               name: textStatusCode
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: B
@@ -295,10 +295,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -308,6 +304,10 @@ schemas: !<!Schemas>
           name: statusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyException
@@ -320,10 +320,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -333,6 +329,10 @@ schemas: !<!Schemas>
           name: httpCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: C
@@ -344,10 +344,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -357,6 +353,10 @@ schemas: !<!Schemas>
           name: httpStatusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: D

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
@@ -230,6 +230,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -265,6 +269,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -287,6 +295,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -308,6 +320,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -328,6 +344,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9

--- a/modelerfour/test/scenarios/httpInfrastructure/flattened.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/flattened.yaml
@@ -220,10 +220,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -241,6 +237,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -259,10 +259,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -277,6 +273,10 @@ schemas: !<!Schemas>
               name: textStatusCode
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: B
@@ -285,10 +285,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -298,6 +294,10 @@ schemas: !<!Schemas>
           name: statusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyException
@@ -310,10 +310,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -323,6 +319,10 @@ schemas: !<!Schemas>
           name: httpCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: C
@@ -334,10 +334,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -347,6 +343,10 @@ schemas: !<!Schemas>
           name: httpStatusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: D

--- a/modelerfour/test/scenarios/httpInfrastructure/flattened.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/flattened.yaml
@@ -220,6 +220,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -255,6 +259,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -277,6 +285,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -298,6 +310,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -318,6 +334,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9

--- a/modelerfour/test/scenarios/httpInfrastructure/grouped.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/grouped.yaml
@@ -220,10 +220,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -241,6 +237,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -259,10 +259,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -277,6 +273,10 @@ schemas: !<!Schemas>
               name: textStatusCode
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: B
@@ -285,10 +285,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -298,6 +294,10 @@ schemas: !<!Schemas>
           name: statusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyException
@@ -310,10 +310,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -323,6 +319,10 @@ schemas: !<!Schemas>
           name: httpCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: C
@@ -334,10 +334,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -347,6 +343,10 @@ schemas: !<!Schemas>
           name: httpStatusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: D

--- a/modelerfour/test/scenarios/httpInfrastructure/grouped.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/grouped.yaml
@@ -220,6 +220,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -255,6 +259,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -277,6 +285,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -298,6 +310,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -318,6 +334,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9

--- a/modelerfour/test/scenarios/httpInfrastructure/modeler.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/modeler.yaml
@@ -220,10 +220,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -241,6 +237,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -259,10 +259,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -277,6 +273,10 @@ schemas: !<!Schemas>
               name: textStatusCode
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: B
@@ -285,10 +285,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -298,6 +294,10 @@ schemas: !<!Schemas>
           name: statusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyException
@@ -310,10 +310,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -323,6 +319,10 @@ schemas: !<!Schemas>
           name: httpCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: C
@@ -334,10 +334,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -347,6 +343,10 @@ schemas: !<!Schemas>
           name: httpStatusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: D

--- a/modelerfour/test/scenarios/httpInfrastructure/modeler.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/modeler.yaml
@@ -220,6 +220,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -255,6 +259,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -277,6 +285,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -298,6 +310,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -318,6 +334,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8

--- a/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
@@ -220,10 +220,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -241,6 +237,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -259,10 +259,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -277,6 +273,10 @@ schemas: !<!Schemas>
               name: textStatusCode
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: B
@@ -285,10 +285,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -298,6 +294,10 @@ schemas: !<!Schemas>
           name: statusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: MyException
@@ -310,10 +310,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -323,6 +319,10 @@ schemas: !<!Schemas>
           name: httpCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: C
@@ -334,10 +334,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -347,6 +343,10 @@ schemas: !<!Schemas>
           name: httpStatusCode
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: D

--- a/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
@@ -220,6 +220,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -255,6 +259,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_4
@@ -277,6 +285,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_6
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -298,6 +310,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -318,6 +334,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9

--- a/modelerfour/test/scenarios/keyvault/flattened.yaml
+++ b/modelerfour/test/scenarios/keyvault/flattened.yaml
@@ -2163,10 +2163,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_261
       schema: *ref_2
@@ -2211,11 +2207,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_6
@@ -2231,11 +2222,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2253,6 +2239,11 @@ schemas: !<!Schemas>
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: SecretAttributes
@@ -2264,11 +2255,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - output
-                - input
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2286,6 +2272,11 @@ schemas: !<!Schemas>
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
@@ -2339,6 +2330,11 @@ schemas: !<!Schemas>
                   name: updated
                   description: Last updated time in UTC.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: Attributes
@@ -2359,6 +2355,11 @@ schemas: !<!Schemas>
                 Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the
                 end of the retention interval.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: KeyAttributes
@@ -2390,6 +2391,10 @@ schemas: !<!Schemas>
           name: curve
           description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyCreateParameters
@@ -2410,10 +2415,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_17
@@ -2446,6 +2447,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the key was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedKeyBundle
@@ -2454,10 +2459,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_21
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_38
@@ -2465,11 +2466,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_22
@@ -2609,6 +2605,11 @@ schemas: !<!Schemas>
               name: 'y'
               description: Y component of an EC public key.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: JsonWebKey
@@ -2646,6 +2647,10 @@ schemas: !<!Schemas>
           name: managed
           description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyBundle
@@ -2658,10 +2663,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_41
@@ -2669,10 +2670,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_39
@@ -2701,6 +2698,10 @@ schemas: !<!Schemas>
               name: innerError
               description: The key vault server error.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Error
@@ -2714,6 +2715,10 @@ schemas: !<!Schemas>
           name: error
           description: The key vault server error.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyVaultError
@@ -2726,10 +2731,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_278
       schema: *ref_42
@@ -2767,6 +2768,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyImportParameters
@@ -2779,10 +2784,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_292
       schema: !<!ArraySchema> &ref_235
@@ -2818,6 +2819,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyUpdateParameters
@@ -2829,10 +2834,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_236
@@ -2852,10 +2853,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_45
@@ -2888,6 +2885,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the key was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedKeyItem
@@ -2896,10 +2897,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_47
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_48
@@ -2934,6 +2931,10 @@ schemas: !<!Schemas>
                 name: managed
                 description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: KeyItem
@@ -2961,6 +2962,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of keys.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyListResult
@@ -2973,10 +2978,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_51
@@ -2987,6 +2988,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up key.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupKeyResult
@@ -2998,10 +3003,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_316
       schema: *ref_52
@@ -3012,6 +3013,10 @@ schemas: !<!Schemas>
           name: keyBundleBackup
           description: The backup blob associated with a key bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyRestoreParameters
@@ -3023,10 +3028,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_321
       schema: *ref_53
@@ -3046,6 +3047,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyOperationsParameters
@@ -3057,10 +3062,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -3080,6 +3081,10 @@ schemas: !<!Schemas>
           name: result
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyOperationResult
@@ -3091,10 +3096,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_337
       schema: *ref_57
@@ -3114,6 +3115,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeySignParameters
@@ -3125,10 +3130,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_346
       schema: *ref_57
@@ -3157,6 +3158,10 @@ schemas: !<!Schemas>
           name: signature
           description: The signature to be verified.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyVerifyParameters
@@ -3168,10 +3173,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -3182,6 +3183,10 @@ schemas: !<!Schemas>
           name: value
           description: 'True if the signature is verified, otherwise false.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyVerifyResult
@@ -3193,10 +3198,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_237
@@ -3226,6 +3227,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted keys.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedKeyListResult
@@ -3238,10 +3243,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_379
       schema: *ref_63
@@ -3279,6 +3280,10 @@ schemas: !<!Schemas>
           name: secretAttributes
           description: The secret management attributes.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretSetParameters
@@ -3298,10 +3303,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_66
@@ -3334,6 +3335,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the secret was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedSecretBundle
@@ -3342,10 +3347,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_70
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_71
@@ -3405,6 +3406,10 @@ schemas: !<!Schemas>
           name: managed
           description: 'True if the secret''s lifetime is managed by key vault. If this is a secret backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SecretBundle
@@ -3417,10 +3422,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_393
       schema: *ref_77
@@ -3446,6 +3447,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretUpdateParameters
@@ -3457,10 +3462,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_238
@@ -3480,10 +3481,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_79
@@ -3516,6 +3513,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the secret was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedSecretItem
@@ -3524,10 +3525,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_81
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_82
@@ -3570,6 +3567,10 @@ schemas: !<!Schemas>
                 name: managed
                 description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SecretItem
@@ -3597,6 +3598,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of secrets.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SecretListResult
@@ -3609,10 +3614,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_239
@@ -3642,6 +3643,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted secrets.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedSecretListResult
@@ -3654,10 +3659,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_88
@@ -3668,6 +3669,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up secret.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupSecretResult
@@ -3679,10 +3684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_425
       schema: *ref_89
@@ -3693,6 +3694,10 @@ schemas: !<!Schemas>
           name: secretBundleBackup
           description: The backup blob associated with a secret bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretRestoreParameters
@@ -3704,10 +3709,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_240
@@ -3727,10 +3728,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_90
@@ -3763,6 +3760,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the certificate was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedCertificateItem
@@ -3771,10 +3772,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_94
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_95
@@ -3808,6 +3805,10 @@ schemas: !<!Schemas>
                 name: X509Thumbprint
                 description: Thumbprint of the certificate.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: CertificateItem
@@ -3835,6 +3836,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateListResult
@@ -3855,10 +3860,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_99
@@ -3891,6 +3892,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the certificate was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedCertificateBundle
@@ -3899,10 +3904,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_101
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_102
@@ -3946,11 +3947,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_105
@@ -3967,11 +3963,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_106
@@ -4013,6 +4004,11 @@ schemas: !<!Schemas>
                   name: curve
                   description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: KeyProperties
@@ -4031,11 +4027,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_108
@@ -4045,6 +4036,11 @@ schemas: !<!Schemas>
                   name: contentType
                   description: The media type (MIME type).
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: SecretProperties
@@ -4063,11 +4059,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_109
@@ -4101,11 +4092,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_242
@@ -4161,6 +4147,11 @@ schemas: !<!Schemas>
                       name: upns
                       description: User principal names.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: SubjectAlternativeNames
@@ -4199,6 +4190,11 @@ schemas: !<!Schemas>
                   name: ValidityInMonths
                   description: The duration that the certificate is valid in months.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: X509CertificateProperties
@@ -4222,11 +4218,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - input
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_131
@@ -4234,11 +4225,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
-                  contexts:
-                  - input
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_116
@@ -4256,6 +4242,11 @@ schemas: !<!Schemas>
                         name: days_before_expiry
                         description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
+                  - input
                   language: !<!Languages> 
                     default:
                       name: Trigger
@@ -4274,11 +4265,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
-                  contexts:
-                  - input
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_118
@@ -4288,6 +4274,11 @@ schemas: !<!Schemas>
                         name: action_type
                         description: The type of the action.
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
+                  - input
                   language: !<!Languages> 
                     default:
                       name: Action
@@ -4300,6 +4291,11 @@ schemas: !<!Schemas>
                     name: action
                     description: The action that will be executed.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: LifetimeAction
@@ -4323,11 +4319,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_119
@@ -4353,6 +4344,11 @@ schemas: !<!Schemas>
                   name: CertificateTransparency
                   description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: IssuerParameters
@@ -4373,6 +4369,11 @@ schemas: !<!Schemas>
               name: attributes
               description: The certificate management attributes.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: CertificatePolicy
@@ -4418,6 +4419,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateBundle
@@ -4439,11 +4444,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_134
@@ -4465,11 +4465,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
-          contexts:
-          - input
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_135
@@ -4495,6 +4490,11 @@ schemas: !<!Schemas>
                 name: phone
                 description: Phone number.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: Contact
@@ -4512,6 +4512,11 @@ schemas: !<!Schemas>
           name: ContactList
           description: The contact list for the vault certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: Contacts
@@ -4524,10 +4529,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_248
@@ -4540,10 +4541,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_139
@@ -4561,6 +4558,10 @@ schemas: !<!Schemas>
                 name: provider
                 description: The issuer provider.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: CertificateIssuerItem
@@ -4588,6 +4589,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of certificate issuers.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateIssuerListResult
@@ -4600,10 +4605,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_447
       schema: *ref_143
@@ -4620,11 +4621,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_144
@@ -4642,6 +4638,11 @@ schemas: !<!Schemas>
               name: Password
               description: The password/secret/account key.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: IssuerCredentials
@@ -4661,11 +4662,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_146
@@ -4686,11 +4682,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - input
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_147
@@ -4724,6 +4715,11 @@ schemas: !<!Schemas>
                     name: phone
                     description: Phone number.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - input
+              - output
               language: !<!Languages> 
                 default:
                   name: AdministratorDetails
@@ -4741,6 +4737,11 @@ schemas: !<!Schemas>
               name: admin_details
               description: Details of the organization administrator.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: OrganizationDetails
@@ -4760,11 +4761,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_150
@@ -4792,6 +4788,11 @@ schemas: !<!Schemas>
               name: updated
               description: Last updated time in UTC.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: IssuerAttributes
@@ -4805,6 +4806,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateIssuerSetParameters
@@ -4820,10 +4825,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_155
@@ -4866,6 +4867,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: IssuerBundle
@@ -4877,10 +4882,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_460
       schema: *ref_157
@@ -4914,6 +4915,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateIssuerUpdateParameters
@@ -4925,10 +4930,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_476
       schema: *ref_125
@@ -4954,6 +4955,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateCreateParameters
@@ -4965,10 +4970,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_159
@@ -5043,6 +5044,10 @@ schemas: !<!Schemas>
           name: request_id
           description: Identifier for the certificate operation.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateOperation
@@ -5054,10 +5059,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_487
       schema: *ref_166
@@ -5104,6 +5105,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateImportParameters
@@ -5115,10 +5120,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_509
       schema: *ref_125
@@ -5144,6 +5145,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateUpdateParameters
@@ -5155,10 +5160,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_523
       schema: *ref_161
@@ -5169,6 +5170,10 @@ schemas: !<!Schemas>
           name: cancellation_requested
           description: Indicates if cancellation was requested on the certificate operation.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateOperationUpdateParameter
@@ -5180,10 +5185,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_533
       schema: !<!ArraySchema> &ref_250
@@ -5222,6 +5223,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateMergeParameters
@@ -5233,10 +5238,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_172
@@ -5247,6 +5248,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up certificate.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupCertificateResult
@@ -5258,10 +5263,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_546
       schema: *ref_173
@@ -5272,6 +5273,10 @@ schemas: !<!Schemas>
           name: certificateBundleBackup
           description: The backup blob associated with a certificate bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateRestoreParameters
@@ -5283,10 +5288,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_251
@@ -5316,6 +5317,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedCertificateListResult
@@ -5328,10 +5333,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_252
@@ -5351,10 +5352,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_175
@@ -5387,6 +5384,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the storage account was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedStorageAccountItem
@@ -5395,10 +5396,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_179
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_180
@@ -5424,11 +5421,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              - input
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5467,6 +5459,11 @@ schemas: !<!Schemas>
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: StorageAccountAttributes
@@ -5489,6 +5486,10 @@ schemas: !<!Schemas>
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: StorageAccountItem
@@ -5516,6 +5517,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of storage accounts.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageListResult
@@ -5529,10 +5534,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_253
@@ -5562,6 +5563,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted storage accounts.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedStorageListResult
@@ -5581,10 +5586,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_187
@@ -5617,6 +5618,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the storage account was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedStorageBundle
@@ -5625,10 +5630,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_189
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_190
@@ -5693,6 +5694,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageBundle
@@ -5705,10 +5710,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_196
@@ -5719,6 +5720,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up storage account.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupStorageResult
@@ -5730,10 +5735,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_577
       schema: *ref_197
@@ -5744,6 +5745,10 @@ schemas: !<!Schemas>
           name: storageBundleBackup
           description: The backup blob associated with a storage account.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageRestoreParameters
@@ -5755,10 +5760,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_586
       schema: *ref_198
@@ -5814,6 +5815,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountCreateParameters
@@ -5825,10 +5830,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_602
       schema: *ref_202
@@ -5870,6 +5871,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountUpdateParameters
@@ -5881,10 +5886,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_616
       schema: *ref_205
@@ -5895,6 +5896,10 @@ schemas: !<!Schemas>
           name: keyName
           description: The storage account key name.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountRegenerteKeyParameters
@@ -5906,10 +5911,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_254
@@ -5929,10 +5930,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_206
@@ -5965,6 +5962,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the SAS definition was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedSasDefinitionItem
@@ -5973,10 +5974,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_210
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -6002,11 +5999,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              - input
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -6045,6 +6037,11 @@ schemas: !<!Schemas>
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: SasDefinitionAttributes
@@ -6067,6 +6064,10 @@ schemas: !<!Schemas>
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SasDefinitionItem
@@ -6094,6 +6095,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of SAS definitions.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SasDefinitionListResult
@@ -6107,10 +6112,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_255
@@ -6140,6 +6141,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted SAS definitions.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedSasDefinitionListResult
@@ -6159,10 +6164,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_217
@@ -6195,6 +6196,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the SAS definition was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedSasDefinitionBundle
@@ -6203,10 +6208,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_219
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_220
@@ -6271,6 +6272,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SasDefinitionBundle
@@ -6283,10 +6288,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_642
       schema: *ref_226
@@ -6333,6 +6334,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SasDefinitionCreateParameters
@@ -6344,10 +6349,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_657
       schema: *ref_229
@@ -6389,6 +6390,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SasDefinitionUpdateParameters

--- a/modelerfour/test/scenarios/keyvault/flattened.yaml
+++ b/modelerfour/test/scenarios/keyvault/flattened.yaml
@@ -2163,6 +2163,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_261
       schema: *ref_2
@@ -2207,6 +2211,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_6
@@ -2222,6 +2231,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2250,6 +2264,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - output
+                - input
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2391,6 +2410,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_17
@@ -2431,6 +2454,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_21
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_38
@@ -2438,6 +2465,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_22
@@ -2626,6 +2658,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_41
@@ -2633,6 +2669,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_39
@@ -2686,6 +2726,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_278
       schema: *ref_42
@@ -2735,6 +2779,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_292
       schema: !<!ArraySchema> &ref_235
@@ -2781,6 +2829,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_236
@@ -2800,6 +2852,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_45
@@ -2840,6 +2896,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_47
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_48
@@ -2913,6 +2973,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_51
@@ -2934,6 +2998,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_316
       schema: *ref_52
@@ -2955,6 +3023,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_321
       schema: *ref_53
@@ -2985,6 +3057,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -3015,6 +3091,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_337
       schema: *ref_57
@@ -3045,6 +3125,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_346
       schema: *ref_57
@@ -3084,6 +3168,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -3105,6 +3193,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_237
@@ -3146,6 +3238,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_379
       schema: *ref_63
@@ -3202,6 +3298,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_66
@@ -3242,6 +3342,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_70
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_71
@@ -3313,6 +3417,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_393
       schema: *ref_77
@@ -3349,6 +3457,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_238
@@ -3368,6 +3480,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_79
@@ -3408,6 +3524,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_81
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_82
@@ -3489,6 +3609,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_239
@@ -3530,6 +3654,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_88
@@ -3551,6 +3679,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_425
       schema: *ref_89
@@ -3572,6 +3704,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_240
@@ -3591,6 +3727,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_90
@@ -3631,6 +3771,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_94
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_95
@@ -3711,6 +3855,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_99
@@ -3751,6 +3899,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_101
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_102
@@ -3794,6 +3946,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_105
@@ -3810,6 +3967,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_106
@@ -3869,6 +4031,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_108
@@ -3896,6 +4063,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_109
@@ -3929,6 +4101,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_242
@@ -4045,6 +4222,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - input
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_131
@@ -4052,6 +4234,11 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
+                  contexts:
+                  - input
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_116
@@ -4087,6 +4274,11 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
+                  contexts:
+                  - input
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_118
@@ -4131,6 +4323,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_119
@@ -4242,6 +4439,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_134
@@ -4263,6 +4465,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
+          contexts:
+          - input
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_135
@@ -4317,6 +4524,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_248
@@ -4329,6 +4540,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_139
@@ -4385,6 +4600,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_447
       schema: *ref_143
@@ -4401,6 +4620,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_144
@@ -4437,6 +4661,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_146
@@ -4457,6 +4686,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - input
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_147
@@ -4526,6 +4760,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_150
@@ -4581,6 +4820,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_155
@@ -4634,6 +4877,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_460
       schema: *ref_157
@@ -4678,6 +4925,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_476
       schema: *ref_125
@@ -4714,6 +4965,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_159
@@ -4799,6 +5054,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_487
       schema: *ref_166
@@ -4856,6 +5115,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_509
       schema: *ref_125
@@ -4892,6 +5155,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_523
       schema: *ref_161
@@ -4913,6 +5180,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_533
       schema: !<!ArraySchema> &ref_250
@@ -4962,6 +5233,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_172
@@ -4983,6 +5258,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_546
       schema: *ref_173
@@ -5004,6 +5283,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_251
@@ -5045,6 +5328,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_252
@@ -5064,6 +5351,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_175
@@ -5104,6 +5395,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_179
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_180
@@ -5129,6 +5424,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              - input
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5229,6 +5529,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_253
@@ -5277,6 +5581,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_187
@@ -5317,6 +5625,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_189
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_190
@@ -5393,6 +5705,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_196
@@ -5414,6 +5730,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_577
       schema: *ref_197
@@ -5435,6 +5755,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_586
       schema: *ref_198
@@ -5501,6 +5825,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_602
       schema: *ref_202
@@ -5553,6 +5881,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_616
       schema: *ref_205
@@ -5574,6 +5906,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_254
@@ -5593,6 +5929,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_206
@@ -5633,6 +5973,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_210
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -5658,6 +6002,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              - input
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5758,6 +6107,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_255
@@ -5806,6 +6159,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_217
@@ -5846,6 +6203,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_219
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_220
@@ -5922,6 +6283,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_642
       schema: *ref_226
@@ -5979,6 +6344,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_657
       schema: *ref_229

--- a/modelerfour/test/scenarios/keyvault/grouped.yaml
+++ b/modelerfour/test/scenarios/keyvault/grouped.yaml
@@ -2163,10 +2163,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_261
       schema: *ref_2
@@ -2211,11 +2207,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_6
@@ -2231,11 +2222,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2253,6 +2239,11 @@ schemas: !<!Schemas>
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: SecretAttributes
@@ -2264,11 +2255,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - output
-                - input
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2286,6 +2272,11 @@ schemas: !<!Schemas>
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
@@ -2339,6 +2330,11 @@ schemas: !<!Schemas>
                   name: updated
                   description: Last updated time in UTC.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: Attributes
@@ -2359,6 +2355,11 @@ schemas: !<!Schemas>
                 Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the
                 end of the retention interval.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: KeyAttributes
@@ -2390,6 +2391,10 @@ schemas: !<!Schemas>
           name: curve
           description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyCreateParameters
@@ -2410,10 +2415,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_17
@@ -2446,6 +2447,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the key was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedKeyBundle
@@ -2454,10 +2459,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_21
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_38
@@ -2465,11 +2466,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_22
@@ -2609,6 +2605,11 @@ schemas: !<!Schemas>
               name: 'y'
               description: Y component of an EC public key.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: JsonWebKey
@@ -2646,6 +2647,10 @@ schemas: !<!Schemas>
           name: managed
           description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyBundle
@@ -2658,10 +2663,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_41
@@ -2669,10 +2670,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_39
@@ -2701,6 +2698,10 @@ schemas: !<!Schemas>
               name: innerError
               description: The key vault server error.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Error
@@ -2714,6 +2715,10 @@ schemas: !<!Schemas>
           name: error
           description: The key vault server error.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyVaultError
@@ -2726,10 +2731,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_278
       schema: *ref_42
@@ -2767,6 +2768,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyImportParameters
@@ -2779,10 +2784,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_292
       schema: !<!ArraySchema> &ref_235
@@ -2818,6 +2819,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyUpdateParameters
@@ -2829,10 +2834,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_236
@@ -2852,10 +2853,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_45
@@ -2888,6 +2885,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the key was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedKeyItem
@@ -2896,10 +2897,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_47
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_48
@@ -2934,6 +2931,10 @@ schemas: !<!Schemas>
                 name: managed
                 description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: KeyItem
@@ -2961,6 +2962,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of keys.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyListResult
@@ -2973,10 +2978,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_51
@@ -2987,6 +2988,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up key.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupKeyResult
@@ -2998,10 +3003,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_316
       schema: *ref_52
@@ -3012,6 +3013,10 @@ schemas: !<!Schemas>
           name: keyBundleBackup
           description: The backup blob associated with a key bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyRestoreParameters
@@ -3023,10 +3028,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_321
       schema: *ref_53
@@ -3046,6 +3047,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyOperationsParameters
@@ -3057,10 +3062,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -3080,6 +3081,10 @@ schemas: !<!Schemas>
           name: result
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyOperationResult
@@ -3091,10 +3096,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_337
       schema: *ref_57
@@ -3114,6 +3115,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeySignParameters
@@ -3125,10 +3130,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_346
       schema: *ref_57
@@ -3157,6 +3158,10 @@ schemas: !<!Schemas>
           name: signature
           description: The signature to be verified.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyVerifyParameters
@@ -3168,10 +3173,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -3182,6 +3183,10 @@ schemas: !<!Schemas>
           name: value
           description: 'True if the signature is verified, otherwise false.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyVerifyResult
@@ -3193,10 +3198,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_237
@@ -3226,6 +3227,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted keys.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedKeyListResult
@@ -3238,10 +3243,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_379
       schema: *ref_63
@@ -3279,6 +3280,10 @@ schemas: !<!Schemas>
           name: secretAttributes
           description: The secret management attributes.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretSetParameters
@@ -3298,10 +3303,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_66
@@ -3334,6 +3335,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the secret was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedSecretBundle
@@ -3342,10 +3347,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_70
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_71
@@ -3405,6 +3406,10 @@ schemas: !<!Schemas>
           name: managed
           description: 'True if the secret''s lifetime is managed by key vault. If this is a secret backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SecretBundle
@@ -3417,10 +3422,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_393
       schema: *ref_77
@@ -3446,6 +3447,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretUpdateParameters
@@ -3457,10 +3462,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_238
@@ -3480,10 +3481,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_79
@@ -3516,6 +3513,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the secret was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedSecretItem
@@ -3524,10 +3525,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_81
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_82
@@ -3570,6 +3567,10 @@ schemas: !<!Schemas>
                 name: managed
                 description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SecretItem
@@ -3597,6 +3598,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of secrets.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SecretListResult
@@ -3609,10 +3614,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_239
@@ -3642,6 +3643,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted secrets.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedSecretListResult
@@ -3654,10 +3659,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_88
@@ -3668,6 +3669,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up secret.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupSecretResult
@@ -3679,10 +3684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_425
       schema: *ref_89
@@ -3693,6 +3694,10 @@ schemas: !<!Schemas>
           name: secretBundleBackup
           description: The backup blob associated with a secret bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretRestoreParameters
@@ -3704,10 +3709,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_240
@@ -3727,10 +3728,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_90
@@ -3763,6 +3760,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the certificate was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedCertificateItem
@@ -3771,10 +3772,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_94
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_95
@@ -3808,6 +3805,10 @@ schemas: !<!Schemas>
                 name: X509Thumbprint
                 description: Thumbprint of the certificate.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: CertificateItem
@@ -3835,6 +3836,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateListResult
@@ -3855,10 +3860,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_99
@@ -3891,6 +3892,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the certificate was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedCertificateBundle
@@ -3899,10 +3904,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_101
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_102
@@ -3946,11 +3947,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_105
@@ -3967,11 +3963,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_106
@@ -4013,6 +4004,11 @@ schemas: !<!Schemas>
                   name: curve
                   description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: KeyProperties
@@ -4031,11 +4027,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_108
@@ -4045,6 +4036,11 @@ schemas: !<!Schemas>
                   name: contentType
                   description: The media type (MIME type).
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: SecretProperties
@@ -4063,11 +4059,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_109
@@ -4101,11 +4092,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_242
@@ -4161,6 +4147,11 @@ schemas: !<!Schemas>
                       name: upns
                       description: User principal names.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: SubjectAlternativeNames
@@ -4199,6 +4190,11 @@ schemas: !<!Schemas>
                   name: ValidityInMonths
                   description: The duration that the certificate is valid in months.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: X509CertificateProperties
@@ -4222,11 +4218,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - input
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_131
@@ -4234,11 +4225,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
-                  contexts:
-                  - input
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_116
@@ -4256,6 +4242,11 @@ schemas: !<!Schemas>
                         name: days_before_expiry
                         description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
+                  - input
                   language: !<!Languages> 
                     default:
                       name: Trigger
@@ -4274,11 +4265,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
-                  contexts:
-                  - input
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_118
@@ -4288,6 +4274,11 @@ schemas: !<!Schemas>
                         name: action_type
                         description: The type of the action.
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
+                  - input
                   language: !<!Languages> 
                     default:
                       name: Action
@@ -4300,6 +4291,11 @@ schemas: !<!Schemas>
                     name: action
                     description: The action that will be executed.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: LifetimeAction
@@ -4323,11 +4319,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_119
@@ -4353,6 +4344,11 @@ schemas: !<!Schemas>
                   name: CertificateTransparency
                   description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: IssuerParameters
@@ -4373,6 +4369,11 @@ schemas: !<!Schemas>
               name: attributes
               description: The certificate management attributes.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: CertificatePolicy
@@ -4418,6 +4419,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateBundle
@@ -4439,11 +4444,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_134
@@ -4465,11 +4465,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
-          contexts:
-          - input
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_135
@@ -4495,6 +4490,11 @@ schemas: !<!Schemas>
                 name: phone
                 description: Phone number.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: Contact
@@ -4512,6 +4512,11 @@ schemas: !<!Schemas>
           name: ContactList
           description: The contact list for the vault certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: Contacts
@@ -4524,10 +4529,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_248
@@ -4540,10 +4541,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_139
@@ -4561,6 +4558,10 @@ schemas: !<!Schemas>
                 name: provider
                 description: The issuer provider.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: CertificateIssuerItem
@@ -4588,6 +4589,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of certificate issuers.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateIssuerListResult
@@ -4600,10 +4605,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_447
       schema: *ref_143
@@ -4620,11 +4621,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_144
@@ -4642,6 +4638,11 @@ schemas: !<!Schemas>
               name: Password
               description: The password/secret/account key.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: IssuerCredentials
@@ -4661,11 +4662,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_146
@@ -4686,11 +4682,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - input
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_147
@@ -4724,6 +4715,11 @@ schemas: !<!Schemas>
                     name: phone
                     description: Phone number.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - input
+              - output
               language: !<!Languages> 
                 default:
                   name: AdministratorDetails
@@ -4741,6 +4737,11 @@ schemas: !<!Schemas>
               name: admin_details
               description: Details of the organization administrator.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: OrganizationDetails
@@ -4760,11 +4761,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_150
@@ -4792,6 +4788,11 @@ schemas: !<!Schemas>
               name: updated
               description: Last updated time in UTC.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: IssuerAttributes
@@ -4805,6 +4806,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateIssuerSetParameters
@@ -4820,10 +4825,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_155
@@ -4866,6 +4867,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: IssuerBundle
@@ -4877,10 +4882,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_460
       schema: *ref_157
@@ -4914,6 +4915,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateIssuerUpdateParameters
@@ -4925,10 +4930,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_476
       schema: *ref_125
@@ -4954,6 +4955,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateCreateParameters
@@ -4965,10 +4970,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_159
@@ -5043,6 +5044,10 @@ schemas: !<!Schemas>
           name: request_id
           description: Identifier for the certificate operation.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateOperation
@@ -5054,10 +5059,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_487
       schema: *ref_166
@@ -5104,6 +5105,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateImportParameters
@@ -5115,10 +5120,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_509
       schema: *ref_125
@@ -5144,6 +5145,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateUpdateParameters
@@ -5155,10 +5160,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_523
       schema: *ref_161
@@ -5169,6 +5170,10 @@ schemas: !<!Schemas>
           name: cancellation_requested
           description: Indicates if cancellation was requested on the certificate operation.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateOperationUpdateParameter
@@ -5180,10 +5185,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_533
       schema: !<!ArraySchema> &ref_250
@@ -5222,6 +5223,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateMergeParameters
@@ -5233,10 +5238,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_172
@@ -5247,6 +5248,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up certificate.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupCertificateResult
@@ -5258,10 +5263,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_546
       schema: *ref_173
@@ -5272,6 +5273,10 @@ schemas: !<!Schemas>
           name: certificateBundleBackup
           description: The backup blob associated with a certificate bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateRestoreParameters
@@ -5283,10 +5288,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_251
@@ -5316,6 +5317,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedCertificateListResult
@@ -5328,10 +5333,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_252
@@ -5351,10 +5352,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_175
@@ -5387,6 +5384,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the storage account was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedStorageAccountItem
@@ -5395,10 +5396,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_179
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_180
@@ -5424,11 +5421,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              - input
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5467,6 +5459,11 @@ schemas: !<!Schemas>
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: StorageAccountAttributes
@@ -5489,6 +5486,10 @@ schemas: !<!Schemas>
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: StorageAccountItem
@@ -5516,6 +5517,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of storage accounts.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageListResult
@@ -5529,10 +5534,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_253
@@ -5562,6 +5563,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted storage accounts.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedStorageListResult
@@ -5581,10 +5586,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_187
@@ -5617,6 +5618,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the storage account was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedStorageBundle
@@ -5625,10 +5630,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_189
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_190
@@ -5693,6 +5694,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageBundle
@@ -5705,10 +5710,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_196
@@ -5719,6 +5720,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up storage account.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupStorageResult
@@ -5730,10 +5735,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_577
       schema: *ref_197
@@ -5744,6 +5745,10 @@ schemas: !<!Schemas>
           name: storageBundleBackup
           description: The backup blob associated with a storage account.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageRestoreParameters
@@ -5755,10 +5760,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_586
       schema: *ref_198
@@ -5814,6 +5815,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountCreateParameters
@@ -5825,10 +5830,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_602
       schema: *ref_202
@@ -5870,6 +5871,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountUpdateParameters
@@ -5881,10 +5886,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_616
       schema: *ref_205
@@ -5895,6 +5896,10 @@ schemas: !<!Schemas>
           name: keyName
           description: The storage account key name.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountRegenerteKeyParameters
@@ -5906,10 +5911,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_254
@@ -5929,10 +5930,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_206
@@ -5965,6 +5962,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the SAS definition was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedSasDefinitionItem
@@ -5973,10 +5974,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_210
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -6002,11 +5999,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              - input
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -6045,6 +6037,11 @@ schemas: !<!Schemas>
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: SasDefinitionAttributes
@@ -6067,6 +6064,10 @@ schemas: !<!Schemas>
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SasDefinitionItem
@@ -6094,6 +6095,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of SAS definitions.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SasDefinitionListResult
@@ -6107,10 +6112,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_255
@@ -6140,6 +6141,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted SAS definitions.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedSasDefinitionListResult
@@ -6159,10 +6164,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_217
@@ -6195,6 +6196,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the SAS definition was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedSasDefinitionBundle
@@ -6203,10 +6208,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_219
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_220
@@ -6271,6 +6272,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SasDefinitionBundle
@@ -6283,10 +6288,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_642
       schema: *ref_226
@@ -6333,6 +6334,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SasDefinitionCreateParameters
@@ -6344,10 +6349,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_657
       schema: *ref_229
@@ -6389,6 +6390,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SasDefinitionUpdateParameters

--- a/modelerfour/test/scenarios/keyvault/grouped.yaml
+++ b/modelerfour/test/scenarios/keyvault/grouped.yaml
@@ -2163,6 +2163,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_261
       schema: *ref_2
@@ -2207,6 +2211,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_6
@@ -2222,6 +2231,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2250,6 +2264,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - output
+                - input
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2391,6 +2410,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_17
@@ -2431,6 +2454,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_21
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_38
@@ -2438,6 +2465,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_22
@@ -2626,6 +2658,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_41
@@ -2633,6 +2669,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_39
@@ -2686,6 +2726,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_278
       schema: *ref_42
@@ -2735,6 +2779,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_292
       schema: !<!ArraySchema> &ref_235
@@ -2781,6 +2829,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_236
@@ -2800,6 +2852,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_45
@@ -2840,6 +2896,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_47
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_48
@@ -2913,6 +2973,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_51
@@ -2934,6 +2998,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_316
       schema: *ref_52
@@ -2955,6 +3023,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_321
       schema: *ref_53
@@ -2985,6 +3057,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -3015,6 +3091,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_337
       schema: *ref_57
@@ -3045,6 +3125,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_346
       schema: *ref_57
@@ -3084,6 +3168,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -3105,6 +3193,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_237
@@ -3146,6 +3238,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_379
       schema: *ref_63
@@ -3202,6 +3298,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_66
@@ -3242,6 +3342,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_70
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_71
@@ -3313,6 +3417,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_393
       schema: *ref_77
@@ -3349,6 +3457,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_238
@@ -3368,6 +3480,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_79
@@ -3408,6 +3524,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_81
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_82
@@ -3489,6 +3609,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_239
@@ -3530,6 +3654,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_88
@@ -3551,6 +3679,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_425
       schema: *ref_89
@@ -3572,6 +3704,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_240
@@ -3591,6 +3727,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_90
@@ -3631,6 +3771,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_94
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_95
@@ -3711,6 +3855,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_99
@@ -3751,6 +3899,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_101
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_102
@@ -3794,6 +3946,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_105
@@ -3810,6 +3967,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_106
@@ -3869,6 +4031,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_108
@@ -3896,6 +4063,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_109
@@ -3929,6 +4101,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_242
@@ -4045,6 +4222,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - input
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_131
@@ -4052,6 +4234,11 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
+                  contexts:
+                  - input
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_116
@@ -4087,6 +4274,11 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
+                  contexts:
+                  - input
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_118
@@ -4131,6 +4323,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_119
@@ -4242,6 +4439,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_134
@@ -4263,6 +4465,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
+          contexts:
+          - input
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_135
@@ -4317,6 +4524,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_248
@@ -4329,6 +4540,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_139
@@ -4385,6 +4600,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_447
       schema: *ref_143
@@ -4401,6 +4620,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_144
@@ -4437,6 +4661,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_146
@@ -4457,6 +4686,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - input
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_147
@@ -4526,6 +4760,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_150
@@ -4581,6 +4820,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_155
@@ -4634,6 +4877,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_460
       schema: *ref_157
@@ -4678,6 +4925,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_476
       schema: *ref_125
@@ -4714,6 +4965,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_159
@@ -4799,6 +5054,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_487
       schema: *ref_166
@@ -4856,6 +5115,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_509
       schema: *ref_125
@@ -4892,6 +5155,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_523
       schema: *ref_161
@@ -4913,6 +5180,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_533
       schema: !<!ArraySchema> &ref_250
@@ -4962,6 +5233,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_172
@@ -4983,6 +5258,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_546
       schema: *ref_173
@@ -5004,6 +5283,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_251
@@ -5045,6 +5328,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_252
@@ -5064,6 +5351,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_175
@@ -5104,6 +5395,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_179
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_180
@@ -5129,6 +5424,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              - input
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5229,6 +5529,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_253
@@ -5277,6 +5581,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_187
@@ -5317,6 +5625,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_189
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_190
@@ -5393,6 +5705,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_196
@@ -5414,6 +5730,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_577
       schema: *ref_197
@@ -5435,6 +5755,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_586
       schema: *ref_198
@@ -5501,6 +5825,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_602
       schema: *ref_202
@@ -5553,6 +5881,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_616
       schema: *ref_205
@@ -5574,6 +5906,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_254
@@ -5593,6 +5929,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_206
@@ -5633,6 +5973,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_210
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -5658,6 +6002,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              - input
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5758,6 +6107,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_255
@@ -5806,6 +6159,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_217
@@ -5846,6 +6203,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_219
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_220
@@ -5922,6 +6283,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_642
       schema: *ref_226
@@ -5979,6 +6344,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_657
       schema: *ref_229

--- a/modelerfour/test/scenarios/keyvault/modeler.yaml
+++ b/modelerfour/test/scenarios/keyvault/modeler.yaml
@@ -2163,10 +2163,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -2211,11 +2207,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_3
@@ -2231,11 +2222,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_3
@@ -2253,6 +2239,11 @@ schemas: !<!Schemas>
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: SecretAttributes
@@ -2264,11 +2255,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - output
-                - input
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_3
@@ -2286,6 +2272,11 @@ schemas: !<!Schemas>
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
@@ -2339,6 +2330,11 @@ schemas: !<!Schemas>
                   name: updated
                   description: Last updated time in UTC.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: Attributes
@@ -2359,6 +2355,11 @@ schemas: !<!Schemas>
                 Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the
                 end of the retention interval.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: KeyAttributes
@@ -2390,6 +2391,10 @@ schemas: !<!Schemas>
           name: curve
           description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyCreateParameters
@@ -2410,10 +2415,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_12
@@ -2446,6 +2447,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the key was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedKeyBundle
@@ -2454,10 +2459,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_13
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_14
@@ -2465,11 +2466,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -2609,6 +2605,11 @@ schemas: !<!Schemas>
               name: 'y'
               description: Y component of an EC public key.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: JsonWebKey
@@ -2646,6 +2647,10 @@ schemas: !<!Schemas>
           name: managed
           description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyBundle
@@ -2658,10 +2663,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_17
@@ -2669,10 +2670,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_15
@@ -2701,6 +2698,10 @@ schemas: !<!Schemas>
               name: innerError
               description: The key vault server error.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Error
@@ -2714,6 +2715,10 @@ schemas: !<!Schemas>
           name: error
           description: The key vault server error.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyVaultError
@@ -2726,10 +2731,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_194
@@ -2767,6 +2768,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyImportParameters
@@ -2779,10 +2784,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_172
@@ -2818,6 +2819,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyUpdateParameters
@@ -2829,10 +2834,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_173
@@ -2852,10 +2853,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_24
@@ -2888,6 +2885,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the key was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedKeyItem
@@ -2896,10 +2897,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_25
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_19
@@ -2934,6 +2931,10 @@ schemas: !<!Schemas>
                 name: managed
                 description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: KeyItem
@@ -2961,6 +2962,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of keys.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyListResult
@@ -2973,10 +2978,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_239
@@ -2987,6 +2988,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up key.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupKeyResult
@@ -2998,10 +3003,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_240
@@ -3012,6 +3013,10 @@ schemas: !<!Schemas>
           name: keyBundleBackup
           description: The backup blob associated with a key bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyRestoreParameters
@@ -3023,10 +3028,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_165
@@ -3046,6 +3047,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyOperationsParameters
@@ -3057,10 +3062,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_27
@@ -3080,6 +3081,10 @@ schemas: !<!Schemas>
           name: result
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyOperationResult
@@ -3091,10 +3096,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_28
@@ -3114,6 +3115,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeySignParameters
@@ -3125,10 +3130,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_28
@@ -3157,6 +3158,10 @@ schemas: !<!Schemas>
           name: signature
           description: The signature to be verified.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyVerifyParameters
@@ -3168,10 +3173,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_195
@@ -3182,6 +3183,10 @@ schemas: !<!Schemas>
           name: value
           description: 'True if the signature is verified, otherwise false.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyVerifyResult
@@ -3193,10 +3198,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_174
@@ -3226,6 +3227,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted keys.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedKeyListResult
@@ -3238,10 +3243,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -3279,6 +3280,10 @@ schemas: !<!Schemas>
           name: secretAttributes
           description: The secret management attributes.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretSetParameters
@@ -3298,10 +3303,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_37
@@ -3334,6 +3335,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the secret was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedSecretBundle
@@ -3342,10 +3347,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_38
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -3405,6 +3406,10 @@ schemas: !<!Schemas>
           name: managed
           description: 'True if the secret''s lifetime is managed by key vault. If this is a secret backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SecretBundle
@@ -3417,10 +3422,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_39
@@ -3446,6 +3447,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretUpdateParameters
@@ -3457,10 +3462,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_175
@@ -3480,10 +3481,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_45
@@ -3516,6 +3513,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the secret was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedSecretItem
@@ -3524,10 +3525,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_46
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_40
@@ -3570,6 +3567,10 @@ schemas: !<!Schemas>
                 name: managed
                 description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SecretItem
@@ -3597,6 +3598,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of secrets.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SecretListResult
@@ -3609,10 +3614,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_176
@@ -3642,6 +3643,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted secrets.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedSecretListResult
@@ -3654,10 +3659,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_246
@@ -3668,6 +3669,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up secret.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupSecretResult
@@ -3679,10 +3684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_247
@@ -3693,6 +3694,10 @@ schemas: !<!Schemas>
           name: secretBundleBackup
           description: The backup blob associated with a secret bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretRestoreParameters
@@ -3704,10 +3709,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_177
@@ -3727,10 +3728,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_51
@@ -3763,6 +3760,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the certificate was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedCertificateItem
@@ -3771,10 +3772,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_52
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -3808,6 +3805,10 @@ schemas: !<!Schemas>
                 name: X509Thumbprint
                 description: Thumbprint of the certificate.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: CertificateItem
@@ -3835,6 +3836,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateListResult
@@ -3855,10 +3860,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_72
@@ -3891,6 +3892,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the certificate was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedCertificateBundle
@@ -3899,10 +3904,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_73
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -3946,11 +3947,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_58
@@ -3967,11 +3963,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_198
@@ -4013,6 +4004,11 @@ schemas: !<!Schemas>
                   name: curve
                   description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: KeyProperties
@@ -4031,11 +4027,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_60
@@ -4045,6 +4036,11 @@ schemas: !<!Schemas>
                   name: contentType
                   description: The media type (MIME type).
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: SecretProperties
@@ -4063,11 +4059,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_61
@@ -4101,11 +4092,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_179
@@ -4161,6 +4147,11 @@ schemas: !<!Schemas>
                       name: upns
                       description: User principal names.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: SubjectAlternativeNames
@@ -4199,6 +4190,11 @@ schemas: !<!Schemas>
                   name: ValidityInMonths
                   description: The duration that the certificate is valid in months.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: X509CertificateProperties
@@ -4222,11 +4218,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - input
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_80
@@ -4234,11 +4225,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
-                  contexts:
-                  - input
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_168
@@ -4256,6 +4242,11 @@ schemas: !<!Schemas>
                         name: days_before_expiry
                         description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
+                  - input
                   language: !<!Languages> 
                     default:
                       name: Trigger
@@ -4274,11 +4265,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
-                  contexts:
-                  - input
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_255
@@ -4288,6 +4274,11 @@ schemas: !<!Schemas>
                         name: action_type
                         description: The type of the action.
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
+                  - input
                   language: !<!Languages> 
                     default:
                       name: Action
@@ -4300,6 +4291,11 @@ schemas: !<!Schemas>
                     name: action
                     description: The action that will be executed.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: LifetimeAction
@@ -4323,11 +4319,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_66
@@ -4353,6 +4344,11 @@ schemas: !<!Schemas>
                   name: CertificateTransparency
                   description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: IssuerParameters
@@ -4373,6 +4369,11 @@ schemas: !<!Schemas>
               name: attributes
               description: The certificate management attributes.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: CertificatePolicy
@@ -4418,6 +4419,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateBundle
@@ -4439,11 +4444,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_83
@@ -4465,11 +4465,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
-          contexts:
-          - input
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_84
@@ -4495,6 +4490,11 @@ schemas: !<!Schemas>
                 name: phone
                 description: Phone number.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: Contact
@@ -4512,6 +4512,11 @@ schemas: !<!Schemas>
           name: ContactList
           description: The contact list for the vault certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: Contacts
@@ -4524,10 +4529,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_185
@@ -4540,10 +4541,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_88
@@ -4561,6 +4558,10 @@ schemas: !<!Schemas>
                 name: provider
                 description: The issuer provider.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: CertificateIssuerItem
@@ -4588,6 +4589,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of certificate issuers.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateIssuerListResult
@@ -4600,10 +4605,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_92
@@ -4620,11 +4621,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_93
@@ -4642,6 +4638,11 @@ schemas: !<!Schemas>
               name: Password
               description: The password/secret/account key.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: IssuerCredentials
@@ -4661,11 +4662,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_95
@@ -4686,11 +4682,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - input
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_96
@@ -4724,6 +4715,11 @@ schemas: !<!Schemas>
                     name: phone
                     description: Phone number.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - input
+              - output
               language: !<!Languages> 
                 default:
                   name: AdministratorDetails
@@ -4741,6 +4737,11 @@ schemas: !<!Schemas>
               name: admin_details
               description: Details of the organization administrator.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: OrganizationDetails
@@ -4760,11 +4761,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_201
@@ -4792,6 +4788,11 @@ schemas: !<!Schemas>
               name: updated
               description: Last updated time in UTC.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: IssuerAttributes
@@ -4805,6 +4806,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateIssuerSetParameters
@@ -4820,10 +4825,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_105
@@ -4866,6 +4867,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: IssuerBundle
@@ -4877,10 +4882,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_107
@@ -4914,6 +4915,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateIssuerUpdateParameters
@@ -4925,10 +4930,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_74
@@ -4954,6 +4955,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateCreateParameters
@@ -4965,10 +4970,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_108
@@ -5043,6 +5044,10 @@ schemas: !<!Schemas>
           name: request_id
           description: Identifier for the certificate operation.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateOperation
@@ -5054,10 +5059,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_113
@@ -5104,6 +5105,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateImportParameters
@@ -5115,10 +5120,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_74
@@ -5144,6 +5145,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateUpdateParameters
@@ -5155,10 +5160,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_115
@@ -5169,6 +5170,10 @@ schemas: !<!Schemas>
           name: cancellation_requested
           description: Indicates if cancellation was requested on the certificate operation.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateOperationUpdateParameter
@@ -5180,10 +5185,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_187
@@ -5222,6 +5223,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateMergeParameters
@@ -5233,10 +5238,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_251
@@ -5247,6 +5248,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up certificate.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupCertificateResult
@@ -5258,10 +5263,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_252
@@ -5272,6 +5273,10 @@ schemas: !<!Schemas>
           name: certificateBundleBackup
           description: The backup blob associated with a certificate bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateRestoreParameters
@@ -5283,10 +5288,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_188
@@ -5316,6 +5317,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedCertificateListResult
@@ -5328,10 +5333,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_189
@@ -5351,10 +5352,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_120
@@ -5387,6 +5384,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the storage account was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedStorageAccountItem
@@ -5395,10 +5396,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_121
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_117
@@ -5424,11 +5421,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              - input
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_143
@@ -5467,6 +5459,11 @@ schemas: !<!Schemas>
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: StorageAccountAttributes
@@ -5489,6 +5486,10 @@ schemas: !<!Schemas>
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: StorageAccountItem
@@ -5516,6 +5517,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of storage accounts.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageListResult
@@ -5529,10 +5534,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_190
@@ -5562,6 +5563,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted storage accounts.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedStorageListResult
@@ -5581,10 +5586,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_132
@@ -5617,6 +5618,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the storage account was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedStorageBundle
@@ -5625,10 +5630,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_133
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_125
@@ -5693,6 +5694,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageBundle
@@ -5705,10 +5710,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_253
@@ -5719,6 +5720,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up storage account.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupStorageResult
@@ -5730,10 +5735,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_254
@@ -5744,6 +5745,10 @@ schemas: !<!Schemas>
           name: storageBundleBackup
           description: The backup blob associated with a storage account.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageRestoreParameters
@@ -5755,10 +5760,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_134
@@ -5814,6 +5815,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountCreateParameters
@@ -5825,10 +5830,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_138
@@ -5870,6 +5871,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountUpdateParameters
@@ -5881,10 +5886,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_140
@@ -5895,6 +5896,10 @@ schemas: !<!Schemas>
           name: keyName
           description: The storage account key name.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountRegenerteKeyParameters
@@ -5906,10 +5911,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_191
@@ -5929,10 +5930,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_145
@@ -5965,6 +5962,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the SAS definition was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedSasDefinitionItem
@@ -5973,10 +5974,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_146
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_141
@@ -6002,11 +5999,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              - input
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_143
@@ -6045,6 +6037,11 @@ schemas: !<!Schemas>
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: SasDefinitionAttributes
@@ -6067,6 +6064,10 @@ schemas: !<!Schemas>
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SasDefinitionItem
@@ -6094,6 +6095,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of SAS definitions.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SasDefinitionListResult
@@ -6107,10 +6112,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_192
@@ -6140,6 +6141,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted SAS definitions.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedSasDefinitionListResult
@@ -6159,10 +6164,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_157
@@ -6195,6 +6196,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the SAS definition was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedSasDefinitionBundle
@@ -6203,10 +6208,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_158
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_150
@@ -6271,6 +6272,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SasDefinitionBundle
@@ -6283,10 +6288,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_159
@@ -6333,6 +6334,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SasDefinitionCreateParameters
@@ -6344,10 +6349,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_162
@@ -6389,6 +6390,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SasDefinitionUpdateParameters

--- a/modelerfour/test/scenarios/keyvault/modeler.yaml
+++ b/modelerfour/test/scenarios/keyvault/modeler.yaml
@@ -2163,6 +2163,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -2207,6 +2211,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_3
@@ -2222,6 +2231,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_3
@@ -2250,6 +2264,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - output
+                - input
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_3
@@ -2391,6 +2410,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_12
@@ -2431,6 +2454,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_13
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_14
@@ -2438,6 +2465,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -2626,6 +2658,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_17
@@ -2633,6 +2669,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_15
@@ -2686,6 +2726,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_194
@@ -2735,6 +2779,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_172
@@ -2781,6 +2829,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_173
@@ -2800,6 +2852,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_24
@@ -2840,6 +2896,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_25
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_19
@@ -2913,6 +2973,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_239
@@ -2934,6 +2998,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_240
@@ -2955,6 +3023,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_165
@@ -2985,6 +3057,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_27
@@ -3015,6 +3091,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_28
@@ -3045,6 +3125,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_28
@@ -3084,6 +3168,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_195
@@ -3105,6 +3193,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_174
@@ -3146,6 +3238,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -3202,6 +3298,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_37
@@ -3242,6 +3342,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_38
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -3313,6 +3417,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_39
@@ -3349,6 +3457,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_175
@@ -3368,6 +3480,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_45
@@ -3408,6 +3524,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_46
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_40
@@ -3489,6 +3609,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_176
@@ -3530,6 +3654,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_246
@@ -3551,6 +3679,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_247
@@ -3572,6 +3704,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_177
@@ -3591,6 +3727,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_51
@@ -3631,6 +3771,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_52
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -3711,6 +3855,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_72
@@ -3751,6 +3899,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_73
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_54
@@ -3794,6 +3946,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_58
@@ -3810,6 +3967,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_198
@@ -3869,6 +4031,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_60
@@ -3896,6 +4063,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_61
@@ -3929,6 +4101,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_179
@@ -4045,6 +4222,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - input
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_80
@@ -4052,6 +4234,11 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
+                  contexts:
+                  - input
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_168
@@ -4087,6 +4274,11 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
+                  contexts:
+                  - input
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_255
@@ -4131,6 +4323,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_66
@@ -4242,6 +4439,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_83
@@ -4263,6 +4465,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
+          contexts:
+          - input
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_84
@@ -4317,6 +4524,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_185
@@ -4329,6 +4540,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_88
@@ -4385,6 +4600,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_92
@@ -4401,6 +4620,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_93
@@ -4437,6 +4661,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_95
@@ -4457,6 +4686,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - input
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_96
@@ -4526,6 +4760,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_201
@@ -4581,6 +4820,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_105
@@ -4634,6 +4877,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_107
@@ -4678,6 +4925,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_74
@@ -4714,6 +4965,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_108
@@ -4799,6 +5054,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_113
@@ -4856,6 +5115,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_74
@@ -4892,6 +5155,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_115
@@ -4913,6 +5180,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_187
@@ -4962,6 +5233,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_251
@@ -4983,6 +5258,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_252
@@ -5004,6 +5283,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_188
@@ -5045,6 +5328,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_189
@@ -5064,6 +5351,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_120
@@ -5104,6 +5395,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_121
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_117
@@ -5129,6 +5424,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              - input
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_143
@@ -5229,6 +5529,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_190
@@ -5277,6 +5581,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_132
@@ -5317,6 +5625,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_133
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_125
@@ -5393,6 +5705,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_253
@@ -5414,6 +5730,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_254
@@ -5435,6 +5755,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_134
@@ -5501,6 +5825,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_138
@@ -5553,6 +5881,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_140
@@ -5574,6 +5906,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_191
@@ -5593,6 +5929,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_145
@@ -5633,6 +5973,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_146
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_141
@@ -5658,6 +6002,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              - input
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_143
@@ -5758,6 +6107,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_192
@@ -5806,6 +6159,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_157
@@ -5846,6 +6203,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_158
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_150
@@ -5922,6 +6283,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_159
@@ -5979,6 +6344,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_162

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -2163,6 +2163,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_261
       schema: *ref_2
@@ -2207,6 +2211,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_6
@@ -2222,6 +2231,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2250,6 +2264,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - output
+                - input
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2391,6 +2410,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_17
@@ -2431,6 +2454,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_21
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_38
@@ -2438,6 +2465,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_22
@@ -2626,6 +2658,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_41
@@ -2633,6 +2669,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_39
@@ -2686,6 +2726,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_278
       schema: *ref_42
@@ -2735,6 +2779,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_292
       schema: !<!ArraySchema> &ref_235
@@ -2781,6 +2829,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_236
@@ -2800,6 +2852,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_45
@@ -2840,6 +2896,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_47
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_48
@@ -2913,6 +2973,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_51
@@ -2934,6 +2998,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_316
       schema: *ref_52
@@ -2955,6 +3023,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_321
       schema: *ref_53
@@ -2985,6 +3057,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -3015,6 +3091,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_337
       schema: *ref_57
@@ -3045,6 +3125,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_346
       schema: *ref_57
@@ -3084,6 +3168,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -3105,6 +3193,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_237
@@ -3146,6 +3238,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_379
       schema: *ref_63
@@ -3202,6 +3298,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_66
@@ -3242,6 +3342,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_70
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_71
@@ -3313,6 +3417,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_393
       schema: *ref_77
@@ -3349,6 +3457,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_238
@@ -3368,6 +3480,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_79
@@ -3408,6 +3524,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_81
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_82
@@ -3489,6 +3609,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_239
@@ -3530,6 +3654,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_88
@@ -3551,6 +3679,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_425
       schema: *ref_89
@@ -3572,6 +3704,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_240
@@ -3591,6 +3727,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_90
@@ -3631,6 +3771,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_94
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_95
@@ -3711,6 +3855,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_99
@@ -3751,6 +3899,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_101
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_102
@@ -3794,6 +3946,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_105
@@ -3810,6 +3967,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_106
@@ -3869,6 +4031,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_108
@@ -3896,6 +4063,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_109
@@ -3929,6 +4101,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_242
@@ -4045,6 +4222,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - input
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_131
@@ -4052,6 +4234,11 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
+                  contexts:
+                  - input
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_116
@@ -4087,6 +4274,11 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
+                  contexts:
+                  - input
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_118
@@ -4131,6 +4323,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_119
@@ -4242,6 +4439,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_134
@@ -4263,6 +4465,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
+          contexts:
+          - input
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_135
@@ -4317,6 +4524,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_248
@@ -4329,6 +4540,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_139
@@ -4385,6 +4600,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_447
       schema: *ref_143
@@ -4401,6 +4620,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_144
@@ -4437,6 +4661,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_146
@@ -4457,6 +4686,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - input
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_147
@@ -4526,6 +4760,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_150
@@ -4581,6 +4820,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_155
@@ -4634,6 +4877,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_460
       schema: *ref_157
@@ -4678,6 +4925,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_476
       schema: *ref_125
@@ -4714,6 +4965,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_159
@@ -4799,6 +5054,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_487
       schema: *ref_166
@@ -4856,6 +5115,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_509
       schema: *ref_125
@@ -4892,6 +5155,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_523
       schema: *ref_161
@@ -4913,6 +5180,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_533
       schema: !<!ArraySchema> &ref_250
@@ -4962,6 +5233,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_172
@@ -4983,6 +5258,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_546
       schema: *ref_173
@@ -5004,6 +5283,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_251
@@ -5045,6 +5328,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_252
@@ -5064,6 +5351,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_175
@@ -5104,6 +5395,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_179
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_180
@@ -5129,6 +5424,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              - input
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5229,6 +5529,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_253
@@ -5277,6 +5581,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_187
@@ -5317,6 +5625,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_189
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_190
@@ -5393,6 +5705,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_196
@@ -5414,6 +5730,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_577
       schema: *ref_197
@@ -5435,6 +5755,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_586
       schema: *ref_198
@@ -5501,6 +5825,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_602
       schema: *ref_202
@@ -5553,6 +5881,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_616
       schema: *ref_205
@@ -5574,6 +5906,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_254
@@ -5593,6 +5929,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               parents: !<!Relations> 
                 all:
                 - *ref_206
@@ -5633,6 +5973,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_210
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -5658,6 +6002,11 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
+              contexts:
+              - output
+              - input
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5758,6 +6107,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_255
@@ -5806,6 +6159,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_217
@@ -5846,6 +6203,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_219
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_220
@@ -5922,6 +6283,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_642
       schema: *ref_226
@@ -5979,6 +6344,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_657
       schema: *ref_229

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -2163,10 +2163,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_261
       schema: *ref_2
@@ -2211,11 +2207,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_6
@@ -2231,11 +2222,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2253,6 +2239,11 @@ schemas: !<!Schemas>
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: SecretAttributes
@@ -2264,11 +2255,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - output
-                - input
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - *ref_6
@@ -2286,6 +2272,11 @@ schemas: !<!Schemas>
                         Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the
                         key, at the end of the retention interval.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
@@ -2339,6 +2330,11 @@ schemas: !<!Schemas>
                   name: updated
                   description: Last updated time in UTC.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: Attributes
@@ -2359,6 +2355,11 @@ schemas: !<!Schemas>
                 Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the
                 end of the retention interval.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: KeyAttributes
@@ -2390,6 +2391,10 @@ schemas: !<!Schemas>
           name: curve
           description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyCreateParameters
@@ -2410,10 +2415,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_17
@@ -2446,6 +2447,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the key was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedKeyBundle
@@ -2454,10 +2459,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_21
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_38
@@ -2465,11 +2466,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_22
@@ -2609,6 +2605,11 @@ schemas: !<!Schemas>
               name: 'y'
               description: Y component of an EC public key.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: JsonWebKey
@@ -2646,6 +2647,10 @@ schemas: !<!Schemas>
           name: managed
           description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyBundle
@@ -2658,10 +2663,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_41
@@ -2669,10 +2670,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_39
@@ -2701,6 +2698,10 @@ schemas: !<!Schemas>
               name: innerError
               description: The key vault server error.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Error
@@ -2714,6 +2715,10 @@ schemas: !<!Schemas>
           name: error
           description: The key vault server error.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyVaultError
@@ -2726,10 +2731,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_278
       schema: *ref_42
@@ -2767,6 +2768,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyImportParameters
@@ -2779,10 +2784,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_292
       schema: !<!ArraySchema> &ref_235
@@ -2818,6 +2819,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyUpdateParameters
@@ -2829,10 +2834,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_236
@@ -2852,10 +2853,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_45
@@ -2888,6 +2885,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the key was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedKeyItem
@@ -2896,10 +2897,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_47
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_48
@@ -2934,6 +2931,10 @@ schemas: !<!Schemas>
                 name: managed
                 description: 'True if the key''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: KeyItem
@@ -2961,6 +2962,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of keys.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyListResult
@@ -2973,10 +2978,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_51
@@ -2987,6 +2988,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up key.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupKeyResult
@@ -2998,10 +3003,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_316
       schema: *ref_52
@@ -3012,6 +3013,10 @@ schemas: !<!Schemas>
           name: keyBundleBackup
           description: The backup blob associated with a key bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyRestoreParameters
@@ -3023,10 +3028,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_321
       schema: *ref_53
@@ -3046,6 +3047,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyOperationsParameters
@@ -3057,10 +3062,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -3080,6 +3081,10 @@ schemas: !<!Schemas>
           name: result
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyOperationResult
@@ -3091,10 +3096,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_337
       schema: *ref_57
@@ -3114,6 +3115,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeySignParameters
@@ -3125,10 +3130,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_346
       schema: *ref_57
@@ -3157,6 +3158,10 @@ schemas: !<!Schemas>
           name: signature
           description: The signature to be verified.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: KeyVerifyParameters
@@ -3168,10 +3173,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_61
@@ -3182,6 +3183,10 @@ schemas: !<!Schemas>
           name: value
           description: 'True if the signature is verified, otherwise false.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyVerifyResult
@@ -3193,10 +3198,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_237
@@ -3226,6 +3227,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted keys.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedKeyListResult
@@ -3238,10 +3243,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_379
       schema: *ref_63
@@ -3279,6 +3280,10 @@ schemas: !<!Schemas>
           name: secretAttributes
           description: The secret management attributes.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretSetParameters
@@ -3298,10 +3303,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_66
@@ -3334,6 +3335,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the secret was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedSecretBundle
@@ -3342,10 +3347,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_70
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_71
@@ -3405,6 +3406,10 @@ schemas: !<!Schemas>
           name: managed
           description: 'True if the secret''s lifetime is managed by key vault. If this is a secret backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SecretBundle
@@ -3417,10 +3422,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_393
       schema: *ref_77
@@ -3446,6 +3447,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretUpdateParameters
@@ -3457,10 +3462,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_238
@@ -3480,10 +3481,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_79
@@ -3516,6 +3513,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the secret was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedSecretItem
@@ -3524,10 +3525,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_81
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_82
@@ -3570,6 +3567,10 @@ schemas: !<!Schemas>
                 name: managed
                 description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SecretItem
@@ -3597,6 +3598,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of secrets.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SecretListResult
@@ -3609,10 +3614,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_239
@@ -3642,6 +3643,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted secrets.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedSecretListResult
@@ -3654,10 +3659,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_88
@@ -3668,6 +3669,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up secret.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupSecretResult
@@ -3679,10 +3684,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_425
       schema: *ref_89
@@ -3693,6 +3694,10 @@ schemas: !<!Schemas>
           name: secretBundleBackup
           description: The backup blob associated with a secret bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SecretRestoreParameters
@@ -3704,10 +3709,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_240
@@ -3727,10 +3728,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_90
@@ -3763,6 +3760,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the certificate was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedCertificateItem
@@ -3771,10 +3772,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_94
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_95
@@ -3808,6 +3805,10 @@ schemas: !<!Schemas>
                 name: x509Thumbprint
                 description: Thumbprint of the certificate.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: CertificateItem
@@ -3835,6 +3836,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateListResult
@@ -3855,10 +3860,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_99
@@ -3891,6 +3892,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the certificate was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedCertificateBundle
@@ -3899,10 +3904,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_101
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_102
@@ -3946,11 +3947,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_105
@@ -3967,11 +3963,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_106
@@ -4013,6 +4004,11 @@ schemas: !<!Schemas>
                   name: curve
                   description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: KeyProperties
@@ -4031,11 +4027,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_108
@@ -4045,6 +4036,11 @@ schemas: !<!Schemas>
                   name: contentType
                   description: The media type (MIME type).
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: SecretProperties
@@ -4063,11 +4059,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_109
@@ -4101,11 +4092,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 7.0-preview
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ArraySchema> &ref_242
@@ -4161,6 +4147,11 @@ schemas: !<!Schemas>
                       name: upns
                       description: User principal names.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: SubjectAlternativeNames
@@ -4199,6 +4190,11 @@ schemas: !<!Schemas>
                   name: validityInMonths
                   description: The duration that the certificate is valid in months.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: X509CertificateProperties
@@ -4222,11 +4218,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - input
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: !<!ObjectSchema> &ref_131
@@ -4234,11 +4225,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
-                  contexts:
-                  - input
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_116
@@ -4256,6 +4242,11 @@ schemas: !<!Schemas>
                         name: daysBeforeExpiry
                         description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
+                  - input
                   language: !<!Languages> 
                     default:
                       name: Trigger
@@ -4274,11 +4265,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 7.0-preview
-                  contexts:
-                  - input
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_118
@@ -4288,6 +4274,11 @@ schemas: !<!Schemas>
                         name: actionType
                         description: The type of the action.
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
+                  - input
                   language: !<!Languages> 
                     default:
                       name: Action
@@ -4300,6 +4291,11 @@ schemas: !<!Schemas>
                     name: action
                     description: The action that will be executed.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: LifetimeAction
@@ -4323,11 +4319,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 7.0-preview
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_119
@@ -4353,6 +4344,11 @@ schemas: !<!Schemas>
                   name: certificateTransparency
                   description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: IssuerParameters
@@ -4373,6 +4369,11 @@ schemas: !<!Schemas>
               name: attributes
               description: The certificate management attributes.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: CertificatePolicy
@@ -4418,6 +4419,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateBundle
@@ -4439,11 +4444,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_134
@@ -4465,11 +4465,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
-          contexts:
-          - input
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_135
@@ -4495,6 +4490,11 @@ schemas: !<!Schemas>
                 name: phone
                 description: Phone number.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: Contact
@@ -4512,6 +4512,11 @@ schemas: !<!Schemas>
           name: contactList
           description: The contact list for the vault certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: Contacts
@@ -4524,10 +4529,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_248
@@ -4540,10 +4541,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 7.0-preview
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_139
@@ -4561,6 +4558,10 @@ schemas: !<!Schemas>
                 name: provider
                 description: The issuer provider.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: CertificateIssuerItem
@@ -4588,6 +4589,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of certificate issuers.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateIssuerListResult
@@ -4600,10 +4605,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_447
       schema: *ref_143
@@ -4620,11 +4621,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_144
@@ -4642,6 +4638,11 @@ schemas: !<!Schemas>
               name: password
               description: The password/secret/account key.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: IssuerCredentials
@@ -4661,11 +4662,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_146
@@ -4686,11 +4682,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - input
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_147
@@ -4724,6 +4715,11 @@ schemas: !<!Schemas>
                     name: phone
                     description: Phone number.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - input
+              - output
               language: !<!Languages> 
                 default:
                   name: AdministratorDetails
@@ -4741,6 +4737,11 @@ schemas: !<!Schemas>
               name: adminDetails
               description: Details of the organization administrator.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: OrganizationDetails
@@ -4760,11 +4761,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_150
@@ -4792,6 +4788,11 @@ schemas: !<!Schemas>
               name: updated
               description: Last updated time in UTC.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: IssuerAttributes
@@ -4805,6 +4806,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateIssuerSetParameters
@@ -4820,10 +4825,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_155
@@ -4866,6 +4867,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: IssuerBundle
@@ -4877,10 +4882,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_460
       schema: *ref_157
@@ -4914,6 +4915,10 @@ schemas: !<!Schemas>
           name: attributes
           description: The attributes of an issuer managed by the Key Vault service.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateIssuerUpdateParameters
@@ -4925,10 +4930,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_476
       schema: *ref_125
@@ -4954,6 +4955,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateCreateParameters
@@ -4965,10 +4970,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_159
@@ -5043,6 +5044,10 @@ schemas: !<!Schemas>
           name: requestId
           description: Identifier for the certificate operation.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CertificateOperation
@@ -5054,10 +5059,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_487
       schema: *ref_166
@@ -5104,6 +5105,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateImportParameters
@@ -5115,10 +5120,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_509
       schema: *ref_125
@@ -5144,6 +5145,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateUpdateParameters
@@ -5155,10 +5160,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_523
       schema: *ref_161
@@ -5169,6 +5170,10 @@ schemas: !<!Schemas>
           name: cancellationRequested
           description: Indicates if cancellation was requested on the certificate operation.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateOperationUpdateParameter
@@ -5180,10 +5185,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_533
       schema: !<!ArraySchema> &ref_250
@@ -5222,6 +5223,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateMergeParameters
@@ -5233,10 +5238,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_172
@@ -5247,6 +5248,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up certificate.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupCertificateResult
@@ -5258,10 +5263,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_546
       schema: *ref_173
@@ -5272,6 +5273,10 @@ schemas: !<!Schemas>
           name: certificateBundleBackup
           description: The backup blob associated with a certificate bundle.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CertificateRestoreParameters
@@ -5283,10 +5288,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_251
@@ -5316,6 +5317,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted certificates.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedCertificateListResult
@@ -5328,10 +5333,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_252
@@ -5351,10 +5352,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_175
@@ -5387,6 +5384,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the storage account was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedStorageAccountItem
@@ -5395,10 +5396,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_179
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_180
@@ -5424,11 +5421,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              - input
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -5467,6 +5459,11 @@ schemas: !<!Schemas>
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: StorageAccountAttributes
@@ -5489,6 +5486,10 @@ schemas: !<!Schemas>
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: StorageAccountItem
@@ -5516,6 +5517,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of storage accounts.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageListResult
@@ -5529,10 +5534,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_253
@@ -5562,6 +5563,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted storage accounts.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedStorageListResult
@@ -5581,10 +5586,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_187
@@ -5617,6 +5618,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the storage account was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedStorageBundle
@@ -5625,10 +5630,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_189
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_190
@@ -5693,6 +5694,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageBundle
@@ -5705,10 +5710,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_196
@@ -5719,6 +5720,10 @@ schemas: !<!Schemas>
           name: value
           description: The backup blob containing the backed up storage account.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BackupStorageResult
@@ -5730,10 +5735,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_577
       schema: *ref_197
@@ -5744,6 +5745,10 @@ schemas: !<!Schemas>
           name: storageBundleBackup
           description: The backup blob associated with a storage account.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageRestoreParameters
@@ -5755,10 +5760,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_586
       schema: *ref_198
@@ -5814,6 +5815,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountCreateParameters
@@ -5825,10 +5830,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_602
       schema: *ref_202
@@ -5870,6 +5871,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountUpdateParameters
@@ -5881,10 +5886,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_616
       schema: *ref_205
@@ -5895,6 +5896,10 @@ schemas: !<!Schemas>
           name: keyName
           description: The storage account key name.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountRegenerteKeyParameters
@@ -5906,10 +5911,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_254
@@ -5929,10 +5930,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               parents: !<!Relations> 
                 all:
                 - *ref_206
@@ -5965,6 +5962,10 @@ schemas: !<!Schemas>
                     name: deletedDate
                     description: 'The time when the SAS definition was deleted, in UTC'
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DeletedSasDefinitionItem
@@ -5973,10 +5974,6 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> {}
             immediate:
             - *ref_210
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_211
@@ -6002,11 +5999,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-              contexts:
-              - output
-              - input
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_182
@@ -6045,6 +6037,11 @@ schemas: !<!Schemas>
                       Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key,
                       at the end of the retention interval.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
+              - input
               language: !<!Languages> 
                 default:
                   name: SasDefinitionAttributes
@@ -6067,6 +6064,10 @@ schemas: !<!Schemas>
                 name: tags
                 description: Application specific metadata in the form of key-value pairs.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: SasDefinitionItem
@@ -6094,6 +6095,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of SAS definitions.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SasDefinitionListResult
@@ -6107,10 +6112,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_255
@@ -6140,6 +6141,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: The URL to get the next set of deleted SAS definitions.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: DeletedSasDefinitionListResult
@@ -6159,10 +6164,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_217
@@ -6195,6 +6196,10 @@ schemas: !<!Schemas>
               name: deletedDate
               description: 'The time when the SAS definition was deleted, in UTC'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: DeletedSasDefinitionBundle
@@ -6203,10 +6208,6 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       immediate:
       - *ref_219
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_220
@@ -6271,6 +6272,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SasDefinitionBundle
@@ -6283,10 +6288,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_642
       schema: *ref_226
@@ -6333,6 +6334,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SasDefinitionCreateParameters
@@ -6344,10 +6349,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 7.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_657
       schema: *ref_229
@@ -6389,6 +6390,10 @@ schemas: !<!Schemas>
           name: tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SasDefinitionUpdateParameters

--- a/modelerfour/test/scenarios/lro/flattened.yaml
+++ b/modelerfour/test/scenarios/lro/flattened.yaml
@@ -418,6 +418,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_2
@@ -513,6 +518,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -545,6 +555,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -575,6 +589,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_42
       schema: *ref_13
@@ -610,6 +629,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_15
@@ -671,6 +695,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_16

--- a/modelerfour/test/scenarios/lro/flattened.yaml
+++ b/modelerfour/test/scenarios/lro/flattened.yaml
@@ -418,11 +418,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_2
@@ -452,6 +447,11 @@ schemas: !<!Schemas>
               name: provisioningStateValues
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Product
@@ -504,6 +504,11 @@ schemas: !<!Schemas>
           name: name
           description: Resource Name
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -518,11 +523,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -541,6 +541,11 @@ schemas: !<!Schemas>
           name: provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
@@ -555,10 +560,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -576,6 +577,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-external: true
     language: !<!Languages> 
@@ -589,11 +594,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_42
       schema: *ref_13
@@ -611,6 +611,11 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: Sku
@@ -629,11 +634,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_15
@@ -663,6 +663,11 @@ schemas: !<!Schemas>
               name: provisioningStateValues
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: SubProduct
@@ -681,6 +686,11 @@ schemas: !<!Schemas>
           name: id
           description: Sub Resource Id
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -695,11 +705,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -718,6 +723,11 @@ schemas: !<!Schemas>
           name: provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true

--- a/modelerfour/test/scenarios/lro/grouped.yaml
+++ b/modelerfour/test/scenarios/lro/grouped.yaml
@@ -418,6 +418,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_2
@@ -513,6 +518,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -545,6 +555,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -575,6 +589,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_42
       schema: *ref_13
@@ -610,6 +629,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_15
@@ -671,6 +695,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_16

--- a/modelerfour/test/scenarios/lro/grouped.yaml
+++ b/modelerfour/test/scenarios/lro/grouped.yaml
@@ -418,11 +418,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_2
@@ -452,6 +447,11 @@ schemas: !<!Schemas>
               name: provisioningStateValues
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Product
@@ -504,6 +504,11 @@ schemas: !<!Schemas>
           name: name
           description: Resource Name
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -518,11 +523,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -541,6 +541,11 @@ schemas: !<!Schemas>
           name: provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
@@ -555,10 +560,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -576,6 +577,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-external: true
     language: !<!Languages> 
@@ -589,11 +594,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_42
       schema: *ref_13
@@ -611,6 +611,11 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: Sku
@@ -629,11 +634,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_15
@@ -663,6 +663,11 @@ schemas: !<!Schemas>
               name: provisioningStateValues
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: SubProduct
@@ -681,6 +686,11 @@ schemas: !<!Schemas>
           name: id
           description: Sub Resource Id
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -695,11 +705,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -718,6 +723,11 @@ schemas: !<!Schemas>
           name: provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true

--- a/modelerfour/test/scenarios/lro/modeler.yaml
+++ b/modelerfour/test/scenarios/lro/modeler.yaml
@@ -418,11 +418,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -435,11 +430,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_5
@@ -458,6 +448,11 @@ schemas: !<!Schemas>
                   name: provisioningStateValues
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             extensions:
               x-ms-client-flatten: true
             language: !<!Languages> 
@@ -474,6 +469,11 @@ schemas: !<!Schemas>
               name: properties
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Product
@@ -526,6 +526,11 @@ schemas: !<!Schemas>
           name: name
           description: Resource Name
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -541,10 +546,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_24
@@ -562,6 +563,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-external: true
     language: !<!Languages> 
@@ -575,11 +580,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -597,6 +597,11 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: Sku
@@ -615,11 +620,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_15
@@ -632,11 +632,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_14
@@ -655,6 +650,11 @@ schemas: !<!Schemas>
                   name: provisioningStateValues
                   description: ''
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             extensions:
               x-ms-client-flatten: true
             language: !<!Languages> 
@@ -671,6 +671,11 @@ schemas: !<!Schemas>
               name: properties
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: SubProduct
@@ -689,6 +694,11 @@ schemas: !<!Schemas>
           name: id
           description: Sub Resource Id
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 

--- a/modelerfour/test/scenarios/lro/modeler.yaml
+++ b/modelerfour/test/scenarios/lro/modeler.yaml
@@ -418,6 +418,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -430,6 +435,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_5
@@ -531,6 +541,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_24
@@ -561,6 +575,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -596,6 +615,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_15
@@ -608,6 +632,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_14

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -418,6 +418,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_2
@@ -513,6 +518,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -545,6 +555,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -575,6 +589,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_42
       schema: *ref_13
@@ -610,6 +629,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_15
@@ -671,6 +695,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_16

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -418,11 +418,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_2
@@ -452,6 +447,11 @@ schemas: !<!Schemas>
               name: provisioningStateValues
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: Product
@@ -504,6 +504,11 @@ schemas: !<!Schemas>
           name: name
           description: Resource Name
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -518,11 +523,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -541,6 +541,11 @@ schemas: !<!Schemas>
           name: provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
@@ -555,10 +560,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_11
@@ -576,6 +577,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     extensions:
       x-ms-external: true
     language: !<!Languages> 
@@ -589,11 +594,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_42
       schema: *ref_13
@@ -611,6 +611,11 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: Sku
@@ -629,11 +634,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_15
@@ -663,6 +663,11 @@ schemas: !<!Schemas>
               name: provisioningStateValues
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: SubProduct
@@ -681,6 +686,11 @@ schemas: !<!Schemas>
           name: id
           description: Sub Resource Id
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -695,11 +705,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -718,6 +723,11 @@ schemas: !<!Schemas>
           name: provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true

--- a/modelerfour/test/scenarios/media_types/flattened.yaml
+++ b/modelerfour/test/scenarios/media_types/flattened.yaml
@@ -82,10 +82,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_9
       schema: *ref_0
@@ -95,6 +91,10 @@ schemas: !<!Schemas>
           name: source
           description: File source path.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SourcePath

--- a/modelerfour/test/scenarios/media_types/flattened.yaml
+++ b/modelerfour/test/scenarios/media_types/flattened.yaml
@@ -82,6 +82,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_9
       schema: *ref_0

--- a/modelerfour/test/scenarios/media_types/grouped.yaml
+++ b/modelerfour/test/scenarios/media_types/grouped.yaml
@@ -82,10 +82,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_9
       schema: *ref_0
@@ -95,6 +91,10 @@ schemas: !<!Schemas>
           name: source
           description: File source path.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SourcePath

--- a/modelerfour/test/scenarios/media_types/grouped.yaml
+++ b/modelerfour/test/scenarios/media_types/grouped.yaml
@@ -82,6 +82,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_9
       schema: *ref_0

--- a/modelerfour/test/scenarios/media_types/modeler.yaml
+++ b/modelerfour/test/scenarios/media_types/modeler.yaml
@@ -82,10 +82,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -95,6 +91,10 @@ schemas: !<!Schemas>
           name: source
           description: File source path.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SourcePath

--- a/modelerfour/test/scenarios/media_types/modeler.yaml
+++ b/modelerfour/test/scenarios/media_types/modeler.yaml
@@ -82,6 +82,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/media_types/namer.yaml
+++ b/modelerfour/test/scenarios/media_types/namer.yaml
@@ -82,10 +82,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2.0-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_9
       schema: *ref_0
@@ -95,6 +91,10 @@ schemas: !<!Schemas>
           name: source
           description: File source path.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: SourcePath

--- a/modelerfour/test/scenarios/media_types/namer.yaml
+++ b/modelerfour/test/scenarios/media_types/namer.yaml
@@ -82,6 +82,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2.0-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_9
       schema: *ref_0

--- a/modelerfour/test/scenarios/model-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/model-flattening/flattened.yaml
@@ -279,11 +279,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_8
@@ -296,10 +291,6 @@ schemas: !<!Schemas>
             - *ref_2
             immediate:
             - *ref_2
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_3
@@ -344,6 +335,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: Resource
@@ -398,6 +394,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -424,10 +425,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_13
@@ -453,6 +450,10 @@ schemas: !<!Schemas>
           name: parentError
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -465,11 +466,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -504,6 +500,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
@@ -518,11 +519,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -532,6 +528,11 @@ schemas: !<!Schemas>
           name: value
           description: the product value
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -545,10 +546,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -561,6 +558,10 @@ schemas: !<!Schemas>
           name: value
           description: the product value
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductWrapper
@@ -572,11 +573,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -612,6 +608,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection
@@ -630,11 +631,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_18
@@ -687,6 +683,11 @@ schemas: !<!Schemas>
               name: '@odata.value'
               description: URL value.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: SimpleProduct
@@ -714,6 +715,11 @@ schemas: !<!Schemas>
           name: description
           description: Description of product.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: BaseProduct
@@ -726,11 +732,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -774,6 +775,11 @@ schemas: !<!Schemas>
           name: '@odata.value'
           description: URL value.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -794,11 +800,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_26
@@ -813,6 +814,11 @@ schemas: !<!Schemas>
               name: '@odata.value'
               description: URL value.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         extensions:
           x-ms-flattened: true
         language: !<!Languages> 
@@ -832,6 +838,11 @@ schemas: !<!Schemas>
           name: generic_value
           description: Generic URL value.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: GenericUrl

--- a/modelerfour/test/scenarios/model-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/model-flattening/flattened.yaml
@@ -279,6 +279,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_8
@@ -291,6 +296,10 @@ schemas: !<!Schemas>
             - *ref_2
             immediate:
             - *ref_2
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_3
@@ -415,6 +424,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_13
@@ -452,6 +465,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -500,6 +518,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -522,6 +545,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -545,6 +572,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -598,6 +630,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_18
@@ -689,6 +726,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -752,6 +794,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_26

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -279,6 +279,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_8
@@ -291,6 +296,10 @@ schemas: !<!Schemas>
             - *ref_2
             immediate:
             - *ref_2
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_3
@@ -449,6 +458,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_18
@@ -692,6 +706,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_13
@@ -729,6 +747,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -777,6 +800,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -799,6 +827,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -822,6 +854,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -870,6 +907,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -933,6 +975,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_26

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -279,11 +279,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_8
@@ -296,10 +291,6 @@ schemas: !<!Schemas>
             - *ref_2
             immediate:
             - *ref_2
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_3
@@ -344,6 +335,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: Resource
@@ -398,6 +394,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -458,11 +459,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_18
@@ -494,6 +490,11 @@ schemas: !<!Schemas>
                   name: description
                   description: Description of product.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: BaseProduct
@@ -549,6 +550,11 @@ schemas: !<!Schemas>
               name: '@odata.value'
               description: URL value.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: SimpleProduct
@@ -706,10 +712,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_13
@@ -735,6 +737,10 @@ schemas: !<!Schemas>
           name: parentError
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -747,11 +753,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -786,6 +787,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
@@ -800,11 +806,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -814,6 +815,11 @@ schemas: !<!Schemas>
           name: value
           description: the product value
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -827,10 +833,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -843,6 +845,10 @@ schemas: !<!Schemas>
           name: value
           description: the product value
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductWrapper
@@ -854,11 +860,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -894,6 +895,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection
@@ -907,11 +913,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -955,6 +956,11 @@ schemas: !<!Schemas>
           name: '@odata.value'
           description: URL value.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -975,11 +981,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_26
@@ -994,6 +995,11 @@ schemas: !<!Schemas>
               name: '@odata.value'
               description: URL value.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         extensions:
           x-ms-flattened: true
         language: !<!Languages> 
@@ -1013,6 +1019,11 @@ schemas: !<!Schemas>
           name: generic_value
           description: Generic URL value.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: GenericUrl

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -700,6 +700,8 @@ schemas: !<!Schemas>
           name: '@odata.value'
           description: URL value.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: flatten-parameter-group

--- a/modelerfour/test/scenarios/model-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/model-flattening/modeler.yaml
@@ -279,6 +279,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_9
@@ -291,6 +296,10 @@ schemas: !<!Schemas>
             - *ref_10
             immediate:
             - *ref_10
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_0
@@ -350,6 +359,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_5
@@ -426,6 +440,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -464,6 +482,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -484,6 +507,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -506,6 +533,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_10
@@ -559,6 +591,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_23
@@ -571,6 +608,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
+            contexts:
+            - input
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_18
@@ -596,6 +638,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
+                contexts:
+                - input
+                - output
+                knownMediaTypes:
+                - json
                 parents: !<!Relations> 
                   all:
                   - !<!ObjectSchema> &ref_22

--- a/modelerfour/test/scenarios/model-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/model-flattening/modeler.yaml
@@ -279,11 +279,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_9
@@ -296,10 +291,6 @@ schemas: !<!Schemas>
             - *ref_10
             immediate:
             - *ref_10
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_0
@@ -344,6 +335,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: Resource
@@ -359,11 +355,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_5
@@ -398,6 +389,11 @@ schemas: !<!Schemas>
                 name: provisioningState
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
+          - input
           extensions:
             x-ms-client-flatten: true
           language: !<!Languages> 
@@ -414,6 +410,11 @@ schemas: !<!Schemas>
             name: properties
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -440,10 +441,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_30
@@ -469,6 +466,10 @@ schemas: !<!Schemas>
           name: parentError
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -482,11 +483,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -496,6 +492,11 @@ schemas: !<!Schemas>
           name: value
           description: the product value
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: WrappedProduct
@@ -507,10 +508,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -522,6 +519,10 @@ schemas: !<!Schemas>
           name: property
           description: The wrapped produc.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductWrapper
@@ -533,11 +534,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_10
@@ -573,6 +569,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection
@@ -591,11 +592,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_23
@@ -608,11 +604,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            contexts:
-            - input
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_18
@@ -638,11 +629,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
-                contexts:
-                - input
-                - output
-                knownMediaTypes:
-                - json
                 parents: !<!Relations> 
                   all:
                   - !<!ObjectSchema> &ref_22
@@ -664,6 +650,11 @@ schemas: !<!Schemas>
                           name: generic_value
                           description: Generic URL value.
                       protocol: !<!Protocols> {}
+                    serializationFormats:
+                    - json
+                    usage:
+                    - input
+                    - output
                     language: !<!Languages> 
                       default:
                         name: GenericUrl
@@ -681,6 +672,11 @@ schemas: !<!Schemas>
                       name: '@odata.value'
                       description: URL value.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: ProductUrl
@@ -696,6 +692,11 @@ schemas: !<!Schemas>
                   name: max_product_image
                   description: The product URL.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: SimpleProductProperties
@@ -710,6 +711,11 @@ schemas: !<!Schemas>
               name: details
               description: The product documentation.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: SimpleProduct
@@ -737,6 +743,11 @@ schemas: !<!Schemas>
           name: description
           description: Description of product.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: BaseProduct

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -700,6 +700,8 @@ schemas: !<!Schemas>
           name: odataValue
           description: URL value.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: FlattenParameterGroup

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -279,6 +279,11 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
+      contexts:
+      - output
+      - input
+      knownMediaTypes:
+      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_8
@@ -291,6 +296,10 @@ schemas: !<!Schemas>
             - *ref_2
             immediate:
             - *ref_2
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_3
@@ -449,6 +458,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_17
@@ -692,6 +706,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -729,6 +747,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -777,6 +800,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_35
@@ -799,6 +827,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_35
@@ -822,6 +854,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -870,6 +907,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_18
@@ -933,6 +975,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - input
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_37

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -279,11 +279,6 @@ schemas: !<!Schemas>
       apiVersions:
       - !<!ApiVersion> 
         version: 1.0.0
-      contexts:
-      - output
-      - input
-      knownMediaTypes:
-      - json
       parents: !<!Relations> 
         all:
         - !<!ObjectSchema> &ref_8
@@ -296,10 +291,6 @@ schemas: !<!Schemas>
             - *ref_2
             immediate:
             - *ref_2
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_3
@@ -344,6 +335,11 @@ schemas: !<!Schemas>
                 name: name
                 description: Resource Name
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
+          - output
           language: !<!Languages> 
             default:
               name: Resource
@@ -398,6 +394,11 @@ schemas: !<!Schemas>
             name: provisioningState
             description: ''
         protocol: !<!Protocols> {}
+      serializationFormats:
+      - json
+      usage:
+      - output
+      - input
       language: !<!Languages> 
         default:
           name: FlattenedProduct
@@ -458,11 +459,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - !<!ObjectSchema> &ref_17
@@ -494,6 +490,11 @@ schemas: !<!Schemas>
                   name: description
                   description: Description of product.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: BaseProduct
@@ -549,6 +550,11 @@ schemas: !<!Schemas>
               name: odataValue
               description: URL value.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: SimpleProduct
@@ -706,10 +712,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -735,6 +737,10 @@ schemas: !<!Schemas>
           name: parentError
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -747,11 +753,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -786,6 +787,11 @@ schemas: !<!Schemas>
           name: provisioningState
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-client-flatten: true
       x-ms-flattened: true
@@ -800,11 +806,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_35
@@ -814,6 +815,11 @@ schemas: !<!Schemas>
           name: value
           description: the product value
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -827,10 +833,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_35
@@ -843,6 +845,10 @@ schemas: !<!Schemas>
           name: value
           description: the product value
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductWrapper
@@ -854,11 +860,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -894,6 +895,11 @@ schemas: !<!Schemas>
           name: dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: ResourceCollection
@@ -907,11 +913,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_18
@@ -955,6 +956,11 @@ schemas: !<!Schemas>
           name: odataValue
           description: URL value.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -975,11 +981,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - input
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_37
@@ -994,6 +995,11 @@ schemas: !<!Schemas>
               name: odataValue
               description: URL value.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         extensions:
           x-ms-flattened: true
         language: !<!Languages> 
@@ -1013,6 +1019,11 @@ schemas: !<!Schemas>
           name: genericValue
           description: Generic URL value.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     language: !<!Languages> 
       default:
         name: GenericUrl

--- a/modelerfour/test/scenarios/paging/flattened.yaml
+++ b/modelerfour/test/scenarios/paging/flattened.yaml
@@ -178,6 +178,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_9
@@ -190,6 +194,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_5
@@ -197,6 +205,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_1
@@ -264,6 +276,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10
@@ -302,6 +318,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_11

--- a/modelerfour/test/scenarios/paging/flattened.yaml
+++ b/modelerfour/test/scenarios/paging/flattened.yaml
@@ -178,10 +178,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_9
@@ -194,10 +190,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_5
@@ -205,10 +197,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_1
@@ -226,6 +214,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Product-properties
@@ -238,6 +230,10 @@ schemas: !<!Schemas>
                 name: properties
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Product
@@ -263,6 +259,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResultValue
@@ -276,10 +276,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10
@@ -307,6 +303,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResult
@@ -318,10 +318,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_11
@@ -349,6 +345,10 @@ schemas: !<!Schemas>
           name: odata.nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: OdataProductResult

--- a/modelerfour/test/scenarios/paging/grouped.yaml
+++ b/modelerfour/test/scenarios/paging/grouped.yaml
@@ -225,6 +225,8 @@ schemas: !<!Schemas>
           name: timeout
           description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: PagingGetMultiplePagesOptions
@@ -282,6 +284,8 @@ schemas: !<!Schemas>
           name: timeout
           description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: PagingGetOdataMultiplePagesOptions
@@ -363,6 +367,8 @@ schemas: !<!Schemas>
           name: timeout
           description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: PagingGetMultiplePagesWithOffsetOptions
@@ -459,6 +465,8 @@ schemas: !<!Schemas>
           name: tenant
           description: Sets the tenant to use.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: custom-parameter-group
@@ -516,6 +524,8 @@ schemas: !<!Schemas>
           name: timeout
           description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: PagingGetMultiplePagesLroOptions

--- a/modelerfour/test/scenarios/paging/grouped.yaml
+++ b/modelerfour/test/scenarios/paging/grouped.yaml
@@ -527,10 +527,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_9
@@ -543,10 +539,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_5
@@ -554,10 +546,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_1
@@ -575,6 +563,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Product-properties
@@ -587,6 +579,10 @@ schemas: !<!Schemas>
                 name: properties
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Product
@@ -612,6 +608,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResultValue
@@ -625,10 +625,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10
@@ -656,6 +652,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResult
@@ -667,10 +667,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_11
@@ -698,6 +694,10 @@ schemas: !<!Schemas>
           name: odata.nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: OdataProductResult

--- a/modelerfour/test/scenarios/paging/grouped.yaml
+++ b/modelerfour/test/scenarios/paging/grouped.yaml
@@ -527,6 +527,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_9
@@ -539,6 +543,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_5
@@ -546,6 +554,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_1
@@ -613,6 +625,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10
@@ -651,6 +667,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_11

--- a/modelerfour/test/scenarios/paging/modeler.yaml
+++ b/modelerfour/test/scenarios/paging/modeler.yaml
@@ -178,10 +178,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_8
@@ -194,10 +190,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_3
@@ -205,10 +197,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_7
@@ -226,6 +214,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Product-properties
@@ -238,6 +230,10 @@ schemas: !<!Schemas>
                 name: properties
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Product
@@ -263,6 +259,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResultValue
@@ -276,10 +276,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_9
@@ -307,6 +303,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResult
@@ -318,10 +318,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10
@@ -349,6 +345,10 @@ schemas: !<!Schemas>
           name: odata.nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: OdataProductResult

--- a/modelerfour/test/scenarios/paging/modeler.yaml
+++ b/modelerfour/test/scenarios/paging/modeler.yaml
@@ -178,6 +178,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_8
@@ -190,6 +194,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_3
@@ -197,6 +205,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_7
@@ -264,6 +276,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_9
@@ -302,6 +318,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10

--- a/modelerfour/test/scenarios/paging/namer.yaml
+++ b/modelerfour/test/scenarios/paging/namer.yaml
@@ -527,10 +527,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_23
@@ -543,10 +539,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_19
@@ -554,10 +546,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_15
@@ -575,6 +563,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ProductProperties
@@ -587,6 +579,10 @@ schemas: !<!Schemas>
                 name: properties
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Product
@@ -612,6 +608,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResultValue
@@ -625,10 +625,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_24
@@ -656,6 +652,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ProductResult
@@ -667,10 +667,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_25
@@ -698,6 +694,10 @@ schemas: !<!Schemas>
           name: odataNextLink
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: OdataProductResult

--- a/modelerfour/test/scenarios/paging/namer.yaml
+++ b/modelerfour/test/scenarios/paging/namer.yaml
@@ -225,6 +225,8 @@ schemas: !<!Schemas>
           name: timeout
           description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: PagingGetMultiplePagesOptions
@@ -282,6 +284,8 @@ schemas: !<!Schemas>
           name: timeout
           description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: PagingGetOdataMultiplePagesOptions
@@ -363,6 +367,8 @@ schemas: !<!Schemas>
           name: timeout
           description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: PagingGetMultiplePagesWithOffsetOptions
@@ -459,6 +465,8 @@ schemas: !<!Schemas>
           name: tenant
           description: Sets the tenant to use.
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: CustomParameterGroup
@@ -516,6 +524,8 @@ schemas: !<!Schemas>
           name: timeout
           description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
       protocol: !<!Protocols> {}
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: PagingGetMultiplePagesLroOptions

--- a/modelerfour/test/scenarios/paging/namer.yaml
+++ b/modelerfour/test/scenarios/paging/namer.yaml
@@ -527,6 +527,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_23
@@ -539,6 +543,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: !<!ObjectSchema> &ref_19
@@ -546,6 +554,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_15
@@ -613,6 +625,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_24
@@ -651,6 +667,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_25

--- a/modelerfour/test/scenarios/parameter-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/flattened.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_7
       schema: *ref_1
@@ -61,6 +57,10 @@ schemas: !<!Schemas>
           name: tags
           description: A description about the set of tags.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AvailabilitySetUpdateParameters

--- a/modelerfour/test/scenarios/parameter-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/flattened.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_7
       schema: *ref_1

--- a/modelerfour/test/scenarios/parameter-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/grouped.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_7
       schema: *ref_1
@@ -61,6 +57,10 @@ schemas: !<!Schemas>
           name: tags
           description: A description about the set of tags.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AvailabilitySetUpdateParameters

--- a/modelerfour/test/scenarios/parameter-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/grouped.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_7
       schema: *ref_1

--- a/modelerfour/test/scenarios/parameter-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/modeler.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -61,6 +57,10 @@ schemas: !<!Schemas>
           name: tags
           description: A description about the set of tags.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AvailabilitySetUpdateParameters

--- a/modelerfour/test/scenarios/parameter-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/modeler.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/parameter-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/namer.yaml
@@ -47,10 +47,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_7
       schema: *ref_1
@@ -61,6 +57,10 @@ schemas: !<!Schemas>
           name: tags
           description: A description about the set of tags.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: AvailabilitySetUpdateParameters

--- a/modelerfour/test/scenarios/parameter-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/namer.yaml
@@ -47,6 +47,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_7
       schema: *ref_1

--- a/modelerfour/test/scenarios/report/flattened.yaml
+++ b/modelerfour/test/scenarios/report/flattened.yaml
@@ -66,10 +66,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -87,6 +83,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/report/flattened.yaml
+++ b/modelerfour/test/scenarios/report/flattened.yaml
@@ -66,6 +66,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/report/grouped.yaml
+++ b/modelerfour/test/scenarios/report/grouped.yaml
@@ -66,10 +66,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -87,6 +83,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/report/grouped.yaml
+++ b/modelerfour/test/scenarios/report/grouped.yaml
@@ -66,6 +66,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/report/modeler.yaml
+++ b/modelerfour/test/scenarios/report/modeler.yaml
@@ -66,10 +66,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -87,6 +83,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/report/modeler.yaml
+++ b/modelerfour/test/scenarios/report/modeler.yaml
@@ -66,6 +66,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/report/namer.yaml
+++ b/modelerfour/test/scenarios/report/namer.yaml
@@ -66,10 +66,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -87,6 +83,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/report/namer.yaml
+++ b/modelerfour/test/scenarios/report/namer.yaml
@@ -66,6 +66,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1

--- a/modelerfour/test/scenarios/required-optional/flattened.yaml
+++ b/modelerfour/test/scenarios/required-optional/flattened.yaml
@@ -127,10 +127,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -148,6 +144,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -159,10 +159,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_28
       schema: *ref_0
@@ -173,6 +169,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -184,10 +184,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_32
       schema: *ref_0
@@ -197,6 +193,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: int-optional-wrapper
@@ -208,10 +208,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_40
       schema: *ref_2
@@ -222,6 +218,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -233,10 +233,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_44
       schema: *ref_3
@@ -246,6 +242,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: string-optional-wrapper
@@ -257,10 +257,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_49
       schema: *ref_0
@@ -280,6 +276,10 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: product
@@ -291,10 +291,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_58
       schema: *ref_5
@@ -305,6 +301,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: class-wrapper
@@ -316,10 +316,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_62
       schema: *ref_5
@@ -329,6 +325,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: class-optional-wrapper
@@ -340,10 +340,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_70
       schema: !<!ArraySchema> &ref_10
@@ -364,6 +360,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -375,10 +375,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_74
       schema: !<!ArraySchema> &ref_11
@@ -398,6 +394,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: array-optional-wrapper

--- a/modelerfour/test/scenarios/required-optional/flattened.yaml
+++ b/modelerfour/test/scenarios/required-optional/flattened.yaml
@@ -127,6 +127,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -155,6 +159,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_28
       schema: *ref_0
@@ -176,6 +184,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_32
       schema: *ref_0
@@ -196,6 +208,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_40
       schema: *ref_2
@@ -217,6 +233,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_44
       schema: *ref_3
@@ -237,6 +257,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_49
       schema: *ref_0
@@ -267,6 +291,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_58
       schema: *ref_5
@@ -288,6 +316,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_62
       schema: *ref_5
@@ -308,6 +340,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_70
       schema: !<!ArraySchema> &ref_10
@@ -339,6 +375,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_74
       schema: !<!ArraySchema> &ref_11

--- a/modelerfour/test/scenarios/required-optional/grouped.yaml
+++ b/modelerfour/test/scenarios/required-optional/grouped.yaml
@@ -127,10 +127,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -148,6 +144,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -159,10 +159,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_28
       schema: *ref_0
@@ -173,6 +169,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -184,10 +184,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_32
       schema: *ref_0
@@ -197,6 +193,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: int-optional-wrapper
@@ -208,10 +208,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_40
       schema: *ref_2
@@ -222,6 +218,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -233,10 +233,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_44
       schema: *ref_3
@@ -246,6 +242,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: string-optional-wrapper
@@ -257,10 +257,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_49
       schema: *ref_0
@@ -280,6 +276,10 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: product
@@ -291,10 +291,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_58
       schema: *ref_5
@@ -305,6 +301,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: class-wrapper
@@ -316,10 +316,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_62
       schema: *ref_5
@@ -329,6 +325,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: class-optional-wrapper
@@ -340,10 +340,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_70
       schema: !<!ArraySchema> &ref_10
@@ -364,6 +360,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -375,10 +375,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_74
       schema: !<!ArraySchema> &ref_11
@@ -398,6 +394,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: array-optional-wrapper

--- a/modelerfour/test/scenarios/required-optional/grouped.yaml
+++ b/modelerfour/test/scenarios/required-optional/grouped.yaml
@@ -127,6 +127,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -155,6 +159,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_28
       schema: *ref_0
@@ -176,6 +184,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_32
       schema: *ref_0
@@ -196,6 +208,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_40
       schema: *ref_2
@@ -217,6 +233,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_44
       schema: *ref_3
@@ -237,6 +257,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_49
       schema: *ref_0
@@ -267,6 +291,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_58
       schema: *ref_5
@@ -288,6 +316,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_62
       schema: *ref_5
@@ -308,6 +340,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_70
       schema: !<!ArraySchema> &ref_10
@@ -339,6 +375,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_74
       schema: !<!ArraySchema> &ref_11

--- a/modelerfour/test/scenarios/required-optional/modeler.yaml
+++ b/modelerfour/test/scenarios/required-optional/modeler.yaml
@@ -127,6 +127,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -155,6 +159,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -176,6 +184,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -196,6 +208,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -217,6 +233,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -237,6 +257,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -267,6 +291,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -288,6 +316,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -308,6 +340,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10
@@ -339,6 +375,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_11

--- a/modelerfour/test/scenarios/required-optional/modeler.yaml
+++ b/modelerfour/test/scenarios/required-optional/modeler.yaml
@@ -127,10 +127,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -148,6 +144,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -159,10 +159,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -173,6 +169,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: int-wrapper
@@ -184,10 +184,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -197,6 +193,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: int-optional-wrapper
@@ -208,10 +208,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_2
@@ -222,6 +218,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: string-wrapper
@@ -233,10 +233,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -246,6 +242,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: string-optional-wrapper
@@ -257,10 +257,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -280,6 +276,10 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: product
@@ -291,10 +291,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -305,6 +301,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: class-wrapper
@@ -316,10 +316,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -329,6 +325,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: class-optional-wrapper
@@ -340,10 +340,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_10
@@ -364,6 +360,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: array-wrapper
@@ -375,10 +375,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_11
@@ -398,6 +394,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: array-optional-wrapper

--- a/modelerfour/test/scenarios/required-optional/namer.yaml
+++ b/modelerfour/test/scenarios/required-optional/namer.yaml
@@ -127,10 +127,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -148,6 +144,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -159,10 +159,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_28
       schema: *ref_0
@@ -173,6 +169,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: IntWrapper
@@ -184,10 +184,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_32
       schema: *ref_0
@@ -197,6 +193,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: IntOptionalWrapper
@@ -208,10 +208,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_40
       schema: *ref_2
@@ -222,6 +218,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StringWrapper
@@ -233,10 +233,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_44
       schema: *ref_3
@@ -246,6 +242,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StringOptionalWrapper
@@ -257,10 +257,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_49
       schema: *ref_0
@@ -280,6 +276,10 @@ schemas: !<!Schemas>
           name: name
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: Product
@@ -291,10 +291,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_58
       schema: *ref_5
@@ -305,6 +301,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ClassWrapper
@@ -316,10 +316,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_62
       schema: *ref_5
@@ -329,6 +325,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ClassOptionalWrapper
@@ -340,10 +340,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_70
       schema: !<!ArraySchema> &ref_10
@@ -364,6 +360,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ArrayWrapper
@@ -375,10 +375,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_74
       schema: !<!ArraySchema> &ref_11
@@ -398,6 +394,10 @@ schemas: !<!Schemas>
           name: value
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: ArrayOptionalWrapper

--- a/modelerfour/test/scenarios/required-optional/namer.yaml
+++ b/modelerfour/test/scenarios/required-optional/namer.yaml
@@ -127,6 +127,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -155,6 +159,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_28
       schema: *ref_0
@@ -176,6 +184,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_32
       schema: *ref_0
@@ -196,6 +208,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_40
       schema: *ref_2
@@ -217,6 +233,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_44
       schema: *ref_3
@@ -237,6 +257,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_49
       schema: *ref_0
@@ -267,6 +291,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_58
       schema: *ref_5
@@ -288,6 +316,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_62
       schema: *ref_5
@@ -308,6 +340,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_70
       schema: !<!ArraySchema> &ref_10
@@ -339,6 +375,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_74
       schema: !<!ArraySchema> &ref_11

--- a/modelerfour/test/scenarios/storage/flattened.yaml
+++ b/modelerfour/test/scenarios/storage/flattened.yaml
@@ -477,6 +477,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_51
       schema: *ref_2
@@ -507,6 +511,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -550,6 +558,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - input
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -578,6 +590,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -612,6 +628,10 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -651,6 +671,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ObjectSchema> &ref_31
@@ -658,6 +682,10 @@ schemas: !<!Schemas>
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                    contexts:
+                    - output
+                    knownMediaTypes:
+                    - json
                     properties:
                     - !<!Property> 
                       schema: *ref_13
@@ -780,6 +808,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_19
@@ -834,6 +867,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - input
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -935,6 +972,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -958,6 +999,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -1067,6 +1112,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1097,6 +1146,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -1125,6 +1178,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_43
@@ -1163,6 +1220,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_73
       schema: *ref_34
@@ -1183,6 +1244,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_44
@@ -1195,6 +1260,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1226,6 +1295,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_38

--- a/modelerfour/test/scenarios/storage/flattened.yaml
+++ b/modelerfour/test/scenarios/storage/flattened.yaml
@@ -477,10 +477,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_51
       schema: *ref_2
@@ -500,6 +496,10 @@ schemas: !<!Schemas>
           name: type
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountCheckNameAvailabilityParameters
@@ -511,10 +511,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -540,6 +536,10 @@ schemas: !<!Schemas>
           name: message
           description: Gets an error message explaining the Reason value in more detail.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CheckNameAvailabilityResult
@@ -558,10 +558,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - input
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -579,6 +575,11 @@ schemas: !<!Schemas>
               name: accountType
               description: Gets or sets the account type.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StorageAccountCreateParameters
@@ -590,10 +591,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -628,10 +625,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -671,10 +664,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ObjectSchema> &ref_31
@@ -682,10 +671,6 @@ schemas: !<!Schemas>
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
-                    contexts:
-                    - output
-                    knownMediaTypes:
-                    - json
                     properties:
                     - !<!Property> 
                       schema: *ref_13
@@ -695,6 +680,11 @@ schemas: !<!Schemas>
                           name: RecursivePoint
                           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                       protocol: !<!Protocols> {}
+                    serializationFormats:
+                    - json
+                    usage:
+                    - output
+                    - input
                     language: !<!Languages> 
                       default:
                         name: Bar
@@ -707,6 +697,11 @@ schemas: !<!Schemas>
                       name: Bar.Point
                       description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: Foo
@@ -719,6 +714,11 @@ schemas: !<!Schemas>
                   name: FooPoint
                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: Endpoints
@@ -808,11 +808,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_19
@@ -830,6 +825,11 @@ schemas: !<!Schemas>
                   name: useSubDomain
                   description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: CustomDomain
@@ -856,6 +856,11 @@ schemas: !<!Schemas>
               name: secondaryEndpoints
               description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: StorageAccount
@@ -867,10 +872,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - input
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -899,6 +900,11 @@ schemas: !<!Schemas>
               name: customDomain
               description: The custom domain assigned to this storage account. This can be set via Update.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StorageAccountUpdateParameters
@@ -958,6 +964,11 @@ schemas: !<!Schemas>
           name: tags
           description: Resource tags
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -972,10 +983,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -985,6 +992,11 @@ schemas: !<!Schemas>
           name: accountType
           description: Gets or sets the account type.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -999,10 +1011,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -1094,6 +1102,11 @@ schemas: !<!Schemas>
           name: secondaryEndpoints
           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -1112,10 +1125,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1133,6 +1142,11 @@ schemas: !<!Schemas>
           name: customDomain
           description: The custom domain assigned to this storage account. This can be set via Update.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -1146,10 +1160,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -1167,6 +1177,10 @@ schemas: !<!Schemas>
           name: key2
           description: Gets the value of key 1.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageAccountKeys
@@ -1178,10 +1192,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_43
@@ -1209,6 +1219,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: Gets the link to the next set of results. Currently this will always be empty as the API does not support pagination.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageAccountListResult
@@ -1220,10 +1234,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_73
       schema: *ref_34
@@ -1233,6 +1243,10 @@ schemas: !<!Schemas>
           name: keyName
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountRegenerateKeyParameters
@@ -1244,10 +1258,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_44
@@ -1260,10 +1270,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1295,10 +1301,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_38
@@ -1316,6 +1318,10 @@ schemas: !<!Schemas>
                     name: localizedValue
                     description: Gets a localized string describing the resource name.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: UsageName
@@ -1328,6 +1334,10 @@ schemas: !<!Schemas>
                 name: name
                 description: The Usage Names.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Usage
@@ -1345,6 +1355,10 @@ schemas: !<!Schemas>
           name: value
           description: Gets or sets the list Storage Resource Usages.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: UsageListResult

--- a/modelerfour/test/scenarios/storage/grouped.yaml
+++ b/modelerfour/test/scenarios/storage/grouped.yaml
@@ -477,6 +477,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_51
       schema: *ref_2
@@ -507,6 +511,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -550,6 +558,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - input
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -578,6 +590,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -612,6 +628,10 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -651,6 +671,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ObjectSchema> &ref_31
@@ -658,6 +682,10 @@ schemas: !<!Schemas>
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                    contexts:
+                    - output
+                    knownMediaTypes:
+                    - json
                     properties:
                     - !<!Property> 
                       schema: *ref_13
@@ -780,6 +808,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_19
@@ -834,6 +867,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - input
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -935,6 +972,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -958,6 +999,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -1067,6 +1112,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1097,6 +1146,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -1125,6 +1178,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_43
@@ -1163,6 +1220,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_73
       schema: *ref_34
@@ -1183,6 +1244,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_44
@@ -1195,6 +1260,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1226,6 +1295,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_38

--- a/modelerfour/test/scenarios/storage/grouped.yaml
+++ b/modelerfour/test/scenarios/storage/grouped.yaml
@@ -477,10 +477,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_51
       schema: *ref_2
@@ -500,6 +496,10 @@ schemas: !<!Schemas>
           name: type
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountCheckNameAvailabilityParameters
@@ -511,10 +511,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -540,6 +536,10 @@ schemas: !<!Schemas>
           name: message
           description: Gets an error message explaining the Reason value in more detail.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CheckNameAvailabilityResult
@@ -558,10 +558,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - input
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -579,6 +575,11 @@ schemas: !<!Schemas>
               name: accountType
               description: Gets or sets the account type.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StorageAccountCreateParameters
@@ -590,10 +591,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -628,10 +625,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -671,10 +664,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ObjectSchema> &ref_31
@@ -682,10 +671,6 @@ schemas: !<!Schemas>
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
-                    contexts:
-                    - output
-                    knownMediaTypes:
-                    - json
                     properties:
                     - !<!Property> 
                       schema: *ref_13
@@ -695,6 +680,11 @@ schemas: !<!Schemas>
                           name: RecursivePoint
                           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                       protocol: !<!Protocols> {}
+                    serializationFormats:
+                    - json
+                    usage:
+                    - output
+                    - input
                     language: !<!Languages> 
                       default:
                         name: Bar
@@ -707,6 +697,11 @@ schemas: !<!Schemas>
                       name: Bar.Point
                       description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: Foo
@@ -719,6 +714,11 @@ schemas: !<!Schemas>
                   name: FooPoint
                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: Endpoints
@@ -808,11 +808,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_19
@@ -830,6 +825,11 @@ schemas: !<!Schemas>
                   name: useSubDomain
                   description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: CustomDomain
@@ -856,6 +856,11 @@ schemas: !<!Schemas>
               name: secondaryEndpoints
               description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: StorageAccount
@@ -867,10 +872,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - input
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -899,6 +900,11 @@ schemas: !<!Schemas>
               name: customDomain
               description: The custom domain assigned to this storage account. This can be set via Update.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StorageAccountUpdateParameters
@@ -958,6 +964,11 @@ schemas: !<!Schemas>
           name: tags
           description: Resource tags
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -972,10 +983,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -985,6 +992,11 @@ schemas: !<!Schemas>
           name: accountType
           description: Gets or sets the account type.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -999,10 +1011,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -1094,6 +1102,11 @@ schemas: !<!Schemas>
           name: secondaryEndpoints
           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -1112,10 +1125,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1133,6 +1142,11 @@ schemas: !<!Schemas>
           name: customDomain
           description: The custom domain assigned to this storage account. This can be set via Update.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -1146,10 +1160,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -1167,6 +1177,10 @@ schemas: !<!Schemas>
           name: key2
           description: Gets the value of key 1.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageAccountKeys
@@ -1178,10 +1192,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_43
@@ -1209,6 +1219,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: Gets the link to the next set of results. Currently this will always be empty as the API does not support pagination.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageAccountListResult
@@ -1220,10 +1234,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_73
       schema: *ref_34
@@ -1233,6 +1243,10 @@ schemas: !<!Schemas>
           name: keyName
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountRegenerateKeyParameters
@@ -1244,10 +1258,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_44
@@ -1260,10 +1270,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1295,10 +1301,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_38
@@ -1316,6 +1318,10 @@ schemas: !<!Schemas>
                     name: localizedValue
                     description: Gets a localized string describing the resource name.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: UsageName
@@ -1328,6 +1334,10 @@ schemas: !<!Schemas>
                 name: name
                 description: The Usage Names.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Usage
@@ -1345,6 +1355,10 @@ schemas: !<!Schemas>
           name: value
           description: Gets or sets the list Storage Resource Usages.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: UsageListResult

--- a/modelerfour/test/scenarios/storage/modeler.yaml
+++ b/modelerfour/test/scenarios/storage/modeler.yaml
@@ -477,6 +477,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -507,6 +511,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_35
@@ -550,6 +558,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - input
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_9
@@ -562,6 +574,10 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - input
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -596,6 +612,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_9
@@ -608,6 +628,10 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_38
@@ -631,6 +655,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_11
@@ -670,6 +698,10 @@ schemas: !<!Schemas>
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                    contexts:
+                    - output
+                    knownMediaTypes:
+                    - json
                     properties:
                     - !<!Property> 
                       schema: !<!ObjectSchema> &ref_26
@@ -677,6 +709,10 @@ schemas: !<!Schemas>
                         apiVersions:
                         - !<!ApiVersion> 
                           version: 2015-05-01-preview
+                        contexts:
+                        - output
+                        knownMediaTypes:
+                        - json
                         properties:
                         - !<!Property> 
                           schema: *ref_14
@@ -778,6 +814,11 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
+                contexts:
+                - output
+                - input
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_18
@@ -840,6 +881,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - input
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_9
@@ -852,6 +897,10 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - input
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -965,6 +1014,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_28
@@ -993,6 +1046,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_44
@@ -1031,6 +1088,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_39
@@ -1051,6 +1112,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_45
@@ -1063,6 +1128,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_40
@@ -1094,6 +1163,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_30

--- a/modelerfour/test/scenarios/storage/modeler.yaml
+++ b/modelerfour/test/scenarios/storage/modeler.yaml
@@ -477,10 +477,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -500,6 +496,10 @@ schemas: !<!Schemas>
           name: type
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountCheckNameAvailabilityParameters
@@ -511,10 +511,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_35
@@ -540,6 +536,10 @@ schemas: !<!Schemas>
           name: message
           description: Gets an error message explaining the Reason value in more detail.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CheckNameAvailabilityResult
@@ -558,10 +558,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - input
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_9
@@ -574,10 +570,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - input
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -587,6 +579,11 @@ schemas: !<!Schemas>
                   name: accountType
                   description: Gets or sets the account type.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: StorageAccountPropertiesCreateParameters
@@ -601,6 +598,11 @@ schemas: !<!Schemas>
               name: properties
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StorageAccountCreateParameters
@@ -612,10 +614,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_9
@@ -628,10 +626,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_38
@@ -655,10 +649,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_11
@@ -698,10 +688,6 @@ schemas: !<!Schemas>
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
-                    contexts:
-                    - output
-                    knownMediaTypes:
-                    - json
                     properties:
                     - !<!Property> 
                       schema: !<!ObjectSchema> &ref_26
@@ -709,10 +695,6 @@ schemas: !<!Schemas>
                         apiVersions:
                         - !<!ApiVersion> 
                           version: 2015-05-01-preview
-                        contexts:
-                        - output
-                        knownMediaTypes:
-                        - json
                         properties:
                         - !<!Property> 
                           schema: *ref_14
@@ -722,6 +704,11 @@ schemas: !<!Schemas>
                               name: RecursivePoint
                               description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                           protocol: !<!Protocols> {}
+                        serializationFormats:
+                        - json
+                        usage:
+                        - output
+                        - input
                         language: !<!Languages> 
                           default:
                             name: Bar
@@ -734,6 +721,11 @@ schemas: !<!Schemas>
                           name: Bar.Point
                           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                       protocol: !<!Protocols> {}
+                    serializationFormats:
+                    - json
+                    usage:
+                    - output
+                    - input
                     language: !<!Languages> 
                       default:
                         name: Foo
@@ -746,6 +738,11 @@ schemas: !<!Schemas>
                       name: FooPoint
                       description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: Endpoints
@@ -814,11 +811,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
-                contexts:
-                - output
-                - input
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_18
@@ -836,6 +828,11 @@ schemas: !<!Schemas>
                       name: useSubDomain
                       description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: CustomDomain
@@ -856,6 +853,11 @@ schemas: !<!Schemas>
                   name: secondaryEndpoints
                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: StorageAccountProperties
@@ -870,6 +872,11 @@ schemas: !<!Schemas>
               name: properties
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: StorageAccount
@@ -881,10 +888,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - input
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_9
@@ -897,10 +900,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - input
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -918,6 +917,11 @@ schemas: !<!Schemas>
                   name: customDomain
                   description: The custom domain assigned to this storage account. This can be set via Update.
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - input
+            - output
             language: !<!Languages> 
               default:
                 name: StorageAccountPropertiesUpdateParameters
@@ -932,6 +936,11 @@ schemas: !<!Schemas>
               name: properties
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StorageAccountUpdateParameters
@@ -991,6 +1000,11 @@ schemas: !<!Schemas>
           name: tags
           description: Resource tags
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -1014,10 +1028,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_28
@@ -1035,6 +1045,10 @@ schemas: !<!Schemas>
           name: key2
           description: Gets the value of key 1.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageAccountKeys
@@ -1046,10 +1060,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_44
@@ -1077,6 +1087,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: Gets the link to the next set of results. Currently this will always be empty as the API does not support pagination.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageAccountListResult
@@ -1088,10 +1102,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_39
@@ -1101,6 +1111,10 @@ schemas: !<!Schemas>
           name: keyName
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountRegenerateKeyParameters
@@ -1112,10 +1126,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_45
@@ -1128,10 +1138,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_40
@@ -1163,10 +1169,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_30
@@ -1184,6 +1186,10 @@ schemas: !<!Schemas>
                     name: localizedValue
                     description: Gets a localized string describing the resource name.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: UsageName
@@ -1196,6 +1202,10 @@ schemas: !<!Schemas>
                 name: name
                 description: The Usage Names.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Usage
@@ -1213,6 +1223,10 @@ schemas: !<!Schemas>
           name: value
           description: Gets or sets the list Storage Resource Usages.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: UsageListResult

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -477,6 +477,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_51
       schema: *ref_2
@@ -507,6 +511,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -550,6 +558,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - input
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -578,6 +590,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -612,6 +628,10 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - output
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -651,6 +671,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ObjectSchema> &ref_31
@@ -658,6 +682,10 @@ schemas: !<!Schemas>
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                    contexts:
+                    - output
+                    knownMediaTypes:
+                    - json
                     properties:
                     - !<!Property> 
                       schema: *ref_13
@@ -780,6 +808,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - json
             properties:
             - !<!Property> 
               schema: *ref_19
@@ -834,6 +867,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
+        contexts:
+        - input
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -935,6 +972,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -958,6 +999,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -1067,6 +1112,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1097,6 +1146,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -1125,6 +1178,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_43
@@ -1163,6 +1220,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_73
       schema: *ref_34
@@ -1183,6 +1244,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_44
@@ -1195,6 +1260,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1226,6 +1295,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_38

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -477,10 +477,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_51
       schema: *ref_2
@@ -500,6 +496,10 @@ schemas: !<!Schemas>
           name: type
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountCheckNameAvailabilityParameters
@@ -511,10 +511,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -540,6 +536,10 @@ schemas: !<!Schemas>
           name: message
           description: Gets an error message explaining the Reason value in more detail.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: CheckNameAvailabilityResult
@@ -558,10 +558,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - input
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -579,6 +575,11 @@ schemas: !<!Schemas>
               name: accountType
               description: Gets or sets the account type.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StorageAccountCreateParameters
@@ -590,10 +591,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -628,10 +625,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - output
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_10
@@ -671,10 +664,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: 2015-05-01-preview
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: !<!ObjectSchema> &ref_31
@@ -682,10 +671,6 @@ schemas: !<!Schemas>
                     apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
-                    contexts:
-                    - output
-                    knownMediaTypes:
-                    - json
                     properties:
                     - !<!Property> 
                       schema: *ref_13
@@ -695,6 +680,11 @@ schemas: !<!Schemas>
                           name: recursivePoint
                           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                       protocol: !<!Protocols> {}
+                    serializationFormats:
+                    - json
+                    usage:
+                    - output
+                    - input
                     language: !<!Languages> 
                       default:
                         name: Bar
@@ -707,6 +697,11 @@ schemas: !<!Schemas>
                       name: barPoint
                       description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
+                - input
                 language: !<!Languages> 
                   default:
                     name: Foo
@@ -719,6 +714,11 @@ schemas: !<!Schemas>
                   name: fooPoint
                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: Endpoints
@@ -808,11 +808,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 2015-05-01-preview
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - json
             properties:
             - !<!Property> 
               schema: *ref_19
@@ -830,6 +825,11 @@ schemas: !<!Schemas>
                   name: useSubDomain
                   description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - json
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: CustomDomain
@@ -856,6 +856,11 @@ schemas: !<!Schemas>
               name: secondaryEndpoints
               description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: StorageAccount
@@ -867,10 +872,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-        contexts:
-        - input
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_7
@@ -899,6 +900,11 @@ schemas: !<!Schemas>
               name: customDomain
               description: The custom domain assigned to this storage account. This can be set via Update.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - input
+        - output
         language: !<!Languages> 
           default:
             name: StorageAccountUpdateParameters
@@ -958,6 +964,11 @@ schemas: !<!Schemas>
           name: tags
           description: Resource tags
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-azure-resource: true
     language: !<!Languages> 
@@ -972,10 +983,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -985,6 +992,11 @@ schemas: !<!Schemas>
           name: accountType
           description: Gets or sets the account type.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -999,10 +1011,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_9
@@ -1094,6 +1102,11 @@ schemas: !<!Schemas>
           name: secondaryEndpoints
           description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -1112,10 +1125,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1133,6 +1142,11 @@ schemas: !<!Schemas>
           name: customDomain
           description: The custom domain assigned to this storage account. This can be set via Update.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
     extensions:
       x-ms-flattened: true
     language: !<!Languages> 
@@ -1146,10 +1160,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_32
@@ -1167,6 +1177,10 @@ schemas: !<!Schemas>
           name: key2
           description: Gets the value of key 1.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageAccountKeys
@@ -1178,10 +1192,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_43
@@ -1209,6 +1219,10 @@ schemas: !<!Schemas>
           name: nextLink
           description: Gets the link to the next set of results. Currently this will always be empty as the API does not support pagination.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: StorageAccountListResult
@@ -1220,10 +1234,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_73
       schema: *ref_34
@@ -1233,6 +1243,10 @@ schemas: !<!Schemas>
           name: keyName
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: StorageAccountRegenerateKeyParameters
@@ -1244,10 +1258,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2015-05-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_44
@@ -1260,10 +1270,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1295,10 +1301,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_38
@@ -1316,6 +1318,10 @@ schemas: !<!Schemas>
                     name: localizedValue
                     description: Gets a localized string describing the resource name.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: UsageName
@@ -1328,6 +1334,10 @@ schemas: !<!Schemas>
                 name: name
                 description: The Usage Names.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Usage
@@ -1345,6 +1355,10 @@ schemas: !<!Schemas>
           name: value
           description: Gets or sets the list Storage Resource Usages.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: UsageListResult

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/flattened.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/flattened.yaml
@@ -77,6 +77,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -105,6 +109,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/flattened.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/flattened.yaml
@@ -77,10 +77,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -98,6 +94,10 @@ schemas: !<!Schemas>
           name: location
           description: resource group location 'West US'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SampleResourceGroup
@@ -109,10 +109,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -130,6 +126,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/grouped.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/grouped.yaml
@@ -77,6 +77,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -105,6 +109,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/grouped.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/grouped.yaml
@@ -77,10 +77,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -98,6 +94,10 @@ schemas: !<!Schemas>
           name: location
           description: resource group location 'West US'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SampleResourceGroup
@@ -109,10 +109,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -130,6 +126,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/modeler.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/modeler.yaml
@@ -77,6 +77,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -105,6 +109,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_4

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/modeler.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/modeler.yaml
@@ -77,10 +77,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -98,6 +94,10 @@ schemas: !<!Schemas>
           name: location
           description: resource group location 'West US'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SampleResourceGroup
@@ -109,10 +109,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_4
@@ -130,6 +126,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
@@ -77,6 +77,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -105,6 +109,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
@@ -77,10 +77,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_1
@@ -98,6 +94,10 @@ schemas: !<!Schemas>
           name: location
           description: resource group location 'West US'
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SampleResourceGroup
@@ -109,10 +109,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 2014-04-01-preview
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -130,6 +126,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/text-analytics/flattened.yaml
+++ b/modelerfour/test/scenarios/text-analytics/flattened.yaml
@@ -692,10 +692,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: !<!ArraySchema> &ref_75
@@ -708,10 +704,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -740,6 +732,10 @@ schemas: !<!Schemas>
                 name: language
                 description: '(Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use "en" for English; "es" for Spanish etc. If not set, use "en" for English as default.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: MultiLanguageInput
@@ -758,6 +754,10 @@ schemas: !<!Schemas>
           name: documents
           description: The set of documents to process as part of this batch.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: MultiLanguageBatchInput
@@ -770,10 +770,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_77
@@ -786,10 +782,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_6
@@ -811,10 +803,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_7
@@ -870,6 +858,10 @@ schemas: !<!Schemas>
                       name: score
                       description: Confidence score between 0 and 1 of the extracted entity.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: Entity
@@ -894,10 +886,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_13
@@ -917,6 +905,10 @@ schemas: !<!Schemas>
                     name: transactionsCount
                     description: Number of transactions for the document.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DocumentStatistics
@@ -930,6 +922,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentEntities
@@ -959,10 +955,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_15
@@ -979,10 +971,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_16
@@ -1017,10 +1005,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: v3.0-preview.1
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_19
@@ -1067,6 +1051,10 @@ schemas: !<!Schemas>
                         name: innerError
                         description: ''
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: InnerError
@@ -1099,6 +1087,10 @@ schemas: !<!Schemas>
                     name: details
                     description: Details about specific errors that led to this reported error.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: TextAnalyticsError
@@ -1112,6 +1104,10 @@ schemas: !<!Schemas>
                 name: error
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentError
@@ -1136,10 +1132,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_25
@@ -1177,6 +1169,10 @@ schemas: !<!Schemas>
               name: transactionsCount
               description: Number of transactions for the request.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: RequestStatistics
@@ -1199,6 +1195,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: EntitiesResult
@@ -1217,10 +1217,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_82
@@ -1233,10 +1229,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1258,10 +1250,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_36
@@ -1283,10 +1271,6 @@ schemas: !<!Schemas>
                       apiVersions:
                       - !<!ApiVersion> 
                         version: v3.0-preview.1
-                      contexts:
-                      - output
-                      knownMediaTypes:
-                      - json
                       properties:
                       - !<!Property> 
                         schema: *ref_37
@@ -1324,6 +1308,10 @@ schemas: !<!Schemas>
                             name: length
                             description: Length (in Unicode characters) for the entity match text.
                         protocol: !<!Protocols> {}
+                      serializationFormats:
+                      - json
+                      usage:
+                      - output
                       language: !<!Languages> 
                         default:
                           name: Match
@@ -1378,6 +1366,10 @@ schemas: !<!Schemas>
                       name: dataSource
                       description: 'Data source used to extract entity linking, such as Wiki/Bing etc.'
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: LinkedEntity
@@ -1405,6 +1397,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentLinkedEntities
@@ -1460,6 +1456,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: EntityLinkingResult
@@ -1474,10 +1474,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -1490,10 +1486,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -1532,6 +1524,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentKeyPhrases
@@ -1587,6 +1583,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyPhraseResult
@@ -1599,10 +1599,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_120
       schema: !<!ArraySchema> &ref_87
@@ -1615,10 +1611,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_53
@@ -1647,6 +1639,10 @@ schemas: !<!Schemas>
                 name: countryHint
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: LanguageInput
@@ -1665,6 +1661,10 @@ schemas: !<!Schemas>
           name: documents
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: LanguageBatchInput
@@ -1677,10 +1677,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_89
@@ -1693,10 +1689,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_57
@@ -1718,10 +1710,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_58
@@ -1750,6 +1738,10 @@ schemas: !<!Schemas>
                       name: score
                       description: A confidence score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: DetectedLanguage
@@ -1777,6 +1769,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentLanguage
@@ -1832,6 +1828,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: LanguageResult
@@ -1845,10 +1845,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_93
@@ -1861,10 +1857,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_64
@@ -1899,10 +1891,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -1931,6 +1919,10 @@ schemas: !<!Schemas>
                     name: negative
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: SentimentConfidenceScorePerLabel
@@ -1955,10 +1947,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_67
@@ -2015,6 +2003,10 @@ schemas: !<!Schemas>
                       name: warnings
                       description: The warnings generated for the sentence.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: SentenceSentiment
@@ -2033,6 +2025,10 @@ schemas: !<!Schemas>
                 name: sentences
                 description: Sentence level sentiment analysis.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentSentiment
@@ -2088,6 +2084,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SentimentResponse

--- a/modelerfour/test/scenarios/text-analytics/flattened.yaml
+++ b/modelerfour/test/scenarios/text-analytics/flattened.yaml
@@ -692,6 +692,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: !<!ArraySchema> &ref_75
@@ -704,6 +708,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -762,6 +770,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_77
@@ -774,6 +786,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_6
@@ -795,6 +811,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_7
@@ -874,6 +894,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_13
@@ -935,6 +959,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_15
@@ -951,6 +979,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_16
@@ -985,6 +1017,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: v3.0-preview.1
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_19
@@ -1100,6 +1136,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_25
@@ -1177,6 +1217,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_82
@@ -1189,6 +1233,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1210,6 +1258,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_36
@@ -1231,6 +1283,10 @@ schemas: !<!Schemas>
                       apiVersions:
                       - !<!ApiVersion> 
                         version: v3.0-preview.1
+                      contexts:
+                      - output
+                      knownMediaTypes:
+                      - json
                       properties:
                       - !<!Property> 
                         schema: *ref_37
@@ -1418,6 +1474,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -1430,6 +1490,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -1535,6 +1599,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_120
       schema: !<!ArraySchema> &ref_87
@@ -1547,6 +1615,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_53
@@ -1605,6 +1677,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_89
@@ -1617,6 +1693,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_57
@@ -1638,6 +1718,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_58
@@ -1761,6 +1845,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_93
@@ -1773,6 +1861,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_64
@@ -1807,6 +1899,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -1859,6 +1955,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_67

--- a/modelerfour/test/scenarios/text-analytics/grouped.yaml
+++ b/modelerfour/test/scenarios/text-analytics/grouped.yaml
@@ -692,10 +692,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: !<!ArraySchema> &ref_75
@@ -708,10 +704,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -740,6 +732,10 @@ schemas: !<!Schemas>
                 name: language
                 description: '(Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use "en" for English; "es" for Spanish etc. If not set, use "en" for English as default.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: MultiLanguageInput
@@ -758,6 +754,10 @@ schemas: !<!Schemas>
           name: documents
           description: The set of documents to process as part of this batch.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: MultiLanguageBatchInput
@@ -770,10 +770,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_77
@@ -786,10 +782,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_6
@@ -811,10 +803,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_7
@@ -870,6 +858,10 @@ schemas: !<!Schemas>
                       name: score
                       description: Confidence score between 0 and 1 of the extracted entity.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: Entity
@@ -894,10 +886,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_13
@@ -917,6 +905,10 @@ schemas: !<!Schemas>
                     name: transactionsCount
                     description: Number of transactions for the document.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DocumentStatistics
@@ -930,6 +922,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentEntities
@@ -959,10 +955,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_15
@@ -979,10 +971,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_16
@@ -1017,10 +1005,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: v3.0-preview.1
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_19
@@ -1067,6 +1051,10 @@ schemas: !<!Schemas>
                         name: innerError
                         description: ''
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: InnerError
@@ -1099,6 +1087,10 @@ schemas: !<!Schemas>
                     name: details
                     description: Details about specific errors that led to this reported error.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: TextAnalyticsError
@@ -1112,6 +1104,10 @@ schemas: !<!Schemas>
                 name: error
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentError
@@ -1136,10 +1132,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_25
@@ -1177,6 +1169,10 @@ schemas: !<!Schemas>
               name: transactionsCount
               description: Number of transactions for the request.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: RequestStatistics
@@ -1199,6 +1195,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: EntitiesResult
@@ -1217,10 +1217,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_82
@@ -1233,10 +1229,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1258,10 +1250,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_36
@@ -1283,10 +1271,6 @@ schemas: !<!Schemas>
                       apiVersions:
                       - !<!ApiVersion> 
                         version: v3.0-preview.1
-                      contexts:
-                      - output
-                      knownMediaTypes:
-                      - json
                       properties:
                       - !<!Property> 
                         schema: *ref_37
@@ -1324,6 +1308,10 @@ schemas: !<!Schemas>
                             name: length
                             description: Length (in Unicode characters) for the entity match text.
                         protocol: !<!Protocols> {}
+                      serializationFormats:
+                      - json
+                      usage:
+                      - output
                       language: !<!Languages> 
                         default:
                           name: Match
@@ -1378,6 +1366,10 @@ schemas: !<!Schemas>
                       name: dataSource
                       description: 'Data source used to extract entity linking, such as Wiki/Bing etc.'
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: LinkedEntity
@@ -1405,6 +1397,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentLinkedEntities
@@ -1460,6 +1456,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: EntityLinkingResult
@@ -1474,10 +1474,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -1490,10 +1486,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -1532,6 +1524,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentKeyPhrases
@@ -1587,6 +1583,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyPhraseResult
@@ -1599,10 +1599,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_120
       schema: !<!ArraySchema> &ref_87
@@ -1615,10 +1611,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_53
@@ -1647,6 +1639,10 @@ schemas: !<!Schemas>
                 name: countryHint
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: LanguageInput
@@ -1665,6 +1661,10 @@ schemas: !<!Schemas>
           name: documents
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: LanguageBatchInput
@@ -1677,10 +1677,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_89
@@ -1693,10 +1689,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_57
@@ -1718,10 +1710,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_58
@@ -1750,6 +1738,10 @@ schemas: !<!Schemas>
                       name: score
                       description: A confidence score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: DetectedLanguage
@@ -1777,6 +1769,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentLanguage
@@ -1832,6 +1828,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: LanguageResult
@@ -1845,10 +1845,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_93
@@ -1861,10 +1857,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_64
@@ -1899,10 +1891,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -1931,6 +1919,10 @@ schemas: !<!Schemas>
                     name: negative
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: SentimentConfidenceScorePerLabel
@@ -1955,10 +1947,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_67
@@ -2015,6 +2003,10 @@ schemas: !<!Schemas>
                       name: warnings
                       description: The warnings generated for the sentence.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: SentenceSentiment
@@ -2033,6 +2025,10 @@ schemas: !<!Schemas>
                 name: sentences
                 description: Sentence level sentiment analysis.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentSentiment
@@ -2088,6 +2084,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SentimentResponse

--- a/modelerfour/test/scenarios/text-analytics/grouped.yaml
+++ b/modelerfour/test/scenarios/text-analytics/grouped.yaml
@@ -692,6 +692,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: !<!ArraySchema> &ref_75
@@ -704,6 +708,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -762,6 +770,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_77
@@ -774,6 +786,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_6
@@ -795,6 +811,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_7
@@ -874,6 +894,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_13
@@ -935,6 +959,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_15
@@ -951,6 +979,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_16
@@ -985,6 +1017,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: v3.0-preview.1
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_19
@@ -1100,6 +1136,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_25
@@ -1177,6 +1217,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_82
@@ -1189,6 +1233,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1210,6 +1258,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_36
@@ -1231,6 +1283,10 @@ schemas: !<!Schemas>
                       apiVersions:
                       - !<!ApiVersion> 
                         version: v3.0-preview.1
+                      contexts:
+                      - output
+                      knownMediaTypes:
+                      - json
                       properties:
                       - !<!Property> 
                         schema: *ref_37
@@ -1418,6 +1474,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -1430,6 +1490,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -1535,6 +1599,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_120
       schema: !<!ArraySchema> &ref_87
@@ -1547,6 +1615,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_53
@@ -1605,6 +1677,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_89
@@ -1617,6 +1693,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_57
@@ -1638,6 +1718,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_58
@@ -1761,6 +1845,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_93
@@ -1773,6 +1861,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_64
@@ -1807,6 +1899,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -1859,6 +1955,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_67

--- a/modelerfour/test/scenarios/text-analytics/modeler.yaml
+++ b/modelerfour/test/scenarios/text-analytics/modeler.yaml
@@ -692,6 +692,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_55
@@ -704,6 +708,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_0
@@ -762,6 +770,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_57
@@ -774,6 +786,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_4
@@ -795,6 +811,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_5
@@ -874,6 +894,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_78
@@ -935,6 +959,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_8
@@ -951,6 +979,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_90
@@ -985,6 +1017,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: v3.0-preview.1
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_91
@@ -1100,6 +1136,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_80
@@ -1177,6 +1217,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_62
@@ -1189,6 +1233,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_23
@@ -1210,6 +1258,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_24
@@ -1231,6 +1283,10 @@ schemas: !<!Schemas>
                       apiVersions:
                       - !<!ApiVersion> 
                         version: v3.0-preview.1
+                      contexts:
+                      - output
+                      knownMediaTypes:
+                      - json
                       properties:
                       - !<!Property> 
                         schema: *ref_84
@@ -1418,6 +1474,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_65
@@ -1430,6 +1490,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_34
@@ -1535,6 +1599,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_67
@@ -1547,6 +1615,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_38
@@ -1605,6 +1677,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_69
@@ -1617,6 +1693,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_42
@@ -1638,6 +1718,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_43
@@ -1761,6 +1845,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_73
@@ -1773,6 +1861,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_48
@@ -1807,6 +1899,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_49
@@ -1859,6 +1955,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_93

--- a/modelerfour/test/scenarios/text-analytics/modeler.yaml
+++ b/modelerfour/test/scenarios/text-analytics/modeler.yaml
@@ -692,10 +692,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_55
@@ -708,10 +704,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_0
@@ -740,6 +732,10 @@ schemas: !<!Schemas>
                 name: language
                 description: '(Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use "en" for English; "es" for Spanish etc. If not set, use "en" for English as default.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: MultiLanguageInput
@@ -758,6 +754,10 @@ schemas: !<!Schemas>
           name: documents
           description: The set of documents to process as part of this batch.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: MultiLanguageBatchInput
@@ -770,10 +770,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_57
@@ -786,10 +782,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_4
@@ -811,10 +803,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_5
@@ -870,6 +858,10 @@ schemas: !<!Schemas>
                       name: score
                       description: Confidence score between 0 and 1 of the extracted entity.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: Entity
@@ -894,10 +886,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_78
@@ -917,6 +905,10 @@ schemas: !<!Schemas>
                     name: transactionsCount
                     description: Number of transactions for the document.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DocumentStatistics
@@ -930,6 +922,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentEntities
@@ -959,10 +955,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_8
@@ -979,10 +971,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_90
@@ -1017,10 +1005,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: v3.0-preview.1
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_91
@@ -1067,6 +1051,10 @@ schemas: !<!Schemas>
                         name: innerError
                         description: ''
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: InnerError
@@ -1099,6 +1087,10 @@ schemas: !<!Schemas>
                     name: details
                     description: Details about specific errors that led to this reported error.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: TextAnalyticsError
@@ -1112,6 +1104,10 @@ schemas: !<!Schemas>
                 name: error
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentError
@@ -1136,10 +1132,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_80
@@ -1177,6 +1169,10 @@ schemas: !<!Schemas>
               name: transactionsCount
               description: Number of transactions for the request.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: RequestStatistics
@@ -1199,6 +1195,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: EntitiesResult
@@ -1217,10 +1217,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_62
@@ -1233,10 +1229,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_23
@@ -1258,10 +1250,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_24
@@ -1283,10 +1271,6 @@ schemas: !<!Schemas>
                       apiVersions:
                       - !<!ApiVersion> 
                         version: v3.0-preview.1
-                      contexts:
-                      - output
-                      knownMediaTypes:
-                      - json
                       properties:
                       - !<!Property> 
                         schema: *ref_84
@@ -1324,6 +1308,10 @@ schemas: !<!Schemas>
                             name: length
                             description: Length (in Unicode characters) for the entity match text.
                         protocol: !<!Protocols> {}
+                      serializationFormats:
+                      - json
+                      usage:
+                      - output
                       language: !<!Languages> 
                         default:
                           name: Match
@@ -1378,6 +1366,10 @@ schemas: !<!Schemas>
                       name: dataSource
                       description: 'Data source used to extract entity linking, such as Wiki/Bing etc.'
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: LinkedEntity
@@ -1405,6 +1397,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentLinkedEntities
@@ -1460,6 +1456,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: EntityLinkingResult
@@ -1474,10 +1474,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_65
@@ -1490,10 +1486,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_34
@@ -1532,6 +1524,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentKeyPhrases
@@ -1587,6 +1583,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyPhraseResult
@@ -1599,10 +1599,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_67
@@ -1615,10 +1611,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_38
@@ -1647,6 +1639,10 @@ schemas: !<!Schemas>
                 name: countryHint
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: LanguageInput
@@ -1665,6 +1661,10 @@ schemas: !<!Schemas>
           name: documents
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: LanguageBatchInput
@@ -1677,10 +1677,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_69
@@ -1693,10 +1689,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_42
@@ -1718,10 +1710,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_43
@@ -1750,6 +1738,10 @@ schemas: !<!Schemas>
                       name: score
                       description: A confidence score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: DetectedLanguage
@@ -1777,6 +1769,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentLanguage
@@ -1832,6 +1828,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: LanguageResult
@@ -1845,10 +1845,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_73
@@ -1861,10 +1857,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_48
@@ -1899,10 +1891,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_49
@@ -1931,6 +1919,10 @@ schemas: !<!Schemas>
                     name: negative
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: SentimentConfidenceScorePerLabel
@@ -1955,10 +1947,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_93
@@ -2015,6 +2003,10 @@ schemas: !<!Schemas>
                       name: warnings
                       description: The warnings generated for the sentence.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: SentenceSentiment
@@ -2033,6 +2025,10 @@ schemas: !<!Schemas>
                 name: sentences
                 description: Sentence level sentiment analysis.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentSentiment
@@ -2088,6 +2084,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SentimentResponse

--- a/modelerfour/test/scenarios/text-analytics/namer.yaml
+++ b/modelerfour/test/scenarios/text-analytics/namer.yaml
@@ -692,10 +692,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_99
       schema: !<!ArraySchema> &ref_75
@@ -708,10 +704,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -740,6 +732,10 @@ schemas: !<!Schemas>
                 name: language
                 description: '(Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use "en" for English; "es" for Spanish etc. If not set, use "en" for English as default.'
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: MultiLanguageInput
@@ -758,6 +754,10 @@ schemas: !<!Schemas>
           name: documents
           description: The set of documents to process as part of this batch.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: MultiLanguageBatchInput
@@ -770,10 +770,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_77
@@ -786,10 +782,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_6
@@ -811,10 +803,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_7
@@ -870,6 +858,10 @@ schemas: !<!Schemas>
                       name: score
                       description: Confidence score between 0 and 1 of the extracted entity.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: Entity
@@ -894,10 +886,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_13
@@ -917,6 +905,10 @@ schemas: !<!Schemas>
                     name: transactionsCount
                     description: Number of transactions for the document.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: DocumentStatistics
@@ -930,6 +922,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentEntities
@@ -959,10 +955,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_15
@@ -979,10 +971,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_16
@@ -1017,10 +1005,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: v3.0-preview.1
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_19
@@ -1067,6 +1051,10 @@ schemas: !<!Schemas>
                         name: innerError
                         description: ''
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - json
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: InnerError
@@ -1099,6 +1087,10 @@ schemas: !<!Schemas>
                     name: details
                     description: Details about specific errors that led to this reported error.
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: TextAnalyticsError
@@ -1112,6 +1104,10 @@ schemas: !<!Schemas>
                 name: error
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentError
@@ -1136,10 +1132,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_25
@@ -1177,6 +1169,10 @@ schemas: !<!Schemas>
               name: transactionsCount
               description: Number of transactions for the request.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: RequestStatistics
@@ -1199,6 +1195,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: EntitiesResult
@@ -1217,10 +1217,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_82
@@ -1233,10 +1229,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1258,10 +1250,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_36
@@ -1283,10 +1271,6 @@ schemas: !<!Schemas>
                       apiVersions:
                       - !<!ApiVersion> 
                         version: v3.0-preview.1
-                      contexts:
-                      - output
-                      knownMediaTypes:
-                      - json
                       properties:
                       - !<!Property> 
                         schema: *ref_37
@@ -1324,6 +1308,10 @@ schemas: !<!Schemas>
                             name: length
                             description: Length (in Unicode characters) for the entity match text.
                         protocol: !<!Protocols> {}
+                      serializationFormats:
+                      - json
+                      usage:
+                      - output
                       language: !<!Languages> 
                         default:
                           name: Match
@@ -1378,6 +1366,10 @@ schemas: !<!Schemas>
                       name: dataSource
                       description: 'Data source used to extract entity linking, such as Wiki/Bing etc.'
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: LinkedEntity
@@ -1405,6 +1397,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentLinkedEntities
@@ -1460,6 +1456,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: EntityLinkingResult
@@ -1474,10 +1474,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -1490,10 +1486,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -1532,6 +1524,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentKeyPhrases
@@ -1587,6 +1583,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: KeyPhraseResult
@@ -1599,10 +1599,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_120
       schema: !<!ArraySchema> &ref_87
@@ -1615,10 +1611,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - input
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_53
@@ -1647,6 +1639,10 @@ schemas: !<!Schemas>
                 name: countryHint
                 description: ''
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - input
           language: !<!Languages> 
             default:
               name: LanguageInput
@@ -1665,6 +1661,10 @@ schemas: !<!Schemas>
           name: documents
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: LanguageBatchInput
@@ -1677,10 +1677,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_89
@@ -1693,10 +1689,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_57
@@ -1718,10 +1710,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_58
@@ -1750,6 +1738,10 @@ schemas: !<!Schemas>
                       name: score
                       description: A confidence score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: DetectedLanguage
@@ -1777,6 +1769,10 @@ schemas: !<!Schemas>
                 name: statistics
                 description: if showStats=true was specified in the request this field will contain information about the document payload.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentLanguage
@@ -1832,6 +1828,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: LanguageResult
@@ -1845,10 +1845,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_93
@@ -1861,10 +1857,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
-          contexts:
-          - output
-          knownMediaTypes:
-          - json
           properties:
           - !<!Property> 
             schema: *ref_64
@@ -1899,10 +1891,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
-              contexts:
-              - output
-              knownMediaTypes:
-              - json
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -1931,6 +1919,10 @@ schemas: !<!Schemas>
                     name: negative
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - json
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: SentimentConfidenceScorePerLabel
@@ -1955,10 +1947,6 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
-                contexts:
-                - output
-                knownMediaTypes:
-                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_67
@@ -2015,6 +2003,10 @@ schemas: !<!Schemas>
                       name: warnings
                       description: The warnings generated for the sentence.
                   protocol: !<!Protocols> {}
+                serializationFormats:
+                - json
+                usage:
+                - output
                 language: !<!Languages> 
                   default:
                     name: SentenceSentiment
@@ -2033,6 +2025,10 @@ schemas: !<!Schemas>
                 name: sentences
                 description: Sentence level sentiment analysis.
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - json
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: DocumentSentiment
@@ -2088,6 +2084,10 @@ schemas: !<!Schemas>
           name: modelVersion
           description: This field indicates which model is used for scoring.
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: SentimentResponse

--- a/modelerfour/test/scenarios/text-analytics/namer.yaml
+++ b/modelerfour/test/scenarios/text-analytics/namer.yaml
@@ -692,6 +692,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_99
       schema: !<!ArraySchema> &ref_75
@@ -704,6 +708,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_2
@@ -762,6 +770,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_77
@@ -774,6 +786,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_6
@@ -795,6 +811,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_7
@@ -874,6 +894,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_13
@@ -935,6 +959,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_15
@@ -951,6 +979,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_16
@@ -985,6 +1017,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: v3.0-preview.1
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - json
                   properties:
                   - !<!Property> 
                     schema: *ref_19
@@ -1100,6 +1136,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_25
@@ -1177,6 +1217,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_82
@@ -1189,6 +1233,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_35
@@ -1210,6 +1258,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_36
@@ -1231,6 +1283,10 @@ schemas: !<!Schemas>
                       apiVersions:
                       - !<!ApiVersion> 
                         version: v3.0-preview.1
+                      contexts:
+                      - output
+                      knownMediaTypes:
+                      - json
                       properties:
                       - !<!Property> 
                         schema: *ref_37
@@ -1418,6 +1474,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_85
@@ -1430,6 +1490,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_49
@@ -1535,6 +1599,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_120
       schema: !<!ArraySchema> &ref_87
@@ -1547,6 +1615,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - input
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_53
@@ -1605,6 +1677,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_89
@@ -1617,6 +1693,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_57
@@ -1638,6 +1718,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_58
@@ -1761,6 +1845,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: v3.0-preview.1
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_93
@@ -1773,6 +1861,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: v3.0-preview.1
+          contexts:
+          - output
+          knownMediaTypes:
+          - json
           properties:
           - !<!Property> 
             schema: *ref_64
@@ -1807,6 +1899,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: v3.0-preview.1
+              contexts:
+              - output
+              knownMediaTypes:
+              - json
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -1859,6 +1955,10 @@ schemas: !<!Schemas>
                 apiVersions:
                 - !<!ApiVersion> 
                   version: v3.0-preview.1
+                contexts:
+                - output
+                knownMediaTypes:
+                - json
                 properties:
                 - !<!Property> 
                   schema: *ref_67

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
@@ -56,10 +56,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -77,6 +73,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
@@ -56,6 +56,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
@@ -56,10 +56,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -77,6 +73,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
@@ -56,6 +56,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
@@ -56,6 +56,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_3

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
@@ -56,10 +56,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_3
@@ -77,6 +73,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
@@ -56,10 +56,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_0
@@ -77,6 +73,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
@@ -56,6 +56,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_0

--- a/modelerfour/test/scenarios/url/flattened.yaml
+++ b/modelerfour/test/scenarios/url/flattened.yaml
@@ -416,6 +416,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7

--- a/modelerfour/test/scenarios/url/flattened.yaml
+++ b/modelerfour/test/scenarios/url/flattened.yaml
@@ -416,10 +416,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -437,6 +433,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/url/grouped.yaml
+++ b/modelerfour/test/scenarios/url/grouped.yaml
@@ -416,6 +416,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7

--- a/modelerfour/test/scenarios/url/grouped.yaml
+++ b/modelerfour/test/scenarios/url/grouped.yaml
@@ -416,10 +416,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -437,6 +433,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/url/modeler.yaml
+++ b/modelerfour/test/scenarios/url/modeler.yaml
@@ -416,10 +416,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_5
@@ -437,6 +433,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/url/modeler.yaml
+++ b/modelerfour/test/scenarios/url/modeler.yaml
@@ -416,6 +416,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_5

--- a/modelerfour/test/scenarios/url/namer.yaml
+++ b/modelerfour/test/scenarios/url/namer.yaml
@@ -416,6 +416,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_7

--- a/modelerfour/test/scenarios/url/namer.yaml
+++ b/modelerfour/test/scenarios/url/namer.yaml
@@ -416,10 +416,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_7
@@ -437,6 +433,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/validation/flattened.yaml
+++ b/modelerfour/test/scenarios/validation/flattened.yaml
@@ -239,11 +239,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -290,11 +285,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -314,6 +304,11 @@ schemas: !<!Schemas>
               name: count
               description: Count
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ChildProduct
@@ -333,11 +328,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -357,6 +347,11 @@ schemas: !<!Schemas>
               name: constProperty2
               description: Constant string2
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ConstantProduct
@@ -397,6 +392,11 @@ schemas: !<!Schemas>
           name: constStringAsEnum
           description: Constant string as Enum
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Product
@@ -410,10 +410,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -439,6 +435,10 @@ schemas: !<!Schemas>
           name: fields
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/validation/flattened.yaml
+++ b/modelerfour/test/scenarios/validation/flattened.yaml
@@ -239,6 +239,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -285,6 +290,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -323,6 +333,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -395,6 +410,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14

--- a/modelerfour/test/scenarios/validation/grouped.yaml
+++ b/modelerfour/test/scenarios/validation/grouped.yaml
@@ -239,11 +239,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -290,11 +285,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -314,6 +304,11 @@ schemas: !<!Schemas>
               name: count
               description: Count
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ChildProduct
@@ -333,11 +328,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -357,6 +347,11 @@ schemas: !<!Schemas>
               name: constProperty2
               description: Constant string2
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ConstantProduct
@@ -397,6 +392,11 @@ schemas: !<!Schemas>
           name: constStringAsEnum
           description: Constant string as Enum
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Product
@@ -410,10 +410,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -439,6 +435,10 @@ schemas: !<!Schemas>
           name: fields
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/validation/grouped.yaml
+++ b/modelerfour/test/scenarios/validation/grouped.yaml
@@ -239,6 +239,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -285,6 +290,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -323,6 +333,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -395,6 +410,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14

--- a/modelerfour/test/scenarios/validation/modeler.yaml
+++ b/modelerfour/test/scenarios/validation/modeler.yaml
@@ -239,11 +239,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -290,11 +285,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -314,6 +304,11 @@ schemas: !<!Schemas>
               name: count
               description: Count
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ChildProduct
@@ -333,11 +328,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -357,6 +347,11 @@ schemas: !<!Schemas>
               name: constProperty2
               description: Constant string2
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ConstantProduct
@@ -397,6 +392,11 @@ schemas: !<!Schemas>
           name: constStringAsEnum
           description: Constant string as Enum
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Product
@@ -410,10 +410,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -439,6 +435,10 @@ schemas: !<!Schemas>
           name: fields
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/validation/modeler.yaml
+++ b/modelerfour/test/scenarios/validation/modeler.yaml
@@ -239,6 +239,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -285,6 +290,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -323,6 +333,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -395,6 +410,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14

--- a/modelerfour/test/scenarios/validation/namer.yaml
+++ b/modelerfour/test/scenarios/validation/namer.yaml
@@ -239,11 +239,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -290,11 +285,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -314,6 +304,11 @@ schemas: !<!Schemas>
               name: count
               description: Count
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ChildProduct
@@ -333,11 +328,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -357,6 +347,11 @@ schemas: !<!Schemas>
               name: constProperty2
               description: Constant string2
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ConstantProduct
@@ -397,6 +392,11 @@ schemas: !<!Schemas>
           name: constStringAsEnum
           description: Constant string as Enum
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Product
@@ -410,10 +410,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -439,6 +435,10 @@ schemas: !<!Schemas>
           name: fields
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error

--- a/modelerfour/test/scenarios/validation/namer.yaml
+++ b/modelerfour/test/scenarios/validation/namer.yaml
@@ -239,6 +239,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_17
@@ -285,6 +290,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -323,6 +333,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - json
         properties:
         - !<!Property> 
           schema: *ref_7
@@ -395,6 +410,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14

--- a/modelerfour/test/scenarios/xml-service/flattened.yaml
+++ b/modelerfour/test/scenarios/xml-service/flattened.yaml
@@ -1107,6 +1107,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_108
       schema: !<!ObjectSchema> &ref_4
@@ -1114,6 +1119,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_2
@@ -1155,6 +1165,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_114
       schema: !<!ObjectSchema> &ref_7
@@ -1162,6 +1177,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -1208,6 +1228,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1244,6 +1269,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_11
@@ -1318,6 +1348,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -1346,6 +1380,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_123
       schema: !<!ArraySchema> &ref_97
@@ -1402,6 +1441,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -1443,6 +1487,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_22
@@ -1491,6 +1539,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_25
@@ -1507,6 +1559,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_26
@@ -1633,6 +1689,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_53
@@ -1640,6 +1701,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_36
@@ -1683,6 +1749,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - xml
             properties:
             - !<!Property> 
               schema: *ref_40
@@ -1733,6 +1804,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_42
@@ -1801,6 +1877,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_47
@@ -1908,6 +1989,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -1924,6 +2010,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -1982,6 +2073,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -2043,6 +2138,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_103
@@ -2055,6 +2154,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_65
@@ -2093,6 +2196,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -2127,6 +2234,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_69
@@ -2466,6 +2577,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_150
       schema: *ref_15
@@ -2486,6 +2601,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_15

--- a/modelerfour/test/scenarios/xml-service/flattened.yaml
+++ b/modelerfour/test/scenarios/xml-service/flattened.yaml
@@ -1107,11 +1107,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_108
       schema: !<!ObjectSchema> &ref_4
@@ -1119,11 +1114,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_2
@@ -1133,6 +1123,11 @@ schemas: !<!Schemas>
               name: ID
               description: The id of the res
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ComplexTypeNoMeta
@@ -1153,6 +1148,11 @@ schemas: !<!Schemas>
           name: Something
           description: Something else (just to avoid flattening)
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RootWithRefAndNoMeta
@@ -1165,11 +1165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_114
       schema: !<!ObjectSchema> &ref_7
@@ -1177,11 +1172,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -1196,6 +1186,11 @@ schemas: !<!Schemas>
             name: XMLComplexTypeWithMeta
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ComplexTypeWithMeta
@@ -1216,6 +1211,11 @@ schemas: !<!Schemas>
           name: Something
           description: Something else (just to avoid flattening)
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RootWithRefAndMeta
@@ -1228,11 +1228,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1269,11 +1264,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_11
@@ -1314,6 +1304,11 @@ schemas: !<!Schemas>
               name: slide
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: Slide
@@ -1336,6 +1331,11 @@ schemas: !<!Schemas>
         name: slideshow
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Slideshow
@@ -1348,10 +1348,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -1369,6 +1365,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -1380,11 +1380,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_123
       schema: !<!ArraySchema> &ref_97
@@ -1430,6 +1425,11 @@ schemas: !<!Schemas>
           name: BadApples
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: AppleBarrel
@@ -1441,11 +1441,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -1476,6 +1471,11 @@ schemas: !<!Schemas>
         name: banana
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Banana
@@ -1487,10 +1487,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_22
@@ -1539,10 +1535,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_25
@@ -1559,10 +1551,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_26
@@ -1618,6 +1606,10 @@ schemas: !<!Schemas>
                     name: PublicAccess
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ContainerProperties
@@ -1640,6 +1632,10 @@ schemas: !<!Schemas>
                 name: Metadata
                 description: Dictionary of <string>
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Container
@@ -1676,6 +1672,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListContainersResponse
@@ -1689,11 +1689,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_53
@@ -1701,11 +1696,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_36
@@ -1749,11 +1739,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - xml
             properties:
             - !<!Property> 
               schema: *ref_40
@@ -1773,6 +1758,11 @@ schemas: !<!Schemas>
                   name: Days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - xml
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: RetentionPolicy
@@ -1786,6 +1776,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Logging
@@ -1804,11 +1799,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_42
@@ -1846,6 +1836,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Metrics
@@ -1877,11 +1872,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_47
@@ -1935,6 +1925,11 @@ schemas: !<!Schemas>
               name: CorsRule
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: CorsRule
@@ -1974,6 +1969,11 @@ schemas: !<!Schemas>
           name: DeleteRetentionPolicy
           description: the retention policy
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: StorageServiceProperties
@@ -1989,11 +1989,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -2010,11 +2005,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -2043,6 +2033,11 @@ schemas: !<!Schemas>
               name: Permission
               description: the permissions for the acl policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: AccessPolicy
@@ -2061,6 +2056,11 @@ schemas: !<!Schemas>
         name: SignedIdentifier
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: SignedIdentifier
@@ -2073,10 +2073,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -2138,10 +2134,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_103
@@ -2154,10 +2146,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_65
@@ -2168,6 +2156,10 @@ schemas: !<!Schemas>
                     name: Name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobPrefix
@@ -2196,10 +2188,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -2234,10 +2222,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_69
@@ -2491,6 +2475,10 @@ schemas: !<!Schemas>
                         name: ArchiveStatus
                         description: ''
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobProperties
@@ -2518,6 +2506,10 @@ schemas: !<!Schemas>
                   name: Blob
                   attribute: false
                   wrapped: false
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Blob
@@ -2535,6 +2527,10 @@ schemas: !<!Schemas>
               name: Blob
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Blobs
@@ -2562,6 +2558,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsResponse
@@ -2577,10 +2577,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_150
       schema: *ref_15
@@ -2590,6 +2586,10 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: JSONInput
@@ -2601,10 +2601,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -2614,6 +2610,10 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: JSONOutput

--- a/modelerfour/test/scenarios/xml-service/grouped.yaml
+++ b/modelerfour/test/scenarios/xml-service/grouped.yaml
@@ -1107,6 +1107,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_108
       schema: !<!ObjectSchema> &ref_4
@@ -1114,6 +1119,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_2
@@ -1155,6 +1165,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_114
       schema: !<!ObjectSchema> &ref_7
@@ -1162,6 +1177,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -1208,6 +1228,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1244,6 +1269,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_11
@@ -1318,6 +1348,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -1346,6 +1380,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_123
       schema: !<!ArraySchema> &ref_97
@@ -1402,6 +1441,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -1443,6 +1487,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_22
@@ -1491,6 +1539,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_25
@@ -1507,6 +1559,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_26
@@ -1633,6 +1689,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_53
@@ -1640,6 +1701,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_36
@@ -1683,6 +1749,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - xml
             properties:
             - !<!Property> 
               schema: *ref_40
@@ -1733,6 +1804,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_42
@@ -1801,6 +1877,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_47
@@ -1908,6 +1989,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -1924,6 +2010,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -1982,6 +2073,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -2043,6 +2138,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_103
@@ -2055,6 +2154,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_65
@@ -2093,6 +2196,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -2127,6 +2234,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_69
@@ -2466,6 +2577,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_150
       schema: *ref_15
@@ -2486,6 +2601,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_15

--- a/modelerfour/test/scenarios/xml-service/grouped.yaml
+++ b/modelerfour/test/scenarios/xml-service/grouped.yaml
@@ -1107,11 +1107,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_108
       schema: !<!ObjectSchema> &ref_4
@@ -1119,11 +1114,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_2
@@ -1133,6 +1123,11 @@ schemas: !<!Schemas>
               name: ID
               description: The id of the res
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ComplexTypeNoMeta
@@ -1153,6 +1148,11 @@ schemas: !<!Schemas>
           name: Something
           description: Something else (just to avoid flattening)
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RootWithRefAndNoMeta
@@ -1165,11 +1165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_114
       schema: !<!ObjectSchema> &ref_7
@@ -1177,11 +1172,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -1196,6 +1186,11 @@ schemas: !<!Schemas>
             name: XMLComplexTypeWithMeta
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ComplexTypeWithMeta
@@ -1216,6 +1211,11 @@ schemas: !<!Schemas>
           name: Something
           description: Something else (just to avoid flattening)
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RootWithRefAndMeta
@@ -1228,11 +1228,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1269,11 +1264,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_11
@@ -1314,6 +1304,11 @@ schemas: !<!Schemas>
               name: slide
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: Slide
@@ -1336,6 +1331,11 @@ schemas: !<!Schemas>
         name: slideshow
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Slideshow
@@ -1348,10 +1348,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -1369,6 +1365,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -1380,11 +1380,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_123
       schema: !<!ArraySchema> &ref_97
@@ -1430,6 +1425,11 @@ schemas: !<!Schemas>
           name: BadApples
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: AppleBarrel
@@ -1441,11 +1441,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -1476,6 +1471,11 @@ schemas: !<!Schemas>
         name: banana
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Banana
@@ -1487,10 +1487,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_22
@@ -1539,10 +1535,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_25
@@ -1559,10 +1551,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_26
@@ -1618,6 +1606,10 @@ schemas: !<!Schemas>
                     name: PublicAccess
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ContainerProperties
@@ -1640,6 +1632,10 @@ schemas: !<!Schemas>
                 name: Metadata
                 description: Dictionary of <string>
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Container
@@ -1676,6 +1672,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListContainersResponse
@@ -1689,11 +1689,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_53
@@ -1701,11 +1696,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_36
@@ -1749,11 +1739,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - xml
             properties:
             - !<!Property> 
               schema: *ref_40
@@ -1773,6 +1758,11 @@ schemas: !<!Schemas>
                   name: Days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - xml
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: RetentionPolicy
@@ -1786,6 +1776,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Logging
@@ -1804,11 +1799,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_42
@@ -1846,6 +1836,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Metrics
@@ -1877,11 +1872,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_47
@@ -1935,6 +1925,11 @@ schemas: !<!Schemas>
               name: CorsRule
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: CorsRule
@@ -1974,6 +1969,11 @@ schemas: !<!Schemas>
           name: DeleteRetentionPolicy
           description: the retention policy
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: StorageServiceProperties
@@ -1989,11 +1989,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -2010,11 +2005,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -2043,6 +2033,11 @@ schemas: !<!Schemas>
               name: Permission
               description: the permissions for the acl policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: AccessPolicy
@@ -2061,6 +2056,11 @@ schemas: !<!Schemas>
         name: SignedIdentifier
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: SignedIdentifier
@@ -2073,10 +2073,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -2138,10 +2134,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_103
@@ -2154,10 +2146,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_65
@@ -2168,6 +2156,10 @@ schemas: !<!Schemas>
                     name: Name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobPrefix
@@ -2196,10 +2188,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -2234,10 +2222,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_69
@@ -2491,6 +2475,10 @@ schemas: !<!Schemas>
                         name: ArchiveStatus
                         description: ''
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobProperties
@@ -2518,6 +2506,10 @@ schemas: !<!Schemas>
                   name: Blob
                   attribute: false
                   wrapped: false
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Blob
@@ -2535,6 +2527,10 @@ schemas: !<!Schemas>
               name: Blob
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Blobs
@@ -2562,6 +2558,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsResponse
@@ -2577,10 +2577,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_150
       schema: *ref_15
@@ -2590,6 +2586,10 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: JSONInput
@@ -2601,10 +2601,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -2614,6 +2610,10 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: JSONOutput

--- a/modelerfour/test/scenarios/xml-service/modeler.yaml
+++ b/modelerfour/test/scenarios/xml-service/modeler.yaml
@@ -1107,11 +1107,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_2
@@ -1119,11 +1114,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_0
@@ -1133,6 +1123,11 @@ schemas: !<!Schemas>
               name: ID
               description: The id of the res
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ComplexTypeNoMeta
@@ -1153,6 +1148,11 @@ schemas: !<!Schemas>
           name: Something
           description: Something else (just to avoid flattening)
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RootWithRefAndNoMeta
@@ -1165,11 +1165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_5
@@ -1177,11 +1172,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_3
@@ -1196,6 +1186,11 @@ schemas: !<!Schemas>
             name: XMLComplexTypeWithMeta
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ComplexTypeWithMeta
@@ -1216,6 +1211,11 @@ schemas: !<!Schemas>
           name: Something
           description: Something else (just to avoid flattening)
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RootWithRefAndMeta
@@ -1228,11 +1228,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -1269,11 +1264,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_9
@@ -1314,6 +1304,11 @@ schemas: !<!Schemas>
               name: slide
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: Slide
@@ -1336,6 +1331,11 @@ schemas: !<!Schemas>
         name: slideshow
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Slideshow
@@ -1348,10 +1348,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_21
@@ -1369,6 +1365,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -1380,11 +1380,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_75
@@ -1430,6 +1425,11 @@ schemas: !<!Schemas>
           name: BadApples
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: AppleBarrel
@@ -1441,11 +1441,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -1476,6 +1471,11 @@ schemas: !<!Schemas>
         name: banana
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Banana
@@ -1487,10 +1487,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_18
@@ -1539,10 +1535,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_22
@@ -1559,10 +1551,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_88
@@ -1618,6 +1606,10 @@ schemas: !<!Schemas>
                     name: PublicAccess
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ContainerProperties
@@ -1640,6 +1632,10 @@ schemas: !<!Schemas>
                 name: Metadata
                 description: Dictionary of <string>
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Container
@@ -1676,6 +1672,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListContainersResponse
@@ -1689,11 +1689,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_38
@@ -1701,11 +1696,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_29
@@ -1749,11 +1739,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - xml
             properties:
             - !<!Property> 
               schema: *ref_102
@@ -1773,6 +1758,11 @@ schemas: !<!Schemas>
                   name: Days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - xml
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: RetentionPolicy
@@ -1786,6 +1776,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Logging
@@ -1804,11 +1799,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_30
@@ -1846,6 +1836,11 @@ schemas: !<!Schemas>
               name: RetentionPolicy
               description: the retention policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Metrics
@@ -1877,11 +1872,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_33
@@ -1935,6 +1925,11 @@ schemas: !<!Schemas>
               name: CorsRule
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: CorsRule
@@ -1974,6 +1969,11 @@ schemas: !<!Schemas>
           name: DeleteRetentionPolicy
           description: the retention policy
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: StorageServiceProperties
@@ -1989,11 +1989,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_40
@@ -2010,11 +2005,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_89
@@ -2043,6 +2033,11 @@ schemas: !<!Schemas>
               name: Permission
               description: the permissions for the acl policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: AccessPolicy
@@ -2061,6 +2056,11 @@ schemas: !<!Schemas>
         name: SignedIdentifier
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: SignedIdentifier
@@ -2073,10 +2073,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_43
@@ -2138,10 +2134,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_81
@@ -2154,10 +2146,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_48
@@ -2168,6 +2156,10 @@ schemas: !<!Schemas>
                     name: Name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobPrefix
@@ -2196,10 +2188,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_49
@@ -2234,10 +2222,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_91
@@ -2491,6 +2475,10 @@ schemas: !<!Schemas>
                         name: ArchiveStatus
                         description: ''
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobProperties
@@ -2518,6 +2506,10 @@ schemas: !<!Schemas>
                   name: Blob
                   attribute: false
                   wrapped: false
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Blob
@@ -2535,6 +2527,10 @@ schemas: !<!Schemas>
               name: Blob
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Blobs
@@ -2562,6 +2558,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsResponse
@@ -2577,10 +2577,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_21
@@ -2590,6 +2586,10 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: JSONInput
@@ -2601,10 +2601,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_21
@@ -2614,6 +2610,10 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: JSONOutput

--- a/modelerfour/test/scenarios/xml-service/modeler.yaml
+++ b/modelerfour/test/scenarios/xml-service/modeler.yaml
@@ -1107,6 +1107,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_2
@@ -1114,6 +1119,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_0
@@ -1155,6 +1165,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_5
@@ -1162,6 +1177,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_3
@@ -1208,6 +1228,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_6
@@ -1244,6 +1269,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_9
@@ -1318,6 +1348,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_21
@@ -1346,6 +1380,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ArraySchema> &ref_75
@@ -1402,6 +1441,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_16
@@ -1443,6 +1487,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_18
@@ -1491,6 +1539,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_22
@@ -1507,6 +1559,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_88
@@ -1633,6 +1689,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_38
@@ -1640,6 +1701,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_29
@@ -1683,6 +1749,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - xml
             properties:
             - !<!Property> 
               schema: *ref_102
@@ -1733,6 +1804,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_30
@@ -1801,6 +1877,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_33
@@ -1908,6 +1989,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_40
@@ -1924,6 +2010,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_89
@@ -1982,6 +2073,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_43
@@ -2043,6 +2138,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_81
@@ -2055,6 +2154,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_48
@@ -2093,6 +2196,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_49
@@ -2127,6 +2234,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_91
@@ -2466,6 +2577,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_21
@@ -2486,6 +2601,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_21

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -1107,11 +1107,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_108
       schema: !<!ObjectSchema> &ref_4
@@ -1119,11 +1114,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_2
@@ -1133,6 +1123,11 @@ schemas: !<!Schemas>
               name: ID
               description: The id of the res
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ComplexTypeNoMeta
@@ -1153,6 +1148,11 @@ schemas: !<!Schemas>
           name: something
           description: Something else (just to avoid flattening)
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RootWithRefAndNoMeta
@@ -1165,11 +1165,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_114
       schema: !<!ObjectSchema> &ref_7
@@ -1177,11 +1172,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -1196,6 +1186,11 @@ schemas: !<!Schemas>
             name: XMLComplexTypeWithMeta
             attribute: false
             wrapped: false
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: ComplexTypeWithMeta
@@ -1216,6 +1211,11 @@ schemas: !<!Schemas>
           name: something
           description: Something else (just to avoid flattening)
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: RootWithRefAndMeta
@@ -1228,11 +1228,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1269,11 +1264,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_11
@@ -1314,6 +1304,11 @@ schemas: !<!Schemas>
               name: slide
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: Slide
@@ -1336,6 +1331,11 @@ schemas: !<!Schemas>
         name: slideshow
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Slideshow
@@ -1348,10 +1348,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -1369,6 +1365,10 @@ schemas: !<!Schemas>
           name: message
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Error
@@ -1380,11 +1380,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> &ref_123
       schema: !<!ArraySchema> &ref_97
@@ -1430,6 +1425,11 @@ schemas: !<!Schemas>
           name: badApples
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: AppleBarrel
@@ -1441,11 +1441,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -1476,6 +1471,11 @@ schemas: !<!Schemas>
         name: banana
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: Banana
@@ -1487,10 +1487,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_22
@@ -1539,10 +1535,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_25
@@ -1559,10 +1551,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_26
@@ -1618,6 +1606,10 @@ schemas: !<!Schemas>
                     name: publicAccess
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: ContainerProperties
@@ -1640,6 +1632,10 @@ schemas: !<!Schemas>
                 name: metadata
                 description: Dictionary of <string>
             protocol: !<!Protocols> {}
+          serializationFormats:
+          - xml
+          usage:
+          - output
           language: !<!Languages> 
             default:
               name: Container
@@ -1676,6 +1672,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListContainersResponse
@@ -1689,11 +1689,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_53
@@ -1701,11 +1696,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_36
@@ -1749,11 +1739,6 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
-            contexts:
-            - output
-            - input
-            knownMediaTypes:
-            - xml
             properties:
             - !<!Property> 
               schema: *ref_40
@@ -1773,6 +1758,11 @@ schemas: !<!Schemas>
                   name: days
                   description: Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted
               protocol: !<!Protocols> {}
+            serializationFormats:
+            - xml
+            usage:
+            - output
+            - input
             language: !<!Languages> 
               default:
                 name: RetentionPolicy
@@ -1786,6 +1776,11 @@ schemas: !<!Schemas>
               name: retentionPolicy
               description: the retention policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Logging
@@ -1804,11 +1799,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_42
@@ -1846,6 +1836,11 @@ schemas: !<!Schemas>
               name: retentionPolicy
               description: the retention policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: Metrics
@@ -1877,11 +1872,6 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-          contexts:
-          - output
-          - input
-          knownMediaTypes:
-          - xml
           properties:
           - !<!Property> 
             schema: *ref_47
@@ -1935,6 +1925,11 @@ schemas: !<!Schemas>
               name: CorsRule
               attribute: false
               wrapped: false
+          serializationFormats:
+          - xml
+          usage:
+          - output
+          - input
           language: !<!Languages> 
             default:
               name: CorsRule
@@ -1974,6 +1969,11 @@ schemas: !<!Schemas>
           name: deleteRetentionPolicy
           description: the retention policy
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: StorageServiceProperties
@@ -1989,11 +1989,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    - input
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -2010,11 +2005,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        - input
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -2043,6 +2033,11 @@ schemas: !<!Schemas>
               name: permission
               description: the permissions for the acl policy
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
+        - input
         language: !<!Languages> 
           default:
             name: AccessPolicy
@@ -2061,6 +2056,11 @@ schemas: !<!Schemas>
         name: SignedIdentifier
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
+    - input
     language: !<!Languages> 
       default:
         name: SignedIdentifier
@@ -2073,10 +2073,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -2138,10 +2134,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_103
@@ -2154,10 +2146,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_65
@@ -2168,6 +2156,10 @@ schemas: !<!Schemas>
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: BlobPrefix
@@ -2196,10 +2188,6 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-              contexts:
-              - output
-              knownMediaTypes:
-              - xml
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -2234,10 +2222,6 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
-                  contexts:
-                  - output
-                  knownMediaTypes:
-                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_69
@@ -2491,6 +2475,10 @@ schemas: !<!Schemas>
                         name: archiveStatus
                         description: ''
                     protocol: !<!Protocols> {}
+                  serializationFormats:
+                  - xml
+                  usage:
+                  - output
                   language: !<!Languages> 
                     default:
                       name: BlobProperties
@@ -2518,6 +2506,10 @@ schemas: !<!Schemas>
                   name: Blob
                   attribute: false
                   wrapped: false
+              serializationFormats:
+              - xml
+              usage:
+              - output
               language: !<!Languages> 
                 default:
                   name: Blob
@@ -2535,6 +2527,10 @@ schemas: !<!Schemas>
               name: blob
               description: ''
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - xml
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Blobs
@@ -2562,6 +2558,10 @@ schemas: !<!Schemas>
         name: EnumerationResults
         attribute: false
         wrapped: false
+    serializationFormats:
+    - xml
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: ListBlobsResponse
@@ -2577,10 +2577,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - input
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> &ref_150
       schema: *ref_15
@@ -2590,6 +2586,10 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
     language: !<!Languages> 
       default:
         name: JsonInput
@@ -2601,10 +2601,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -2614,6 +2610,10 @@ schemas: !<!Schemas>
           name: id
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: JsonOutput

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -1107,6 +1107,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_108
       schema: !<!ObjectSchema> &ref_4
@@ -1114,6 +1119,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_2
@@ -1155,6 +1165,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_114
       schema: !<!ObjectSchema> &ref_7
@@ -1162,6 +1177,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_5
@@ -1208,6 +1228,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_8
@@ -1244,6 +1269,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_11
@@ -1318,6 +1348,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_15
@@ -1346,6 +1380,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> &ref_123
       schema: !<!ArraySchema> &ref_97
@@ -1402,6 +1441,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_19
@@ -1443,6 +1487,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_22
@@ -1491,6 +1539,10 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_25
@@ -1507,6 +1559,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_26
@@ -1633,6 +1689,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: !<!ObjectSchema> &ref_53
@@ -1640,6 +1701,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_36
@@ -1683,6 +1749,11 @@ schemas: !<!Schemas>
             apiVersions:
             - !<!ApiVersion> 
               version: 1.0.0
+            contexts:
+            - output
+            - input
+            knownMediaTypes:
+            - xml
             properties:
             - !<!Property> 
               schema: *ref_40
@@ -1733,6 +1804,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_42
@@ -1801,6 +1877,11 @@ schemas: !<!Schemas>
           apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
+          contexts:
+          - output
+          - input
+          knownMediaTypes:
+          - xml
           properties:
           - !<!Property> 
             schema: *ref_47
@@ -1908,6 +1989,11 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    - input
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_55
@@ -1924,6 +2010,11 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        - input
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: *ref_56
@@ -1982,6 +2073,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - xml
     properties:
     - !<!Property> 
       schema: *ref_60
@@ -2043,6 +2138,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - xml
         properties:
         - !<!Property> 
           schema: !<!ArraySchema> &ref_103
@@ -2055,6 +2154,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_65
@@ -2093,6 +2196,10 @@ schemas: !<!Schemas>
               apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
+              contexts:
+              - output
+              knownMediaTypes:
+              - xml
               properties:
               - !<!Property> 
                 schema: *ref_66
@@ -2127,6 +2234,10 @@ schemas: !<!Schemas>
                   apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
+                  contexts:
+                  - output
+                  knownMediaTypes:
+                  - xml
                   properties:
                   - !<!Property> 
                     schema: *ref_69
@@ -2466,6 +2577,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - input
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> &ref_150
       schema: *ref_15
@@ -2486,6 +2601,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 1.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_15

--- a/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
@@ -166,6 +166,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_0
@@ -278,6 +282,8 @@ schemas: !<!Schemas>
           immediate:
           - *ref_8
           - *ref_9
+        contexts:
+        - output
         discriminator: !<!Discriminator> 
           all:
             AnimalNotFound: *ref_9
@@ -296,6 +302,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -343,6 +351,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 0.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -440,6 +452,8 @@ schemas: !<!Schemas>
       - *ref_18
       immediate:
       - *ref_15
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         PetHungryOrThirstyError: *ref_18
@@ -447,6 +461,8 @@ schemas: !<!Schemas>
       immediate:
         PetSadError: *ref_15
       property: *ref_21
+    knownMediaTypes:
+    - json
     properties:
     - *ref_21
     - !<!Property> 

--- a/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
@@ -166,10 +166,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_0
@@ -185,6 +181,10 @@ schemas: !<!Schemas>
               name: name
               description: Gets the Pet by id.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Pet
@@ -202,6 +202,10 @@ schemas: !<!Schemas>
           name: aniType
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Animal
@@ -282,8 +286,6 @@ schemas: !<!Schemas>
           immediate:
           - *ref_8
           - *ref_9
-        contexts:
-        - output
         discriminator: !<!Discriminator> 
           all:
             AnimalNotFound: *ref_9
@@ -302,8 +304,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -320,6 +320,10 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - *ref_12
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: NotFoundErrorBase
@@ -339,6 +343,10 @@ schemas: !<!Schemas>
           name: someBaseProp
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BaseError
@@ -351,10 +359,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 0.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -364,6 +368,10 @@ schemas: !<!Schemas>
           name: actionResponse
           description: action feedback
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PetAction
@@ -452,8 +460,6 @@ schemas: !<!Schemas>
       - *ref_18
       immediate:
       - *ref_15
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         PetHungryOrThirstyError: *ref_18
@@ -461,8 +467,6 @@ schemas: !<!Schemas>
       immediate:
         PetSadError: *ref_15
       property: *ref_21
-    knownMediaTypes:
-    - json
     properties:
     - *ref_21
     - !<!Property> 
@@ -474,6 +478,10 @@ schemas: !<!Schemas>
           name: errorMessage
           description: the error message
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PetActionError

--- a/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
@@ -166,6 +166,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_0
@@ -278,6 +282,8 @@ schemas: !<!Schemas>
           immediate:
           - *ref_8
           - *ref_9
+        contexts:
+        - output
         discriminator: !<!Discriminator> 
           all:
             AnimalNotFound: *ref_9
@@ -296,6 +302,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -343,6 +351,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 0.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -440,6 +452,8 @@ schemas: !<!Schemas>
       - *ref_18
       immediate:
       - *ref_15
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         PetHungryOrThirstyError: *ref_18
@@ -447,6 +461,8 @@ schemas: !<!Schemas>
       immediate:
         PetSadError: *ref_15
       property: *ref_21
+    knownMediaTypes:
+    - json
     properties:
     - *ref_21
     - !<!Property> 

--- a/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
@@ -166,10 +166,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_0
@@ -185,6 +181,10 @@ schemas: !<!Schemas>
               name: name
               description: Gets the Pet by id.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Pet
@@ -202,6 +202,10 @@ schemas: !<!Schemas>
           name: aniType
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Animal
@@ -282,8 +286,6 @@ schemas: !<!Schemas>
           immediate:
           - *ref_8
           - *ref_9
-        contexts:
-        - output
         discriminator: !<!Discriminator> 
           all:
             AnimalNotFound: *ref_9
@@ -302,8 +304,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -320,6 +320,10 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - *ref_12
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: NotFoundErrorBase
@@ -339,6 +343,10 @@ schemas: !<!Schemas>
           name: someBaseProp
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BaseError
@@ -351,10 +359,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 0.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -364,6 +368,10 @@ schemas: !<!Schemas>
           name: actionResponse
           description: action feedback
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PetAction
@@ -452,8 +460,6 @@ schemas: !<!Schemas>
       - *ref_18
       immediate:
       - *ref_15
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         PetHungryOrThirstyError: *ref_18
@@ -461,8 +467,6 @@ schemas: !<!Schemas>
       immediate:
         PetSadError: *ref_15
       property: *ref_21
-    knownMediaTypes:
-    - json
     properties:
     - *ref_21
     - !<!Property> 
@@ -474,6 +478,10 @@ schemas: !<!Schemas>
           name: errorMessage
           description: the error message
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PetActionError

--- a/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
@@ -166,6 +166,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_2
@@ -278,6 +282,8 @@ schemas: !<!Schemas>
           immediate:
           - *ref_12
           - *ref_13
+        contexts:
+        - output
         discriminator: !<!Discriminator> 
           all:
             AnimalNotFound: *ref_13
@@ -296,6 +302,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_10
@@ -343,6 +351,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 0.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -440,6 +452,8 @@ schemas: !<!Schemas>
       - *ref_22
       immediate:
       - *ref_21
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         PetHungryOrThirstyError: *ref_22
@@ -447,6 +461,8 @@ schemas: !<!Schemas>
       immediate:
         PetSadError: *ref_21
       property: *ref_17
+    knownMediaTypes:
+    - json
     properties:
     - *ref_17
     - !<!Property> 

--- a/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
@@ -166,10 +166,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_2
@@ -185,6 +181,10 @@ schemas: !<!Schemas>
               name: name
               description: Gets the Pet by id.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Pet
@@ -202,6 +202,10 @@ schemas: !<!Schemas>
           name: aniType
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Animal
@@ -282,8 +286,6 @@ schemas: !<!Schemas>
           immediate:
           - *ref_12
           - *ref_13
-        contexts:
-        - output
         discriminator: !<!Discriminator> 
           all:
             AnimalNotFound: *ref_13
@@ -302,8 +304,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_10
@@ -320,6 +320,10 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - *ref_7
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: NotFoundErrorBase
@@ -339,6 +343,10 @@ schemas: !<!Schemas>
           name: someBaseProp
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BaseError
@@ -351,10 +359,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 0.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -364,6 +368,10 @@ schemas: !<!Schemas>
           name: actionResponse
           description: action feedback
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PetAction
@@ -452,8 +460,6 @@ schemas: !<!Schemas>
       - *ref_22
       immediate:
       - *ref_21
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         PetHungryOrThirstyError: *ref_22
@@ -461,8 +467,6 @@ schemas: !<!Schemas>
       immediate:
         PetSadError: *ref_21
       property: *ref_17
-    knownMediaTypes:
-    - json
     properties:
     - *ref_17
     - !<!Property> 
@@ -474,6 +478,10 @@ schemas: !<!Schemas>
           name: errorMessage
           description: the error message
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PetActionError

--- a/modelerfour/test/scenarios/xms-error-responses/namer.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/namer.yaml
@@ -166,6 +166,10 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
+        contexts:
+        - output
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_0
@@ -278,6 +282,8 @@ schemas: !<!Schemas>
           immediate:
           - *ref_8
           - *ref_9
+        contexts:
+        - output
         discriminator: !<!Discriminator> 
           all:
             AnimalNotFound: *ref_9
@@ -296,6 +302,8 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
+        knownMediaTypes:
+        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -343,6 +351,10 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 0.0.0
+    contexts:
+    - output
+    knownMediaTypes:
+    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -440,6 +452,8 @@ schemas: !<!Schemas>
       - *ref_18
       immediate:
       - *ref_15
+    contexts:
+    - output
     discriminator: !<!Discriminator> 
       all:
         PetHungryOrThirstyError: *ref_18
@@ -447,6 +461,8 @@ schemas: !<!Schemas>
       immediate:
         PetSadError: *ref_15
       property: *ref_21
+    knownMediaTypes:
+    - json
     properties:
     - *ref_21
     - !<!Property> 

--- a/modelerfour/test/scenarios/xms-error-responses/namer.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/namer.yaml
@@ -166,10 +166,6 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
-        contexts:
-        - output
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_0
@@ -185,6 +181,10 @@ schemas: !<!Schemas>
               name: name
               description: Gets the Pet by id.
           protocol: !<!Protocols> {}
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: Pet
@@ -202,6 +202,10 @@ schemas: !<!Schemas>
           name: aniType
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: Animal
@@ -282,8 +286,6 @@ schemas: !<!Schemas>
           immediate:
           - *ref_8
           - *ref_9
-        contexts:
-        - output
         discriminator: !<!Discriminator> 
           all:
             AnimalNotFound: *ref_9
@@ -302,8 +304,6 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
         discriminatorValue: NotFoundErrorBase
-        knownMediaTypes:
-        - json
         parents: !<!Relations> 
           all:
           - *ref_5
@@ -320,6 +320,10 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - *ref_12
+        serializationFormats:
+        - json
+        usage:
+        - output
         language: !<!Languages> 
           default:
             name: NotFoundErrorBase
@@ -339,6 +343,10 @@ schemas: !<!Schemas>
           name: someBaseProp
           description: ''
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: BaseError
@@ -351,10 +359,6 @@ schemas: !<!Schemas>
     apiVersions:
     - !<!ApiVersion> 
       version: 0.0.0
-    contexts:
-    - output
-    knownMediaTypes:
-    - json
     properties:
     - !<!Property> 
       schema: *ref_14
@@ -364,6 +368,10 @@ schemas: !<!Schemas>
           name: actionResponse
           description: action feedback
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PetAction
@@ -452,8 +460,6 @@ schemas: !<!Schemas>
       - *ref_18
       immediate:
       - *ref_15
-    contexts:
-    - output
     discriminator: !<!Discriminator> 
       all:
         PetHungryOrThirstyError: *ref_18
@@ -461,8 +467,6 @@ schemas: !<!Schemas>
       immediate:
         PetSadError: *ref_15
       property: *ref_21
-    knownMediaTypes:
-    - json
     properties:
     - *ref_21
     - !<!Property> 
@@ -474,6 +478,10 @@ schemas: !<!Schemas>
           name: errorMessage
           description: the error message
       protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
     language: !<!Languages> 
       default:
         name: PetActionError


### PR DESCRIPTION
This change is the second half of the fix for Azure/autorest.modelerfour#23, following on from Azure/perks#92.  It adds logic to track the usage of object schemas that are referenced as request or response bodies in operations.  This would enable a language generator to understand what kind of serialization code will be necessary for the schema in all contexts.

I am certainly interested in feedback from @MiYanni and @pakrym about whether this is what you had in mind.  Please take a look at some of the YAML files that got generated as a result of this change to see what it looks like in practice.  I'd love to know if I missed any cases!