### PR TITLE
Switch to the Python generator for regression testing

### DIFF
--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -53,6 +53,19 @@ specs:
      - xml-service.json
      - xms-error-responses.json
 languages:
+  - language: python
+    excludeSpecs:
+      # The following specs aren't yet supported by @autorest/modelerfour
+      - body-formdata-urlencoded.json
+      - body-formdata.json
+    outputPath: ../modelerfour/test/regression/python
+    oldArgs:
+      - --v3
+      - --use:@autorest/python@5.0.0-dev.20200225.1
+    newArgs:
+      - --v3
+      - --use:../modelerfour
+      - --use:@autorest/python@5.0.0-dev.20200225.1
   - language: typescript
     excludeSpecs:
       # The following specs currently crash the v3 TypeScript generator
@@ -72,13 +85,10 @@ languages:
     outputPath: ../modelerfour/test/regression/typescript
     oldArgs:
       - --v3
-      - --version:3.0.6200
       - --package-name:test-package
-      - --use:@autorest/modelerfour@4.5.175
       - --use:@autorest/typescript@0.1.0-dev.20200203.1
     newArgs:
       - --v3
-      - --version:3.0.6200
       - --package-name:test-package
       - --use:../modelerfour
       - --use:@autorest/typescript@0.1.0-dev.20200203.1

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -28,8 +28,12 @@ steps:
 
   displayName: 'Rush install, build and test'
 
-- script: npm install -g @autorest/compare@~0.2.0
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+
+- script: npm install -g @autorest/compare@~0.3.0
   displayName: Install autorest-compare
 
-- script: autorest-compare --compare:.scripts/regression-compare.yaml
-  displayName: Regression Test - @autorest/typescript
+- script: autorest-compare --compare:.scripts/regression-compare.yaml --language:python
+  displayName: Regression Test - @autorest/python


### PR DESCRIPTION
This change leverages the new Python language support in`@autorest/compare` to switch over to the Python generator for regression testing because it has more complete support for the new CodeModel.