### PR TITLE
Update regression test specs and generators

### DIFF
--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -40,7 +40,12 @@ specs:
      - httpInfrastructure.json
      - httpInfrastructure.quirks.json
      - lro.json
+     - media_types.json
      - model-flattening.json
+     - multiapi-v1.json
+     - multiapi-v2.json
+     - multiapi-v3.json
+     - object-type.json
      - paging.json
      - parameter-flattening.json
      - report.json
@@ -61,34 +66,31 @@ languages:
     outputPath: ../modelerfour/test/regression/python
     oldArgs:
       - --v3
-      - --use:@autorest/python@5.0.0-dev.20200225.1
+      - --use:@autorest/python@5.0.0-dev.20200314.1
     newArgs:
       - --v3
       - --use:../modelerfour
-      - --use:@autorest/python@5.0.0-dev.20200225.1
+      - --use:@autorest/python@5.0.0-dev.20200314.1
   - language: typescript
     excludeSpecs:
       # The following specs currently crash the v3 TypeScript generator
-      - additionalProperties.json
-      - azure-parameter-grouping.json
       - azure-special-properties.json
-      - body-array.json
-      - body-dictionary.json
       - body-formdata-urlencoded.json
       - body-formdata.json
-      - custom-baseUrl-paging.json
-      - header.json
       - lro.json
+      - media_types.json
       - model-flattening.json
-      - paging.json
+      - multiapi-v3.json
       - required-optional.json
     outputPath: ../modelerfour/test/regression/typescript
     oldArgs:
       - --v3
       - --package-name:test-package
-      - --use:@autorest/typescript@0.1.0-dev.20200203.1
+      - --title:TestClient
+      - --use:@autorest/typescript@6.0.0-dev.20200325.1
     newArgs:
       - --v3
       - --package-name:test-package
+      - --title:TestClient
       - --use:../modelerfour
-      - --use:@autorest/typescript@0.1.0-dev.20200203.1
+      - --use:@autorest/typescript@6.0.0-dev.20200325.1

--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -66,11 +66,11 @@ languages:
     outputPath: ../modelerfour/test/regression/python
     oldArgs:
       - --v3
-      - --use:@autorest/python@5.0.0-dev.20200314.1
+      - --use:@autorest/python@5.0.0-dev.20200326.1
     newArgs:
       - --v3
       - --use:../modelerfour
-      - --use:@autorest/python@5.0.0-dev.20200314.1
+      - --use:@autorest/python@5.0.0-dev.20200326.1
   - language: typescript
     excludeSpecs:
       # The following specs currently crash the v3 TypeScript generator

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -38,5 +38,5 @@ steps:
 - script: autorest-compare --compare:.scripts/regression-compare.yaml --language:python
   displayName: Regression Test - @autorest/python
 
-- script: autorest-compare --compare:.scripts/regression-compare.yaml --language:typescript
-  displayName: Regression Test - @autorest/typescript
+# - script: autorest-compare --compare:.scripts/regression-compare.yaml --language:typescript
+#   displayName: Regression Test - @autorest/typescript

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -37,3 +37,6 @@ steps:
 
 - script: autorest-compare --compare:.scripts/regression-compare.yaml --language:python
   displayName: Regression Test - @autorest/python
+
+- script: autorest-compare --compare:.scripts/regression-compare.yaml --language:typescript
+  displayName: Regression Test - @autorest/typescript


### PR DESCRIPTION
This change updates our regression testing configuration to use the latest dev version of the Python generator and re-enable testing with the TypeScript generator's latest dev version.  I've also added some of the newer testserver specs that were added recently.