### PR TITLE
Add Azure REST API Specs benchmark CI pipeline and script

### DIFF
--- a/.scripts/benchmark-azure-specs.yaml
+++ b/.scripts/benchmark-azure-specs.yaml
@@ -1,0 +1,35 @@
+# This pipeline is meant to be run manually or scheduled
+trigger: none
+pr: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '12.x'
+  displayName: 'Install Node.js'
+
+- script: |
+    npm install -g npm
+    npm cache clear --force
+
+    npx @microsoft/rush update
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
+    npx @microsoft/rush rebuild
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
+
+  displayName: 'Build Modelerfour'
+
+- script: |
+    npm install -g autorest
+    git clone --no-tags --depth=1 https://github.com/Azure/azure-rest-api-specs
+    node .scripts/run-benchmark.js ./azure-rest-api-specs ./output
+  displayName: Benchmark Azure REST API Specs
+
+- task: PublishPipelineArtifact@1
+  inputs:
+    targetPath: '$(System.DefaultWorkingDirectory)/output'
+    artifactName: benchmark-output
+  displayName: 'Upload Results'

--- a/.scripts/run-benchmark.js
+++ b/.scripts/run-benchmark.js
@@ -1,0 +1,117 @@
+const fs = require("fs");
+const path = require("path");
+const cp = require("child_process");
+
+const specsRepoPath = process.argv[2];
+const outputBasePath = process.argv[3];
+
+const specsPath = path.join(specsRepoPath, "specification");
+
+function getReadmesRecursively(folderPath) {
+  let filesInPath = [];
+
+  if (!fs.existsSync(folderPath)) {
+    return [];
+  }
+
+  for (const childPath of fs.readdirSync(folderPath)) {
+    const rootedPath = path.join(folderPath, childPath);
+    if (fs.statSync(rootedPath).isDirectory()) {
+      filesInPath = filesInPath.concat(getReadmesRecursively(rootedPath));
+    } else if (path.basename(rootedPath).match(/README.md/i)) {
+      filesInPath.push(rootedPath);
+    }
+  }
+
+  return filesInPath;
+}
+
+function executeBenchmark(readmePath) {
+  const relativePath = path.relative(path.dirname(specsRepoPath), readmePath);
+  const outputPath = path.join("output", path.dirname(relativePath));
+
+  fs.mkdirSync(outputPath, { recursive: true });
+
+  const fileStream = fs.openSync(
+    path.join(outputPath, "autorest-output.txt"),
+    "w"
+  );
+
+  console.log(relativePath);
+
+  let result = "succeeded";
+  let resultColor = "\033[1;32m";
+  const startTime = process.hrtime();
+  try {
+    const autoRestProcess = cp.execSync(
+      `autorest --v3 \
+                --debug \
+                --use=./modelerfour \
+                --inspector \
+                --inspector.output-folder="./${outputPath}" \
+                --output-folder="./${outputPath}" \
+                "${readmePath}"`,
+      { stdio: ["inherit", fileStream, fileStream] }
+    );
+  } catch (err) {
+    result = "failed";
+    resultColor = "\033[1;31m";
+  }
+
+  const elapsedTime = process.hrtime(startTime);
+  const elapsedSeconds = (elapsedTime[0] + elapsedTime[1] / 1000000000).toFixed(
+    3
+  );
+  console.log(`  └ ${resultColor}${result} in ${elapsedSeconds}`, "\033[0m\n");
+
+  return {
+    specPath: readmePath,
+    outputPath,
+    succeeded: result === "succeeded",
+    time: parseFloat(elapsedSeconds)
+  };
+}
+
+// Add some space for output
+console.log("");
+
+const readmePaths = getReadmesRecursively(specsPath);
+
+const results = readmePaths
+  .map(executeBenchmark)
+  .sort((a, b) => b.time - a.time);
+
+let aggregate = results.reduce(
+  (totals, result) => {
+    totals.success += result.succeeded === true ? 1 : 0;
+    totals.time += result.time;
+    return totals;
+  },
+  { time: 0.0, success: 0 }
+);
+
+const successPercentage = ((aggregate.success / results.length) * 100).toFixed(
+  2
+);
+
+console.log(
+  `${aggregate.success} out of ${
+    results.length
+  } succeeded (${successPercentage}%), ${aggregate.time.toFixed(
+    3
+  )}s total time\n`
+);
+
+const topCount = Math.min(5, results.length);
+console.log(`Top ${topCount} longest runs:\n`);
+results
+  .slice(0, topCount)
+  .forEach(r => console.log(`${r.time}s  ${r.specPath}`));
+
+// Write out aggregate results file
+const resultsFile = fs.writeFileSync(
+  path.join(outputBasePath, "autorest-benchmark-results.csv"),
+  results
+    .map(r => `${r.specPath},${r.succeeded ? "succeeded" : "failed"},${r.time}`)
+    .join("\n")
+);


### PR DESCRIPTION
This change adds a CI pipeline and Node.js script that runs all specs in the `azure-rest-api-specs` repo through AutoRest v3 and the latest changes in the `autorest.modelerfour` repo to benchmark runtime and figure out which specs we still fail on.  It works by searching the `azure-rest-api-specs/specification` folder for all `README.md` files and then running AutoRest with `--inspector` turned on to capture

Once all of the specs are run, a CSV file is written out with runtime and success/failure information for each spec.  The script also reports on the top 5 longest-running specs and the total percentage that successfully completed.  Finally, all of the output from each run (including stdout/stderr logs) are uploaded as artifacts for the CI run.

Here's an example CI run:

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=337930&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=5caf77c8-9b10-50ef-b5c7-ca89c63e1c86

The aggregate results from that run are as follows:

```
139 out of 214 succeeded (64.95%), 1410.568s total time

Top 5 longest runs:

85.621s  azure-rest-api-specs/specification/sql/resource-manager/readme.md
70.005s  azure-rest-api-specs/specification/network/resource-manager/readme.md
35.613s  azure-rest-api-specs/specification/web/resource-manager/readme.md
33.191s  azure-rest-api-specs/specification/apimanagement/resource-manager/readme.md
28.478s  azure-rest-api-specs/specification/servicefabric/data-plane/readme.md
```

Once we're happy with this change, my plan is to turn this on for nightly runs on `master`.