### PR TITLE
Propagate schema usage to elements schemas of array and dictionary schemas

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -1530,7 +1530,7 @@ export class ModelerFour {
           const schema = mediatypes[0].schema.instance;
 
           if (schema) {
-            let s = this.processSchema('response', schema);
+            let s = this.processSchema(mediatypes[0].schema.name || 'response', schema);
 
             // response schemas should not be constant types.
             // this replaces the constant value with the value type itself.
@@ -1713,22 +1713,17 @@ export class ModelerFour {
 
     const innerApplySchemaUsage = (schema: Schema, schemaUsage: SchemaUsage) => {
       this.trackSchemaUsage(schema, schemaUsage);
-      innerPropagateSchemaUsage(schema);
+      innerPropagateSchemaUsage(schema, schemaUsage);
     };
 
-    const innerPropagateSchemaUsage = (schema: Schema) => {
-      const schemaUsage = schema as SchemaUsage;
-      if (!schemaUsage.usage && !schemaUsage.serializationFormats) {
-        return;
-      }
-
+    const innerPropagateSchemaUsage = (schema: Schema, schemaUsage: SchemaUsage) => {
       if (processedSchemas.has(schema)) {
         return;
       }
 
       processedSchemas.add(schema);
       if (schema instanceof ObjectSchema) {
-        if (schema.usage || schema.serializationFormats) {
+        if (schemaUsage.usage || schemaUsage.serializationFormats) {
           schema.properties?.forEach(p => innerApplySchemaUsage(p.schema, schemaUsage));
 
           schema.parents?.all?.forEach(p => innerApplySchemaUsage(p, schemaUsage));
@@ -1751,7 +1746,8 @@ export class ModelerFour {
       }
     }
 
-    innerPropagateSchemaUsage(schema);
+    // Propagate the usage of the initial schema itself
+    innerPropagateSchemaUsage(schema, schema as SchemaUsage);
   }
 
   private trackSchemaUsage(schema: Schema, schemaUsage: SchemaUsage): void {

--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -1758,6 +1758,32 @@ schemas: !<!Schemas>
         description: ''
         namespace: ''
     protocol: !<!Protocols> {}
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2016-02-29'
+    properties:
+    - !<!Property> 
+      schema: *ref_62
+      serializedName: propBH1
+      language: !<!Languages> 
+        default:
+          name: propBH1
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MyBaseHelperType
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_37
   - *ref_40
   - *ref_43

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -1758,6 +1758,32 @@ schemas: !<!Schemas>
         description: ''
         namespace: ''
     protocol: !<!Protocols> {}
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2016-02-29'
+    properties:
+    - !<!Property> 
+      schema: *ref_62
+      serializedName: propBH1
+      language: !<!Languages> 
+        default:
+          name: propBH1
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MyBaseHelperType
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_37
   - *ref_40
   - *ref_43

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -1758,6 +1758,32 @@ schemas: !<!Schemas>
         description: ''
         namespace: ''
     protocol: !<!Protocols> {}
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2016-02-29'
+    properties:
+    - !<!Property> 
+      schema: *ref_62
+      serializedName: propBH1
+      language: !<!Languages> 
+        default:
+          name: propBH1
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MyBaseHelperType
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_37
   - *ref_40
   - *ref_43

--- a/modelerfour/test/scenarios/advisor/flattened.yaml
+++ b/modelerfour/test/scenarios/advisor/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: AdvisorManagementClient
 schemas: !<!Schemas> 
   booleans:
-  - !<!BooleanSchema> &ref_20
+  - !<!BooleanSchema> &ref_23
     type: boolean
     language: !<!Languages> 
       default:
@@ -112,7 +112,7 @@ schemas: !<!Schemas>
         name: MetadataSupportedValueDetail-displayName
         description: The display name.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
+  - !<!StringSchema> &ref_15
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -122,7 +122,7 @@ schemas: !<!Schemas>
         name: ARMErrorResponseBody-message
         description: Gets or sets the string that describes the error in detail and provides debugging information.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
+  - !<!StringSchema> &ref_16
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -132,7 +132,7 @@ schemas: !<!Schemas>
         name: ARMErrorResponseBody-code
         description: Gets or sets the string that can be used to programmatically identify the error.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
+  - !<!StringSchema> &ref_18
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         name: MetadataEntityListResult-nextLink
         description: The link used to get the next page of metadata.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_16
+  - !<!StringSchema> &ref_19
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -152,7 +152,7 @@ schemas: !<!Schemas>
         name: ConfigData-id
         description: The resource Id of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_17
+  - !<!StringSchema> &ref_20
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
         name: ConfigData-type
         description: The type of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_18
+  - !<!StringSchema> &ref_21
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         name: ConfigData-name
         description: The name of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_21
+  - !<!StringSchema> &ref_24
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
         name: ConfigData-properties-low_cpu_threshold
         description: 'Minimum percentage threshold for Advisor low CPU utilization evaluation. Valid only for subscriptions. Valid values: 5 (default), 10, 15 or 20.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
+  - !<!StringSchema> &ref_25
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -213,7 +213,7 @@ schemas: !<!Schemas>
         name: string
         description: ''
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
+  - !<!StringSchema> &ref_28
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -223,7 +223,7 @@ schemas: !<!Schemas>
         name: ResourceRecommendationBaseListResult-nextLink
         description: The link used to get the next page of recommendations.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
+  - !<!StringSchema> &ref_34
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -233,7 +233,7 @@ schemas: !<!Schemas>
         name: Resource-id
         description: The resource ID.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
+  - !<!StringSchema> &ref_35
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -243,7 +243,7 @@ schemas: !<!Schemas>
         name: Resource-name
         description: The name of the resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
+  - !<!StringSchema> &ref_36
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -253,7 +253,7 @@ schemas: !<!Schemas>
         name: Resource-type
         description: The type of the resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
+  - !<!StringSchema> &ref_39
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -263,7 +263,7 @@ schemas: !<!Schemas>
         name: RecommendationProperties-impactedField
         description: The resource type identified by Advisor.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
+  - !<!StringSchema> &ref_40
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -273,7 +273,7 @@ schemas: !<!Schemas>
         name: RecommendationProperties-impactedValue
         description: The resource identified by Advisor.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_40
+  - !<!StringSchema> &ref_43
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -283,7 +283,7 @@ schemas: !<!Schemas>
         name: RecommendationProperties-recommendationTypeId
         description: The recommendation-type GUID.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_42
+  - !<!StringSchema> &ref_45
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -293,7 +293,7 @@ schemas: !<!Schemas>
         name: ShortDescription-problem
         description: The issue or opportunity identified by the recommendation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_43
+  - !<!StringSchema> &ref_46
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -303,7 +303,7 @@ schemas: !<!Schemas>
         name: ShortDescription-solution
         description: The remediation action suggested by the recommendation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
+  - !<!StringSchema> &ref_51
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -313,7 +313,7 @@ schemas: !<!Schemas>
         name: OperationEntityListResult-nextLink
         description: The link used to get the next page of operations.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_48
+  - !<!StringSchema> &ref_52
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -323,7 +323,7 @@ schemas: !<!Schemas>
         name: OperationEntity-name
         description: 'Operation name: {provider}/{resource}/{operation}.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_49
+  - !<!StringSchema> &ref_53
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -333,7 +333,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfo-description
         description: The description of the operation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_50
+  - !<!StringSchema> &ref_54
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -343,7 +343,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfo-operation
         description: 'The action that users can perform, based on their permission level.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_51
+  - !<!StringSchema> &ref_55
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -353,7 +353,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfo-provider
         description: 'Service provider: Microsoft Advisor.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_52
+  - !<!StringSchema> &ref_56
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -363,7 +363,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfo-resource
         description: Resource on which the operation is performed.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_28
+  - !<!StringSchema> &ref_31
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -373,7 +373,7 @@ schemas: !<!Schemas>
         name: SuppressionProperties-suppressionId
         description: The GUID of the suppression.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
+  - !<!StringSchema> &ref_32
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
         name: SuppressionProperties-ttl
         description: The duration for which the suppression is valid.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_55
+  - !<!StringSchema> &ref_59
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -394,7 +394,7 @@ schemas: !<!Schemas>
         description: The link used to get the next page of suppressions.
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_34
+  - !<!ChoiceSchema> &ref_37
     choices:
     - !<!ChoiceValue> 
       value: HighAvailability
@@ -436,7 +436,7 @@ schemas: !<!Schemas>
         name: category
         description: The category of the recommendation.
     protocol: !<!Protocols> {}
-  - !<!ChoiceSchema> &ref_35
+  - !<!ChoiceSchema> &ref_38
     choices:
     - !<!ChoiceValue> 
       value: High
@@ -466,7 +466,7 @@ schemas: !<!Schemas>
         name: impact
         description: The business impact of the recommendation.
     protocol: !<!Protocols> {}
-  - !<!ChoiceSchema> &ref_41
+  - !<!ChoiceSchema> &ref_44
     choices:
     - !<!ChoiceValue> 
       value: Error
@@ -521,7 +521,7 @@ schemas: !<!Schemas>
         description: ''
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_19
+  - !<!DictionarySchema> &ref_22
     type: dictionary
     elementType: !<!AnySchema> &ref_1
       type: any
@@ -535,7 +535,7 @@ schemas: !<!Schemas>
         name: ConfigData-properties
         description: The list of property name/value pairs.
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_39
+  - !<!DictionarySchema> &ref_42
     type: dictionary
     elementType: *ref_1
     language: !<!Languages> 
@@ -543,7 +543,7 @@ schemas: !<!Schemas>
         name: RecommendationProperties-metadata
         description: The recommendation metadata.
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_45
+  - !<!DictionarySchema> &ref_48
     type: dictionary
     elementType: *ref_2
     language: !<!Languages> 
@@ -554,7 +554,7 @@ schemas: !<!Schemas>
   any:
   - *ref_1
   dateTimes:
-  - !<!DateTimeSchema> &ref_38
+  - !<!DateTimeSchema> &ref_41
     type: date-time
     format: date-time
     apiVersions:
@@ -576,7 +576,7 @@ schemas: !<!Schemas>
         name: uuid
         description: ''
     protocol: !<!Protocols> {}
-  - !<!UuidSchema> &ref_44
+  - !<!UuidSchema> &ref_47
     type: uuid
     apiVersions:
     - !<!ApiVersion> 
@@ -587,7 +587,7 @@ schemas: !<!Schemas>
         description: ''
     protocol: !<!Protocols> {}
   objects:
-  - !<!ObjectSchema> &ref_14
+  - !<!ObjectSchema> &ref_17
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -629,7 +629,7 @@ schemas: !<!Schemas>
           description: The display name.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_56
+      schema: !<!ArraySchema> &ref_11
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -650,7 +650,7 @@ schemas: !<!Schemas>
           description: The list of keys on which this entity depends on.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_57
+      schema: !<!ArraySchema> &ref_12
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -671,12 +671,12 @@ schemas: !<!Schemas>
           description: The list of scenarios applicable to this metadata entity.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_58
+      schema: !<!ArraySchema> &ref_13
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_11
+        elementType: !<!ObjectSchema> &ref_14
           type: object
           apiVersions:
           - !<!ApiVersion> 
@@ -732,7 +732,57 @@ schemas: !<!Schemas>
         description: The metadata entity contract.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_11
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_6
+      serializedName: displayName
+      language: !<!Languages> 
+        default:
+          name: displayName
+          description: The display name.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_11
+      serializedName: dependsOn
+      language: !<!Languages> 
+        default:
+          name: dependsOn
+          description: The list of keys on which this entity depends on.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_12
+      serializedName: applicableScenarios
+      language: !<!Languages> 
+        default:
+          name: applicableScenarios
+          description: The list of scenarios applicable to this metadata entity.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: supportedValues
+      language: !<!Languages> 
+        default:
+          name: supportedValues
+          description: The list of supported values.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MetadataEntityProperties
+        description: The metadata entity properties
+        namespace: ''
+    protocol: !<!Protocols> {}
+  - *ref_14
   - !<!ObjectSchema> &ref_70
     type: object
     apiVersions:
@@ -740,7 +790,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_12
+      schema: *ref_15
       serializedName: message
       language: !<!Languages> 
         default:
@@ -748,7 +798,7 @@ schemas: !<!Schemas>
           description: Gets or sets the string that describes the error in detail and provides debugging information.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_13
+      schema: *ref_16
       serializedName: code
       language: !<!Languages> 
         default:
@@ -772,12 +822,12 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_59
+      schema: !<!ArraySchema> &ref_60
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: *ref_14
+        elementType: *ref_17
         language: !<!Languages> 
           default:
             name: MetadataEntityListResult-value
@@ -790,7 +840,7 @@ schemas: !<!Schemas>
           description: The list of metadata entities.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_15
+      schema: *ref_18
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -814,19 +864,19 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_60
+      schema: !<!ArraySchema> &ref_61
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_23
+        elementType: !<!ObjectSchema> &ref_26
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           properties:
           - !<!Property> 
-            schema: *ref_16
+            schema: *ref_19
             serializedName: id
             language: !<!Languages> 
               default:
@@ -834,7 +884,7 @@ schemas: !<!Schemas>
                 description: The resource Id of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_17
+            schema: *ref_20
             serializedName: type
             language: !<!Languages> 
               default:
@@ -842,7 +892,7 @@ schemas: !<!Schemas>
                 description: The type of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_18
+            schema: *ref_21
             serializedName: name
             language: !<!Languages> 
               default:
@@ -850,19 +900,19 @@ schemas: !<!Schemas>
                 description: The name of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_24
+            schema: !<!ObjectSchema> &ref_27
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               parents: !<!Relations> 
                 all:
-                - *ref_19
+                - *ref_22
                 immediate:
-                - *ref_19
+                - *ref_22
               properties:
               - !<!Property> 
-                schema: *ref_20
+                schema: *ref_23
                 serializedName: exclude
                 language: !<!Languages> 
                   default:
@@ -870,7 +920,7 @@ schemas: !<!Schemas>
                     description: 'Exclude the resource from Advisor evaluations. Valid values: False (default) or True.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_21
+                schema: *ref_24
                 serializedName: low_cpu_threshold
                 language: !<!Languages> 
                   default:
@@ -880,8 +930,8 @@ schemas: !<!Schemas>
               serializationFormats:
               - json
               usage:
-              - input
               - output
+              - input
               language: !<!Languages> 
                 default:
                   name: ConfigData-properties
@@ -917,7 +967,7 @@ schemas: !<!Schemas>
           description: The list of configurations.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_22
+      schema: *ref_25
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -934,8 +984,8 @@ schemas: !<!Schemas>
         description: The list of Advisor configurations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_23
-  - *ref_24
+  - *ref_26
+  - *ref_27
   - !<!ObjectSchema> &ref_85
     type: object
     apiVersions:
@@ -943,7 +993,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_25
+      schema: *ref_28
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -956,34 +1006,34 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_26
+        elementType: !<!ObjectSchema> &ref_29
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           parents: !<!Relations> 
             all:
-            - !<!ObjectSchema> &ref_27
+            - !<!ObjectSchema> &ref_30
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               children: !<!Relations> 
                 all:
-                - *ref_26
-                - !<!ObjectSchema> &ref_30
+                - *ref_29
+                - !<!ObjectSchema> &ref_33
                   type: object
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2017-04-19'
                   parents: !<!Relations> 
                     all:
-                    - *ref_27
+                    - *ref_30
                     immediate:
-                    - *ref_27
+                    - *ref_30
                   properties:
                   - !<!Property> &ref_93
-                    schema: *ref_28
+                    schema: *ref_31
                     flattenedNames:
                     - properties
                     - suppressionId
@@ -994,7 +1044,7 @@ schemas: !<!Schemas>
                         description: The GUID of the suppression.
                     protocol: !<!Protocols> {}
                   - !<!Property> &ref_94
-                    schema: *ref_29
+                    schema: *ref_32
                     flattenedNames:
                     - properties
                     - ttl
@@ -1016,11 +1066,11 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
                 immediate:
-                - *ref_26
-                - *ref_30
+                - *ref_29
+                - *ref_33
               properties:
               - !<!Property> 
-                schema: *ref_31
+                schema: *ref_34
                 readOnly: true
                 serializedName: id
                 language: !<!Languages> 
@@ -1029,7 +1079,7 @@ schemas: !<!Schemas>
                     description: The resource ID.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_32
+                schema: *ref_35
                 readOnly: true
                 serializedName: name
                 language: !<!Languages> 
@@ -1038,7 +1088,7 @@ schemas: !<!Schemas>
                     description: The name of the resource.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_33
+                schema: *ref_36
                 readOnly: true
                 serializedName: type
                 language: !<!Languages> 
@@ -1060,10 +1110,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
             immediate:
-            - *ref_27
+            - *ref_30
           properties:
           - !<!Property> 
-            schema: *ref_34
+            schema: *ref_37
             flattenedNames:
             - properties
             - category
@@ -1074,7 +1124,7 @@ schemas: !<!Schemas>
                 description: The category of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_35
+            schema: *ref_38
             flattenedNames:
             - properties
             - impact
@@ -1085,7 +1135,7 @@ schemas: !<!Schemas>
                 description: The business impact of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_36
+            schema: *ref_39
             flattenedNames:
             - properties
             - impactedField
@@ -1096,7 +1146,7 @@ schemas: !<!Schemas>
                 description: The resource type identified by Advisor.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_37
+            schema: *ref_40
             flattenedNames:
             - properties
             - impactedValue
@@ -1107,7 +1157,7 @@ schemas: !<!Schemas>
                 description: The resource identified by Advisor.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_38
+            schema: *ref_41
             flattenedNames:
             - properties
             - lastUpdated
@@ -1118,7 +1168,7 @@ schemas: !<!Schemas>
                 description: The most recent time that Advisor checked the validity of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_39
+            schema: *ref_42
             flattenedNames:
             - properties
             - metadata
@@ -1129,7 +1179,7 @@ schemas: !<!Schemas>
                 description: The recommendation metadata.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_40
+            schema: *ref_43
             flattenedNames:
             - properties
             - recommendationTypeId
@@ -1140,7 +1190,7 @@ schemas: !<!Schemas>
                 description: The recommendation-type GUID.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_41
+            schema: *ref_44
             flattenedNames:
             - properties
             - risk
@@ -1151,14 +1201,14 @@ schemas: !<!Schemas>
                 description: The potential risk of not implementing the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_46
+            schema: !<!ObjectSchema> &ref_49
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               properties:
               - !<!Property> 
-                schema: *ref_42
+                schema: *ref_45
                 serializedName: problem
                 language: !<!Languages> 
                   default:
@@ -1166,7 +1216,7 @@ schemas: !<!Schemas>
                     description: The issue or opportunity identified by the recommendation.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_43
+                schema: *ref_46
                 serializedName: solution
                 language: !<!Languages> 
                   default:
@@ -1194,12 +1244,12 @@ schemas: !<!Schemas>
                 description: A summary of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ArraySchema> &ref_61
+            schema: !<!ArraySchema> &ref_50
               type: array
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
-              elementType: *ref_44
+              elementType: *ref_47
               language: !<!Languages> 
                 default:
                   name: RecommendationProperties-suppressionIds
@@ -1215,7 +1265,7 @@ schemas: !<!Schemas>
                 description: The list of snoozed and dismissed rules for the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_45
+            schema: *ref_48
             flattenedNames:
             - properties
             - extendedProperties
@@ -1257,9 +1307,116 @@ schemas: !<!Schemas>
         description: The list of Advisor recommendations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_27
-  - *ref_26
-  - *ref_46
+  - *ref_30
+  - *ref_29
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_37
+      serializedName: category
+      language: !<!Languages> 
+        default:
+          name: category
+          description: The category of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_38
+      serializedName: impact
+      language: !<!Languages> 
+        default:
+          name: impact
+          description: The business impact of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_39
+      serializedName: impactedField
+      language: !<!Languages> 
+        default:
+          name: impactedField
+          description: The resource type identified by Advisor.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_40
+      serializedName: impactedValue
+      language: !<!Languages> 
+        default:
+          name: impactedValue
+          description: The resource identified by Advisor.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_41
+      serializedName: lastUpdated
+      language: !<!Languages> 
+        default:
+          name: lastUpdated
+          description: The most recent time that Advisor checked the validity of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_42
+      serializedName: metadata
+      language: !<!Languages> 
+        default:
+          name: metadata
+          description: The recommendation metadata.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_43
+      serializedName: recommendationTypeId
+      language: !<!Languages> 
+        default:
+          name: recommendationTypeId
+          description: The recommendation-type GUID.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_44
+      serializedName: risk
+      language: !<!Languages> 
+        default:
+          name: risk
+          description: The potential risk of not implementing the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_49
+      serializedName: shortDescription
+      language: !<!Languages> 
+        default:
+          name: shortDescription
+          description: A summary of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_50
+      serializedName: suppressionIds
+      language: !<!Languages> 
+        default:
+          name: suppressionIds
+          description: The list of snoozed and dismissed rules for the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_48
+      serializedName: extendedProperties
+      language: !<!Languages> 
+        default:
+          name: extendedProperties
+          description: Extended properties
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: RecommendationProperties
+        description: The properties of the recommendation.
+        namespace: ''
+    protocol: !<!Protocols> {}
+  - *ref_49
   - !<!ObjectSchema> &ref_88
     type: object
     apiVersions:
@@ -1267,7 +1424,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_47
+      schema: *ref_51
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -1280,14 +1437,14 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_53
+        elementType: !<!ObjectSchema> &ref_57
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           properties:
           - !<!Property> 
-            schema: *ref_48
+            schema: *ref_52
             serializedName: name
             language: !<!Languages> 
               default:
@@ -1295,14 +1452,14 @@ schemas: !<!Schemas>
                 description: 'Operation name: {provider}/{resource}/{operation}.'
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_54
+            schema: !<!ObjectSchema> &ref_58
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               properties:
               - !<!Property> 
-                schema: *ref_49
+                schema: *ref_53
                 serializedName: description
                 language: !<!Languages> 
                   default:
@@ -1310,7 +1467,7 @@ schemas: !<!Schemas>
                     description: The description of the operation.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_50
+                schema: *ref_54
                 serializedName: operation
                 language: !<!Languages> 
                   default:
@@ -1318,7 +1475,7 @@ schemas: !<!Schemas>
                     description: 'The action that users can perform, based on their permission level.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_51
+                schema: *ref_55
                 serializedName: provider
                 language: !<!Languages> 
                   default:
@@ -1326,7 +1483,7 @@ schemas: !<!Schemas>
                     description: 'Service provider: Microsoft Advisor.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_52
+                schema: *ref_56
                 serializedName: resource
                 language: !<!Languages> 
                   default:
@@ -1380,9 +1537,44 @@ schemas: !<!Schemas>
         description: The list of Advisor operations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_53
-  - *ref_54
-  - *ref_30
+  - *ref_57
+  - *ref_58
+  - *ref_33
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_31
+      serializedName: suppressionId
+      language: !<!Languages> 
+        default:
+          name: suppressionId
+          description: The GUID of the suppression.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_32
+      serializedName: ttl
+      language: !<!Languages> 
+        default:
+          name: ttl
+          description: The duration for which the suppression is valid.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SuppressionProperties
+        description: The properties of the suppression.
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_105
     type: object
     apiVersions:
@@ -1390,7 +1582,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_55
+      schema: *ref_59
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -1403,7 +1595,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: *ref_30
+        elementType: *ref_33
         language: !<!Languages> 
           default:
             name: SuppressionContractListResult-value
@@ -1426,12 +1618,12 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   arrays:
-  - *ref_56
-  - *ref_57
-  - *ref_58
-  - *ref_59
+  - *ref_11
+  - *ref_12
+  - *ref_13
   - *ref_60
   - *ref_61
+  - *ref_50
   - *ref_62
   - *ref_63
   - *ref_64
@@ -1517,7 +1709,7 @@ operationGroups:
     - *ref_69
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1657,7 +1849,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_74
-        schema: *ref_23
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1794,7 +1986,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_76
-        schema: *ref_23
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2084,7 +2276,7 @@ operationGroups:
     - *ref_87
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2220,7 +2412,7 @@ operationGroups:
     - *ref_91
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2284,7 +2476,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_92
-        schema: *ref_30
+        schema: *ref_33
         flattened: true
         implementation: Method
         required: true
@@ -2297,7 +2489,7 @@ operationGroups:
             in: body
             style: json
       - !<!VirtualParameter> &ref_95
-        schema: *ref_28
+        schema: *ref_31
         implementation: Method
         originalParameter: *ref_92
         pathToProperty: []
@@ -2308,7 +2500,7 @@ operationGroups:
             description: The GUID of the suppression.
         protocol: !<!Protocols> {}
       - !<!VirtualParameter> &ref_96
-        schema: *ref_29
+        schema: *ref_32
         implementation: Method
         originalParameter: *ref_92
         pathToProperty: []
@@ -2339,7 +2531,7 @@ operationGroups:
     - *ref_99
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/scenarios/advisor/grouped.yaml
+++ b/modelerfour/test/scenarios/advisor/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: AdvisorManagementClient
 schemas: !<!Schemas> 
   booleans:
-  - !<!BooleanSchema> &ref_20
+  - !<!BooleanSchema> &ref_23
     type: boolean
     language: !<!Languages> 
       default:
@@ -112,7 +112,7 @@ schemas: !<!Schemas>
         name: MetadataSupportedValueDetail-displayName
         description: The display name.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
+  - !<!StringSchema> &ref_15
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -122,7 +122,7 @@ schemas: !<!Schemas>
         name: ARMErrorResponseBody-message
         description: Gets or sets the string that describes the error in detail and provides debugging information.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
+  - !<!StringSchema> &ref_16
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -132,7 +132,7 @@ schemas: !<!Schemas>
         name: ARMErrorResponseBody-code
         description: Gets or sets the string that can be used to programmatically identify the error.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
+  - !<!StringSchema> &ref_18
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         name: MetadataEntityListResult-nextLink
         description: The link used to get the next page of metadata.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_16
+  - !<!StringSchema> &ref_19
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -152,7 +152,7 @@ schemas: !<!Schemas>
         name: ConfigData-id
         description: The resource Id of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_17
+  - !<!StringSchema> &ref_20
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
         name: ConfigData-type
         description: The type of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_18
+  - !<!StringSchema> &ref_21
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         name: ConfigData-name
         description: The name of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_21
+  - !<!StringSchema> &ref_24
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
         name: ConfigData-properties-low_cpu_threshold
         description: 'Minimum percentage threshold for Advisor low CPU utilization evaluation. Valid only for subscriptions. Valid values: 5 (default), 10, 15 or 20.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
+  - !<!StringSchema> &ref_25
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -213,7 +213,7 @@ schemas: !<!Schemas>
         name: string
         description: ''
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
+  - !<!StringSchema> &ref_28
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -223,7 +223,7 @@ schemas: !<!Schemas>
         name: ResourceRecommendationBaseListResult-nextLink
         description: The link used to get the next page of recommendations.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
+  - !<!StringSchema> &ref_34
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -233,7 +233,7 @@ schemas: !<!Schemas>
         name: Resource-id
         description: The resource ID.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
+  - !<!StringSchema> &ref_35
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -243,7 +243,7 @@ schemas: !<!Schemas>
         name: Resource-name
         description: The name of the resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
+  - !<!StringSchema> &ref_36
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -253,7 +253,7 @@ schemas: !<!Schemas>
         name: Resource-type
         description: The type of the resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
+  - !<!StringSchema> &ref_39
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -263,7 +263,7 @@ schemas: !<!Schemas>
         name: RecommendationProperties-impactedField
         description: The resource type identified by Advisor.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
+  - !<!StringSchema> &ref_40
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -273,7 +273,7 @@ schemas: !<!Schemas>
         name: RecommendationProperties-impactedValue
         description: The resource identified by Advisor.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_40
+  - !<!StringSchema> &ref_43
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -283,7 +283,7 @@ schemas: !<!Schemas>
         name: RecommendationProperties-recommendationTypeId
         description: The recommendation-type GUID.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_42
+  - !<!StringSchema> &ref_45
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -293,7 +293,7 @@ schemas: !<!Schemas>
         name: ShortDescription-problem
         description: The issue or opportunity identified by the recommendation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_43
+  - !<!StringSchema> &ref_46
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -303,7 +303,7 @@ schemas: !<!Schemas>
         name: ShortDescription-solution
         description: The remediation action suggested by the recommendation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
+  - !<!StringSchema> &ref_51
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -313,7 +313,7 @@ schemas: !<!Schemas>
         name: OperationEntityListResult-nextLink
         description: The link used to get the next page of operations.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_48
+  - !<!StringSchema> &ref_52
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -323,7 +323,7 @@ schemas: !<!Schemas>
         name: OperationEntity-name
         description: 'Operation name: {provider}/{resource}/{operation}.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_49
+  - !<!StringSchema> &ref_53
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -333,7 +333,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfo-description
         description: The description of the operation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_50
+  - !<!StringSchema> &ref_54
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -343,7 +343,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfo-operation
         description: 'The action that users can perform, based on their permission level.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_51
+  - !<!StringSchema> &ref_55
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -353,7 +353,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfo-provider
         description: 'Service provider: Microsoft Advisor.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_52
+  - !<!StringSchema> &ref_56
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -363,7 +363,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfo-resource
         description: Resource on which the operation is performed.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_28
+  - !<!StringSchema> &ref_31
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -373,7 +373,7 @@ schemas: !<!Schemas>
         name: SuppressionProperties-suppressionId
         description: The GUID of the suppression.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
+  - !<!StringSchema> &ref_32
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
         name: SuppressionProperties-ttl
         description: The duration for which the suppression is valid.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_55
+  - !<!StringSchema> &ref_59
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -394,7 +394,7 @@ schemas: !<!Schemas>
         description: The link used to get the next page of suppressions.
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_34
+  - !<!ChoiceSchema> &ref_37
     choices:
     - !<!ChoiceValue> 
       value: HighAvailability
@@ -436,7 +436,7 @@ schemas: !<!Schemas>
         name: category
         description: The category of the recommendation.
     protocol: !<!Protocols> {}
-  - !<!ChoiceSchema> &ref_35
+  - !<!ChoiceSchema> &ref_38
     choices:
     - !<!ChoiceValue> 
       value: High
@@ -466,7 +466,7 @@ schemas: !<!Schemas>
         name: impact
         description: The business impact of the recommendation.
     protocol: !<!Protocols> {}
-  - !<!ChoiceSchema> &ref_41
+  - !<!ChoiceSchema> &ref_44
     choices:
     - !<!ChoiceValue> 
       value: Error
@@ -521,7 +521,7 @@ schemas: !<!Schemas>
         description: ''
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_19
+  - !<!DictionarySchema> &ref_22
     type: dictionary
     elementType: !<!AnySchema> &ref_1
       type: any
@@ -535,7 +535,7 @@ schemas: !<!Schemas>
         name: ConfigData-properties
         description: The list of property name/value pairs.
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_39
+  - !<!DictionarySchema> &ref_42
     type: dictionary
     elementType: *ref_1
     language: !<!Languages> 
@@ -543,7 +543,7 @@ schemas: !<!Schemas>
         name: RecommendationProperties-metadata
         description: The recommendation metadata.
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_45
+  - !<!DictionarySchema> &ref_48
     type: dictionary
     elementType: *ref_2
     language: !<!Languages> 
@@ -554,7 +554,7 @@ schemas: !<!Schemas>
   any:
   - *ref_1
   dateTimes:
-  - !<!DateTimeSchema> &ref_38
+  - !<!DateTimeSchema> &ref_41
     type: date-time
     format: date-time
     apiVersions:
@@ -576,7 +576,7 @@ schemas: !<!Schemas>
         name: uuid
         description: ''
     protocol: !<!Protocols> {}
-  - !<!UuidSchema> &ref_44
+  - !<!UuidSchema> &ref_47
     type: uuid
     apiVersions:
     - !<!ApiVersion> 
@@ -587,7 +587,7 @@ schemas: !<!Schemas>
         description: ''
     protocol: !<!Protocols> {}
   objects:
-  - !<!ObjectSchema> &ref_14
+  - !<!ObjectSchema> &ref_17
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -629,7 +629,7 @@ schemas: !<!Schemas>
           description: The display name.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_56
+      schema: !<!ArraySchema> &ref_11
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -650,7 +650,7 @@ schemas: !<!Schemas>
           description: The list of keys on which this entity depends on.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_57
+      schema: !<!ArraySchema> &ref_12
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -671,12 +671,12 @@ schemas: !<!Schemas>
           description: The list of scenarios applicable to this metadata entity.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_58
+      schema: !<!ArraySchema> &ref_13
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_11
+        elementType: !<!ObjectSchema> &ref_14
           type: object
           apiVersions:
           - !<!ApiVersion> 
@@ -732,7 +732,57 @@ schemas: !<!Schemas>
         description: The metadata entity contract.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_11
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_6
+      serializedName: displayName
+      language: !<!Languages> 
+        default:
+          name: displayName
+          description: The display name.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_11
+      serializedName: dependsOn
+      language: !<!Languages> 
+        default:
+          name: dependsOn
+          description: The list of keys on which this entity depends on.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_12
+      serializedName: applicableScenarios
+      language: !<!Languages> 
+        default:
+          name: applicableScenarios
+          description: The list of scenarios applicable to this metadata entity.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: supportedValues
+      language: !<!Languages> 
+        default:
+          name: supportedValues
+          description: The list of supported values.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MetadataEntityProperties
+        description: The metadata entity properties
+        namespace: ''
+    protocol: !<!Protocols> {}
+  - *ref_14
   - !<!ObjectSchema> &ref_70
     type: object
     apiVersions:
@@ -740,7 +790,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_12
+      schema: *ref_15
       serializedName: message
       language: !<!Languages> 
         default:
@@ -748,7 +798,7 @@ schemas: !<!Schemas>
           description: Gets or sets the string that describes the error in detail and provides debugging information.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_13
+      schema: *ref_16
       serializedName: code
       language: !<!Languages> 
         default:
@@ -772,12 +822,12 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_59
+      schema: !<!ArraySchema> &ref_60
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: *ref_14
+        elementType: *ref_17
         language: !<!Languages> 
           default:
             name: MetadataEntityListResult-value
@@ -790,7 +840,7 @@ schemas: !<!Schemas>
           description: The list of metadata entities.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_15
+      schema: *ref_18
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -814,19 +864,19 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_60
+      schema: !<!ArraySchema> &ref_61
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_23
+        elementType: !<!ObjectSchema> &ref_26
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           properties:
           - !<!Property> 
-            schema: *ref_16
+            schema: *ref_19
             serializedName: id
             language: !<!Languages> 
               default:
@@ -834,7 +884,7 @@ schemas: !<!Schemas>
                 description: The resource Id of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_17
+            schema: *ref_20
             serializedName: type
             language: !<!Languages> 
               default:
@@ -842,7 +892,7 @@ schemas: !<!Schemas>
                 description: The type of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_18
+            schema: *ref_21
             serializedName: name
             language: !<!Languages> 
               default:
@@ -850,19 +900,19 @@ schemas: !<!Schemas>
                 description: The name of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_24
+            schema: !<!ObjectSchema> &ref_27
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               parents: !<!Relations> 
                 all:
-                - *ref_19
+                - *ref_22
                 immediate:
-                - *ref_19
+                - *ref_22
               properties:
               - !<!Property> 
-                schema: *ref_20
+                schema: *ref_23
                 serializedName: exclude
                 language: !<!Languages> 
                   default:
@@ -870,7 +920,7 @@ schemas: !<!Schemas>
                     description: 'Exclude the resource from Advisor evaluations. Valid values: False (default) or True.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_21
+                schema: *ref_24
                 serializedName: low_cpu_threshold
                 language: !<!Languages> 
                   default:
@@ -880,8 +930,8 @@ schemas: !<!Schemas>
               serializationFormats:
               - json
               usage:
-              - input
               - output
+              - input
               language: !<!Languages> 
                 default:
                   name: ConfigData-properties
@@ -917,7 +967,7 @@ schemas: !<!Schemas>
           description: The list of configurations.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_22
+      schema: *ref_25
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -934,8 +984,8 @@ schemas: !<!Schemas>
         description: The list of Advisor configurations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_23
-  - *ref_24
+  - *ref_26
+  - *ref_27
   - !<!ObjectSchema> &ref_85
     type: object
     apiVersions:
@@ -943,7 +993,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_25
+      schema: *ref_28
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -956,34 +1006,34 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_26
+        elementType: !<!ObjectSchema> &ref_29
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           parents: !<!Relations> 
             all:
-            - !<!ObjectSchema> &ref_27
+            - !<!ObjectSchema> &ref_30
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               children: !<!Relations> 
                 all:
-                - *ref_26
-                - !<!ObjectSchema> &ref_30
+                - *ref_29
+                - !<!ObjectSchema> &ref_33
                   type: object
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2017-04-19'
                   parents: !<!Relations> 
                     all:
-                    - *ref_27
+                    - *ref_30
                     immediate:
-                    - *ref_27
+                    - *ref_30
                   properties:
                   - !<!Property> &ref_93
-                    schema: *ref_28
+                    schema: *ref_31
                     flattenedNames:
                     - properties
                     - suppressionId
@@ -994,7 +1044,7 @@ schemas: !<!Schemas>
                         description: The GUID of the suppression.
                     protocol: !<!Protocols> {}
                   - !<!Property> &ref_94
-                    schema: *ref_29
+                    schema: *ref_32
                     flattenedNames:
                     - properties
                     - ttl
@@ -1016,11 +1066,11 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
                 immediate:
-                - *ref_26
-                - *ref_30
+                - *ref_29
+                - *ref_33
               properties:
               - !<!Property> 
-                schema: *ref_31
+                schema: *ref_34
                 readOnly: true
                 serializedName: id
                 language: !<!Languages> 
@@ -1029,7 +1079,7 @@ schemas: !<!Schemas>
                     description: The resource ID.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_32
+                schema: *ref_35
                 readOnly: true
                 serializedName: name
                 language: !<!Languages> 
@@ -1038,7 +1088,7 @@ schemas: !<!Schemas>
                     description: The name of the resource.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_33
+                schema: *ref_36
                 readOnly: true
                 serializedName: type
                 language: !<!Languages> 
@@ -1060,10 +1110,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
             immediate:
-            - *ref_27
+            - *ref_30
           properties:
           - !<!Property> 
-            schema: *ref_34
+            schema: *ref_37
             flattenedNames:
             - properties
             - category
@@ -1074,7 +1124,7 @@ schemas: !<!Schemas>
                 description: The category of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_35
+            schema: *ref_38
             flattenedNames:
             - properties
             - impact
@@ -1085,7 +1135,7 @@ schemas: !<!Schemas>
                 description: The business impact of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_36
+            schema: *ref_39
             flattenedNames:
             - properties
             - impactedField
@@ -1096,7 +1146,7 @@ schemas: !<!Schemas>
                 description: The resource type identified by Advisor.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_37
+            schema: *ref_40
             flattenedNames:
             - properties
             - impactedValue
@@ -1107,7 +1157,7 @@ schemas: !<!Schemas>
                 description: The resource identified by Advisor.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_38
+            schema: *ref_41
             flattenedNames:
             - properties
             - lastUpdated
@@ -1118,7 +1168,7 @@ schemas: !<!Schemas>
                 description: The most recent time that Advisor checked the validity of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_39
+            schema: *ref_42
             flattenedNames:
             - properties
             - metadata
@@ -1129,7 +1179,7 @@ schemas: !<!Schemas>
                 description: The recommendation metadata.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_40
+            schema: *ref_43
             flattenedNames:
             - properties
             - recommendationTypeId
@@ -1140,7 +1190,7 @@ schemas: !<!Schemas>
                 description: The recommendation-type GUID.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_41
+            schema: *ref_44
             flattenedNames:
             - properties
             - risk
@@ -1151,14 +1201,14 @@ schemas: !<!Schemas>
                 description: The potential risk of not implementing the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_46
+            schema: !<!ObjectSchema> &ref_49
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               properties:
               - !<!Property> 
-                schema: *ref_42
+                schema: *ref_45
                 serializedName: problem
                 language: !<!Languages> 
                   default:
@@ -1166,7 +1216,7 @@ schemas: !<!Schemas>
                     description: The issue or opportunity identified by the recommendation.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_43
+                schema: *ref_46
                 serializedName: solution
                 language: !<!Languages> 
                   default:
@@ -1194,12 +1244,12 @@ schemas: !<!Schemas>
                 description: A summary of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ArraySchema> &ref_61
+            schema: !<!ArraySchema> &ref_50
               type: array
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
-              elementType: *ref_44
+              elementType: *ref_47
               language: !<!Languages> 
                 default:
                   name: RecommendationProperties-suppressionIds
@@ -1215,7 +1265,7 @@ schemas: !<!Schemas>
                 description: The list of snoozed and dismissed rules for the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_45
+            schema: *ref_48
             flattenedNames:
             - properties
             - extendedProperties
@@ -1257,9 +1307,116 @@ schemas: !<!Schemas>
         description: The list of Advisor recommendations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_27
-  - *ref_26
-  - *ref_46
+  - *ref_30
+  - *ref_29
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_37
+      serializedName: category
+      language: !<!Languages> 
+        default:
+          name: category
+          description: The category of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_38
+      serializedName: impact
+      language: !<!Languages> 
+        default:
+          name: impact
+          description: The business impact of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_39
+      serializedName: impactedField
+      language: !<!Languages> 
+        default:
+          name: impactedField
+          description: The resource type identified by Advisor.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_40
+      serializedName: impactedValue
+      language: !<!Languages> 
+        default:
+          name: impactedValue
+          description: The resource identified by Advisor.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_41
+      serializedName: lastUpdated
+      language: !<!Languages> 
+        default:
+          name: lastUpdated
+          description: The most recent time that Advisor checked the validity of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_42
+      serializedName: metadata
+      language: !<!Languages> 
+        default:
+          name: metadata
+          description: The recommendation metadata.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_43
+      serializedName: recommendationTypeId
+      language: !<!Languages> 
+        default:
+          name: recommendationTypeId
+          description: The recommendation-type GUID.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_44
+      serializedName: risk
+      language: !<!Languages> 
+        default:
+          name: risk
+          description: The potential risk of not implementing the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_49
+      serializedName: shortDescription
+      language: !<!Languages> 
+        default:
+          name: shortDescription
+          description: A summary of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_50
+      serializedName: suppressionIds
+      language: !<!Languages> 
+        default:
+          name: suppressionIds
+          description: The list of snoozed and dismissed rules for the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_48
+      serializedName: extendedProperties
+      language: !<!Languages> 
+        default:
+          name: extendedProperties
+          description: Extended properties
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: RecommendationProperties
+        description: The properties of the recommendation.
+        namespace: ''
+    protocol: !<!Protocols> {}
+  - *ref_49
   - !<!ObjectSchema> &ref_88
     type: object
     apiVersions:
@@ -1267,7 +1424,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_47
+      schema: *ref_51
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -1280,14 +1437,14 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_53
+        elementType: !<!ObjectSchema> &ref_57
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           properties:
           - !<!Property> 
-            schema: *ref_48
+            schema: *ref_52
             serializedName: name
             language: !<!Languages> 
               default:
@@ -1295,14 +1452,14 @@ schemas: !<!Schemas>
                 description: 'Operation name: {provider}/{resource}/{operation}.'
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_54
+            schema: !<!ObjectSchema> &ref_58
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               properties:
               - !<!Property> 
-                schema: *ref_49
+                schema: *ref_53
                 serializedName: description
                 language: !<!Languages> 
                   default:
@@ -1310,7 +1467,7 @@ schemas: !<!Schemas>
                     description: The description of the operation.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_50
+                schema: *ref_54
                 serializedName: operation
                 language: !<!Languages> 
                   default:
@@ -1318,7 +1475,7 @@ schemas: !<!Schemas>
                     description: 'The action that users can perform, based on their permission level.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_51
+                schema: *ref_55
                 serializedName: provider
                 language: !<!Languages> 
                   default:
@@ -1326,7 +1483,7 @@ schemas: !<!Schemas>
                     description: 'Service provider: Microsoft Advisor.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_52
+                schema: *ref_56
                 serializedName: resource
                 language: !<!Languages> 
                   default:
@@ -1380,9 +1537,44 @@ schemas: !<!Schemas>
         description: The list of Advisor operations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_53
-  - *ref_54
-  - *ref_30
+  - *ref_57
+  - *ref_58
+  - *ref_33
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_31
+      serializedName: suppressionId
+      language: !<!Languages> 
+        default:
+          name: suppressionId
+          description: The GUID of the suppression.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_32
+      serializedName: ttl
+      language: !<!Languages> 
+        default:
+          name: ttl
+          description: The duration for which the suppression is valid.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SuppressionProperties
+        description: The properties of the suppression.
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_105
     type: object
     apiVersions:
@@ -1390,7 +1582,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_55
+      schema: *ref_59
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -1403,7 +1595,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: *ref_30
+        elementType: *ref_33
         language: !<!Languages> 
           default:
             name: SuppressionContractListResult-value
@@ -1426,12 +1618,12 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   arrays:
-  - *ref_56
-  - *ref_57
-  - *ref_58
-  - *ref_59
+  - *ref_11
+  - *ref_12
+  - *ref_13
   - *ref_60
   - *ref_61
+  - *ref_50
   - *ref_62
   - *ref_63
   - *ref_64
@@ -1517,7 +1709,7 @@ operationGroups:
     - *ref_69
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1657,7 +1849,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_74
-        schema: *ref_23
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1794,7 +1986,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_76
-        schema: *ref_23
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2084,7 +2276,7 @@ operationGroups:
     - *ref_87
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2220,7 +2412,7 @@ operationGroups:
     - *ref_91
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2284,7 +2476,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_92
-        schema: *ref_30
+        schema: *ref_33
         flattened: true
         implementation: Method
         required: true
@@ -2297,7 +2489,7 @@ operationGroups:
             in: body
             style: json
       - !<!VirtualParameter> &ref_95
-        schema: *ref_28
+        schema: *ref_31
         implementation: Method
         originalParameter: *ref_92
         pathToProperty: []
@@ -2308,7 +2500,7 @@ operationGroups:
             description: The GUID of the suppression.
         protocol: !<!Protocols> {}
       - !<!VirtualParameter> &ref_96
-        schema: *ref_29
+        schema: *ref_32
         implementation: Method
         originalParameter: *ref_92
         pathToProperty: []
@@ -2339,7 +2531,7 @@ operationGroups:
     - *ref_99
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/scenarios/advisor/modeler.yaml
+++ b/modelerfour/test/scenarios/advisor/modeler.yaml
@@ -894,8 +894,8 @@ schemas: !<!Schemas>
               serializationFormats:
               - json
               usage:
-              - input
               - output
+              - input
               language: !<!Languages> 
                 default:
                   name: ConfigData-properties

--- a/modelerfour/test/scenarios/advisor/namer.yaml
+++ b/modelerfour/test/scenarios/advisor/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: AdvisorManagementClient
 schemas: !<!Schemas> 
   booleans:
-  - !<!BooleanSchema> &ref_20
+  - !<!BooleanSchema> &ref_23
     type: boolean
     language: !<!Languages> 
       default:
@@ -112,7 +112,7 @@ schemas: !<!Schemas>
         name: MetadataSupportedValueDetailDisplayName
         description: The display name.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_12
+  - !<!StringSchema> &ref_15
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -122,7 +122,7 @@ schemas: !<!Schemas>
         name: ARMErrorResponseBodyMessage
         description: Gets or sets the string that describes the error in detail and provides debugging information.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_13
+  - !<!StringSchema> &ref_16
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -132,7 +132,7 @@ schemas: !<!Schemas>
         name: ARMErrorResponseBodyCode
         description: Gets or sets the string that can be used to programmatically identify the error.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_15
+  - !<!StringSchema> &ref_18
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
         name: MetadataEntityListResultNextLink
         description: The link used to get the next page of metadata.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_16
+  - !<!StringSchema> &ref_19
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -152,7 +152,7 @@ schemas: !<!Schemas>
         name: ConfigDataId
         description: The resource Id of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_17
+  - !<!StringSchema> &ref_20
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
         name: ConfigDataType
         description: The type of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_18
+  - !<!StringSchema> &ref_21
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
         name: ConfigDataName
         description: The name of the configuration resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_21
+  - !<!StringSchema> &ref_24
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
         name: ConfigDataPropertiesLowCpuThreshold
         description: 'Minimum percentage threshold for Advisor low CPU utilization evaluation. Valid only for subscriptions. Valid values: 5 (default), 10, 15 or 20.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_22
+  - !<!StringSchema> &ref_25
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -213,7 +213,7 @@ schemas: !<!Schemas>
         name: String
         description: ''
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_25
+  - !<!StringSchema> &ref_28
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -223,7 +223,7 @@ schemas: !<!Schemas>
         name: ResourceRecommendationBaseListResultNextLink
         description: The link used to get the next page of recommendations.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_31
+  - !<!StringSchema> &ref_34
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -233,7 +233,7 @@ schemas: !<!Schemas>
         name: ResourceId
         description: The resource ID.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_32
+  - !<!StringSchema> &ref_35
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -243,7 +243,7 @@ schemas: !<!Schemas>
         name: ResourceName
         description: The name of the resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_33
+  - !<!StringSchema> &ref_36
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -253,7 +253,7 @@ schemas: !<!Schemas>
         name: ResourceType
         description: The type of the resource.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_36
+  - !<!StringSchema> &ref_39
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -263,7 +263,7 @@ schemas: !<!Schemas>
         name: RecommendationPropertiesImpactedField
         description: The resource type identified by Advisor.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_37
+  - !<!StringSchema> &ref_40
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -273,7 +273,7 @@ schemas: !<!Schemas>
         name: RecommendationPropertiesImpactedValue
         description: The resource identified by Advisor.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_40
+  - !<!StringSchema> &ref_43
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -283,7 +283,7 @@ schemas: !<!Schemas>
         name: RecommendationPropertiesRecommendationTypeId
         description: The recommendation-type GUID.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_42
+  - !<!StringSchema> &ref_45
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -293,7 +293,7 @@ schemas: !<!Schemas>
         name: ShortDescriptionProblem
         description: The issue or opportunity identified by the recommendation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_43
+  - !<!StringSchema> &ref_46
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -303,7 +303,7 @@ schemas: !<!Schemas>
         name: ShortDescriptionSolution
         description: The remediation action suggested by the recommendation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_47
+  - !<!StringSchema> &ref_51
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -313,7 +313,7 @@ schemas: !<!Schemas>
         name: OperationEntityListResultNextLink
         description: The link used to get the next page of operations.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_48
+  - !<!StringSchema> &ref_52
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -323,7 +323,7 @@ schemas: !<!Schemas>
         name: OperationEntityName
         description: 'Operation name: {provider}/{resource}/{operation}.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_49
+  - !<!StringSchema> &ref_53
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -333,7 +333,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfoDescription
         description: The description of the operation.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_50
+  - !<!StringSchema> &ref_54
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -343,7 +343,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfoOperation
         description: 'The action that users can perform, based on their permission level.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_51
+  - !<!StringSchema> &ref_55
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -353,7 +353,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfoProvider
         description: 'Service provider: Microsoft Advisor.'
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_52
+  - !<!StringSchema> &ref_56
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -363,7 +363,7 @@ schemas: !<!Schemas>
         name: OperationDisplayInfoResource
         description: Resource on which the operation is performed.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_28
+  - !<!StringSchema> &ref_31
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -373,7 +373,7 @@ schemas: !<!Schemas>
         name: SuppressionPropertiesSuppressionId
         description: The GUID of the suppression.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_29
+  - !<!StringSchema> &ref_32
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
         name: SuppressionPropertiesTtl
         description: The duration for which the suppression is valid.
     protocol: !<!Protocols> {}
-  - !<!StringSchema> &ref_55
+  - !<!StringSchema> &ref_59
     type: string
     apiVersions:
     - !<!ApiVersion> 
@@ -394,7 +394,7 @@ schemas: !<!Schemas>
         description: The link used to get the next page of suppressions.
     protocol: !<!Protocols> {}
   choices:
-  - !<!ChoiceSchema> &ref_34
+  - !<!ChoiceSchema> &ref_37
     choices:
     - !<!ChoiceValue> 
       value: HighAvailability
@@ -436,7 +436,7 @@ schemas: !<!Schemas>
         name: Category
         description: The category of the recommendation.
     protocol: !<!Protocols> {}
-  - !<!ChoiceSchema> &ref_35
+  - !<!ChoiceSchema> &ref_38
     choices:
     - !<!ChoiceValue> 
       value: High
@@ -466,7 +466,7 @@ schemas: !<!Schemas>
         name: Impact
         description: The business impact of the recommendation.
     protocol: !<!Protocols> {}
-  - !<!ChoiceSchema> &ref_41
+  - !<!ChoiceSchema> &ref_44
     choices:
     - !<!ChoiceValue> 
       value: Error
@@ -521,7 +521,7 @@ schemas: !<!Schemas>
         description: ''
     protocol: !<!Protocols> {}
   dictionaries:
-  - !<!DictionarySchema> &ref_19
+  - !<!DictionarySchema> &ref_22
     type: dictionary
     elementType: !<!AnySchema> &ref_1
       type: any
@@ -535,7 +535,7 @@ schemas: !<!Schemas>
         name: ConfigDataProperties
         description: The list of property name/value pairs.
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_39
+  - !<!DictionarySchema> &ref_42
     type: dictionary
     elementType: *ref_1
     language: !<!Languages> 
@@ -543,7 +543,7 @@ schemas: !<!Schemas>
         name: RecommendationPropertiesMetadata
         description: The recommendation metadata.
     protocol: !<!Protocols> {}
-  - !<!DictionarySchema> &ref_45
+  - !<!DictionarySchema> &ref_48
     type: dictionary
     elementType: *ref_2
     language: !<!Languages> 
@@ -554,7 +554,7 @@ schemas: !<!Schemas>
   any:
   - *ref_1
   dateTimes:
-  - !<!DateTimeSchema> &ref_38
+  - !<!DateTimeSchema> &ref_41
     type: date-time
     format: date-time
     apiVersions:
@@ -576,7 +576,7 @@ schemas: !<!Schemas>
         name: Uuid
         description: ''
     protocol: !<!Protocols> {}
-  - !<!UuidSchema> &ref_44
+  - !<!UuidSchema> &ref_47
     type: uuid
     apiVersions:
     - !<!ApiVersion> 
@@ -587,7 +587,7 @@ schemas: !<!Schemas>
         description: ''
     protocol: !<!Protocols> {}
   objects:
-  - !<!ObjectSchema> &ref_14
+  - !<!ObjectSchema> &ref_17
     type: object
     apiVersions:
     - !<!ApiVersion> 
@@ -629,7 +629,7 @@ schemas: !<!Schemas>
           description: The display name.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_56
+      schema: !<!ArraySchema> &ref_11
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -650,7 +650,7 @@ schemas: !<!Schemas>
           description: The list of keys on which this entity depends on.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_57
+      schema: !<!ArraySchema> &ref_12
         type: array
         apiVersions:
         - !<!ApiVersion> 
@@ -671,12 +671,12 @@ schemas: !<!Schemas>
           description: The list of scenarios applicable to this metadata entity.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_58
+      schema: !<!ArraySchema> &ref_13
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_11
+        elementType: !<!ObjectSchema> &ref_14
           type: object
           apiVersions:
           - !<!ApiVersion> 
@@ -732,7 +732,57 @@ schemas: !<!Schemas>
         description: The metadata entity contract.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_11
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_6
+      serializedName: displayName
+      language: !<!Languages> 
+        default:
+          name: displayName
+          description: The display name.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_11
+      serializedName: dependsOn
+      language: !<!Languages> 
+        default:
+          name: dependsOn
+          description: The list of keys on which this entity depends on.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_12
+      serializedName: applicableScenarios
+      language: !<!Languages> 
+        default:
+          name: applicableScenarios
+          description: The list of scenarios applicable to this metadata entity.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: supportedValues
+      language: !<!Languages> 
+        default:
+          name: supportedValues
+          description: The list of supported values.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MetadataEntityProperties
+        description: The metadata entity properties
+        namespace: ''
+    protocol: !<!Protocols> {}
+  - *ref_14
   - !<!ObjectSchema> &ref_70
     type: object
     apiVersions:
@@ -740,7 +790,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_12
+      schema: *ref_15
       serializedName: message
       language: !<!Languages> 
         default:
@@ -748,7 +798,7 @@ schemas: !<!Schemas>
           description: Gets or sets the string that describes the error in detail and provides debugging information.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_13
+      schema: *ref_16
       serializedName: code
       language: !<!Languages> 
         default:
@@ -772,12 +822,12 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_59
+      schema: !<!ArraySchema> &ref_60
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: *ref_14
+        elementType: *ref_17
         language: !<!Languages> 
           default:
             name: MetadataEntityListResultValue
@@ -790,7 +840,7 @@ schemas: !<!Schemas>
           description: The list of metadata entities.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_15
+      schema: *ref_18
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -814,19 +864,19 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: !<!ArraySchema> &ref_60
+      schema: !<!ArraySchema> &ref_61
         type: array
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_23
+        elementType: !<!ObjectSchema> &ref_26
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           properties:
           - !<!Property> 
-            schema: *ref_16
+            schema: *ref_19
             serializedName: id
             language: !<!Languages> 
               default:
@@ -834,7 +884,7 @@ schemas: !<!Schemas>
                 description: The resource Id of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_17
+            schema: *ref_20
             serializedName: type
             language: !<!Languages> 
               default:
@@ -842,7 +892,7 @@ schemas: !<!Schemas>
                 description: The type of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_18
+            schema: *ref_21
             serializedName: name
             language: !<!Languages> 
               default:
@@ -850,19 +900,19 @@ schemas: !<!Schemas>
                 description: The name of the configuration resource.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_24
+            schema: !<!ObjectSchema> &ref_27
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               parents: !<!Relations> 
                 all:
-                - *ref_19
+                - *ref_22
                 immediate:
-                - *ref_19
+                - *ref_22
               properties:
               - !<!Property> 
-                schema: *ref_20
+                schema: *ref_23
                 serializedName: exclude
                 language: !<!Languages> 
                   default:
@@ -870,7 +920,7 @@ schemas: !<!Schemas>
                     description: 'Exclude the resource from Advisor evaluations. Valid values: False (default) or True.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_21
+                schema: *ref_24
                 serializedName: low_cpu_threshold
                 language: !<!Languages> 
                   default:
@@ -880,8 +930,8 @@ schemas: !<!Schemas>
               serializationFormats:
               - json
               usage:
-              - input
               - output
+              - input
               language: !<!Languages> 
                 default:
                   name: ConfigDataProperties
@@ -917,7 +967,7 @@ schemas: !<!Schemas>
           description: The list of configurations.
       protocol: !<!Protocols> {}
     - !<!Property> 
-      schema: *ref_22
+      schema: *ref_25
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -934,8 +984,8 @@ schemas: !<!Schemas>
         description: The list of Advisor configurations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_23
-  - *ref_24
+  - *ref_26
+  - *ref_27
   - !<!ObjectSchema> &ref_85
     type: object
     apiVersions:
@@ -943,7 +993,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_25
+      schema: *ref_28
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -956,34 +1006,34 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_26
+        elementType: !<!ObjectSchema> &ref_29
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           parents: !<!Relations> 
             all:
-            - !<!ObjectSchema> &ref_27
+            - !<!ObjectSchema> &ref_30
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               children: !<!Relations> 
                 all:
-                - *ref_26
-                - !<!ObjectSchema> &ref_30
+                - *ref_29
+                - !<!ObjectSchema> &ref_33
                   type: object
                   apiVersions:
                   - !<!ApiVersion> 
                     version: '2017-04-19'
                   parents: !<!Relations> 
                     all:
-                    - *ref_27
+                    - *ref_30
                     immediate:
-                    - *ref_27
+                    - *ref_30
                   properties:
                   - !<!Property> &ref_93
-                    schema: *ref_28
+                    schema: *ref_31
                     flattenedNames:
                     - properties
                     - suppressionId
@@ -994,7 +1044,7 @@ schemas: !<!Schemas>
                         description: The GUID of the suppression.
                     protocol: !<!Protocols> {}
                   - !<!Property> &ref_94
-                    schema: *ref_29
+                    schema: *ref_32
                     flattenedNames:
                     - properties
                     - ttl
@@ -1016,11 +1066,11 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
                 immediate:
-                - *ref_26
-                - *ref_30
+                - *ref_29
+                - *ref_33
               properties:
               - !<!Property> 
-                schema: *ref_31
+                schema: *ref_34
                 readOnly: true
                 serializedName: id
                 language: !<!Languages> 
@@ -1029,7 +1079,7 @@ schemas: !<!Schemas>
                     description: The resource ID.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_32
+                schema: *ref_35
                 readOnly: true
                 serializedName: name
                 language: !<!Languages> 
@@ -1038,7 +1088,7 @@ schemas: !<!Schemas>
                     description: The name of the resource.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_33
+                schema: *ref_36
                 readOnly: true
                 serializedName: type
                 language: !<!Languages> 
@@ -1060,10 +1110,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
             immediate:
-            - *ref_27
+            - *ref_30
           properties:
           - !<!Property> 
-            schema: *ref_34
+            schema: *ref_37
             flattenedNames:
             - properties
             - category
@@ -1074,7 +1124,7 @@ schemas: !<!Schemas>
                 description: The category of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_35
+            schema: *ref_38
             flattenedNames:
             - properties
             - impact
@@ -1085,7 +1135,7 @@ schemas: !<!Schemas>
                 description: The business impact of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_36
+            schema: *ref_39
             flattenedNames:
             - properties
             - impactedField
@@ -1096,7 +1146,7 @@ schemas: !<!Schemas>
                 description: The resource type identified by Advisor.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_37
+            schema: *ref_40
             flattenedNames:
             - properties
             - impactedValue
@@ -1107,7 +1157,7 @@ schemas: !<!Schemas>
                 description: The resource identified by Advisor.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_38
+            schema: *ref_41
             flattenedNames:
             - properties
             - lastUpdated
@@ -1118,7 +1168,7 @@ schemas: !<!Schemas>
                 description: The most recent time that Advisor checked the validity of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_39
+            schema: *ref_42
             flattenedNames:
             - properties
             - metadata
@@ -1129,7 +1179,7 @@ schemas: !<!Schemas>
                 description: The recommendation metadata.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_40
+            schema: *ref_43
             flattenedNames:
             - properties
             - recommendationTypeId
@@ -1140,7 +1190,7 @@ schemas: !<!Schemas>
                 description: The recommendation-type GUID.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_41
+            schema: *ref_44
             flattenedNames:
             - properties
             - risk
@@ -1151,14 +1201,14 @@ schemas: !<!Schemas>
                 description: The potential risk of not implementing the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_46
+            schema: !<!ObjectSchema> &ref_49
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               properties:
               - !<!Property> 
-                schema: *ref_42
+                schema: *ref_45
                 serializedName: problem
                 language: !<!Languages> 
                   default:
@@ -1166,7 +1216,7 @@ schemas: !<!Schemas>
                     description: The issue or opportunity identified by the recommendation.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_43
+                schema: *ref_46
                 serializedName: solution
                 language: !<!Languages> 
                   default:
@@ -1194,12 +1244,12 @@ schemas: !<!Schemas>
                 description: A summary of the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ArraySchema> &ref_61
+            schema: !<!ArraySchema> &ref_50
               type: array
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
-              elementType: *ref_44
+              elementType: *ref_47
               language: !<!Languages> 
                 default:
                   name: RecommendationPropertiesSuppressionIds
@@ -1215,7 +1265,7 @@ schemas: !<!Schemas>
                 description: The list of snoozed and dismissed rules for the recommendation.
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_45
+            schema: *ref_48
             flattenedNames:
             - properties
             - extendedProperties
@@ -1257,9 +1307,116 @@ schemas: !<!Schemas>
         description: The list of Advisor recommendations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_27
-  - *ref_26
-  - *ref_46
+  - *ref_30
+  - *ref_29
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_37
+      serializedName: category
+      language: !<!Languages> 
+        default:
+          name: category
+          description: The category of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_38
+      serializedName: impact
+      language: !<!Languages> 
+        default:
+          name: impact
+          description: The business impact of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_39
+      serializedName: impactedField
+      language: !<!Languages> 
+        default:
+          name: impactedField
+          description: The resource type identified by Advisor.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_40
+      serializedName: impactedValue
+      language: !<!Languages> 
+        default:
+          name: impactedValue
+          description: The resource identified by Advisor.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_41
+      serializedName: lastUpdated
+      language: !<!Languages> 
+        default:
+          name: lastUpdated
+          description: The most recent time that Advisor checked the validity of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_42
+      serializedName: metadata
+      language: !<!Languages> 
+        default:
+          name: metadata
+          description: The recommendation metadata.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_43
+      serializedName: recommendationTypeId
+      language: !<!Languages> 
+        default:
+          name: recommendationTypeId
+          description: The recommendation-type GUID.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_44
+      serializedName: risk
+      language: !<!Languages> 
+        default:
+          name: risk
+          description: The potential risk of not implementing the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_49
+      serializedName: shortDescription
+      language: !<!Languages> 
+        default:
+          name: shortDescription
+          description: A summary of the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_50
+      serializedName: suppressionIds
+      language: !<!Languages> 
+        default:
+          name: suppressionIds
+          description: The list of snoozed and dismissed rules for the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_48
+      serializedName: extendedProperties
+      language: !<!Languages> 
+        default:
+          name: extendedProperties
+          description: Extended properties
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: RecommendationProperties
+        description: The properties of the recommendation.
+        namespace: ''
+    protocol: !<!Protocols> {}
+  - *ref_49
   - !<!ObjectSchema> &ref_88
     type: object
     apiVersions:
@@ -1267,7 +1424,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_47
+      schema: *ref_51
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -1280,14 +1437,14 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: !<!ObjectSchema> &ref_53
+        elementType: !<!ObjectSchema> &ref_57
           type: object
           apiVersions:
           - !<!ApiVersion> 
             version: '2017-04-19'
           properties:
           - !<!Property> 
-            schema: *ref_48
+            schema: *ref_52
             serializedName: name
             language: !<!Languages> 
               default:
@@ -1295,14 +1452,14 @@ schemas: !<!Schemas>
                 description: 'Operation name: {provider}/{resource}/{operation}.'
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: !<!ObjectSchema> &ref_54
+            schema: !<!ObjectSchema> &ref_58
               type: object
               apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
               properties:
               - !<!Property> 
-                schema: *ref_49
+                schema: *ref_53
                 serializedName: description
                 language: !<!Languages> 
                   default:
@@ -1310,7 +1467,7 @@ schemas: !<!Schemas>
                     description: The description of the operation.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_50
+                schema: *ref_54
                 serializedName: operation
                 language: !<!Languages> 
                   default:
@@ -1318,7 +1475,7 @@ schemas: !<!Schemas>
                     description: 'The action that users can perform, based on their permission level.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_51
+                schema: *ref_55
                 serializedName: provider
                 language: !<!Languages> 
                   default:
@@ -1326,7 +1483,7 @@ schemas: !<!Schemas>
                     description: 'Service provider: Microsoft Advisor.'
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_52
+                schema: *ref_56
                 serializedName: resource
                 language: !<!Languages> 
                   default:
@@ -1380,9 +1537,44 @@ schemas: !<!Schemas>
         description: The list of Advisor operations.
         namespace: ''
     protocol: !<!Protocols> {}
-  - *ref_53
-  - *ref_54
-  - *ref_30
+  - *ref_57
+  - *ref_58
+  - *ref_33
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2017-04-19'
+    properties:
+    - !<!Property> 
+      schema: *ref_31
+      serializedName: suppressionId
+      language: !<!Languages> 
+        default:
+          name: suppressionId
+          description: The GUID of the suppression.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_32
+      serializedName: ttl
+      language: !<!Languages> 
+        default:
+          name: ttl
+          description: The duration for which the suppression is valid.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    - input
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SuppressionProperties
+        description: The properties of the suppression.
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_105
     type: object
     apiVersions:
@@ -1390,7 +1582,7 @@ schemas: !<!Schemas>
       version: '2017-04-19'
     properties:
     - !<!Property> 
-      schema: *ref_55
+      schema: *ref_59
       serializedName: nextLink
       language: !<!Languages> 
         default:
@@ -1403,7 +1595,7 @@ schemas: !<!Schemas>
         apiVersions:
         - !<!ApiVersion> 
           version: '2017-04-19'
-        elementType: *ref_30
+        elementType: *ref_33
         language: !<!Languages> 
           default:
             name: SuppressionContractListResultValue
@@ -1426,12 +1618,12 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   arrays:
-  - *ref_56
-  - *ref_57
-  - *ref_58
-  - *ref_59
+  - *ref_11
+  - *ref_12
+  - *ref_13
   - *ref_60
   - *ref_61
+  - *ref_50
   - *ref_62
   - *ref_63
   - *ref_64
@@ -1517,7 +1709,7 @@ operationGroups:
     - *ref_69
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_14
+      schema: *ref_17
       language: !<!Languages> 
         default:
           name: ''
@@ -1657,7 +1849,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_74
-        schema: *ref_23
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -1794,7 +1986,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_76
-        schema: *ref_23
+        schema: *ref_26
         implementation: Method
         required: true
         language: !<!Languages> 
@@ -2084,7 +2276,7 @@ operationGroups:
     - *ref_87
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_26
+      schema: *ref_29
       language: !<!Languages> 
         default:
           name: ''
@@ -2220,7 +2412,7 @@ operationGroups:
     - *ref_91
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''
@@ -2284,7 +2476,7 @@ operationGroups:
     - !<!Request> 
       parameters:
       - !<!Parameter> &ref_92
-        schema: *ref_30
+        schema: *ref_33
         flattened: true
         implementation: Method
         required: true
@@ -2297,7 +2489,7 @@ operationGroups:
             in: body
             style: json
       - !<!VirtualParameter> &ref_95
-        schema: *ref_28
+        schema: *ref_31
         implementation: Method
         originalParameter: *ref_92
         pathToProperty: []
@@ -2308,7 +2500,7 @@ operationGroups:
             description: The GUID of the suppression.
         protocol: !<!Protocols> {}
       - !<!VirtualParameter> &ref_96
-        schema: *ref_29
+        schema: *ref_32
         implementation: Method
         originalParameter: *ref_92
         pathToProperty: []
@@ -2339,7 +2531,7 @@ operationGroups:
     - *ref_99
     responses:
     - !<!SchemaResponse> 
-      schema: *ref_30
+      schema: *ref_33
       language: !<!Languages> 
         default:
           name: ''

--- a/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
@@ -280,6 +280,49 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_1
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: pname
+      language: !<!Languages> 
+        default:
+          name: pname
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: lsize
+      language: !<!Languages> 
+        default:
+          name: lsize
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedResourceProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
@@ -280,6 +280,49 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_1
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: pname
+      language: !<!Languages> 
+        default:
+          name: pname
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: lsize
+      language: !<!Languages> 
+        default:
+          name: lsize
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedResourceProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
@@ -222,8 +222,8 @@ schemas: !<!Schemas>
           serializationFormats:
           - json
           usage:
-          - output
           - input
+          - output
           language: !<!Languages> 
             default:
               name: FlattenedResourceProperties

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -280,6 +280,49 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_1
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: pname
+      language: !<!Languages> 
+        default:
+          name: pname
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: lsize
+      language: !<!Languages> 
+        default:
+          name: lsize
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedResourceProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/azure-resource/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource/flattened.yaml
@@ -280,6 +280,49 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_1
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: pname
+      language: !<!Languages> 
+        default:
+          name: pname
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: lsize
+      language: !<!Languages> 
+        default:
+          name: lsize
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedResourceProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/azure-resource/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource/grouped.yaml
@@ -280,6 +280,49 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_1
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: pname
+      language: !<!Languages> 
+        default:
+          name: pname
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: lsize
+      language: !<!Languages> 
+        default:
+          name: lsize
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedResourceProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/azure-resource/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource/modeler.yaml
@@ -222,8 +222,8 @@ schemas: !<!Schemas>
           serializationFormats:
           - json
           usage:
-          - output
           - input
+          - output
           language: !<!Languages> 
             default:
               name: FlattenedResourceProperties

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -280,6 +280,49 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_1
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: pname
+      language: !<!Languages> 
+        default:
+          name: pname
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: lsize
+      language: !<!Languages> 
+        default:
+          name: lsize
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedResourceProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_22
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -1763,6 +1763,32 @@ schemas: !<!Schemas>
         description: ''
         namespace: ''
     protocol: !<!Protocols> {}
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2016-02-29'
+    properties:
+    - !<!Property> 
+      schema: *ref_62
+      serializedName: propBH1
+      language: !<!Languages> 
+        default:
+          name: propBH1
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MyBaseHelperType
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_37
   - *ref_40
   - *ref_43

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -1763,6 +1763,32 @@ schemas: !<!Schemas>
         description: ''
         namespace: ''
     protocol: !<!Protocols> {}
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2016-02-29'
+    properties:
+    - !<!Property> 
+      schema: *ref_62
+      serializedName: propBH1
+      language: !<!Languages> 
+        default:
+          name: propBH1
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MyBaseHelperType
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_37
   - *ref_40
   - *ref_43

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -1763,6 +1763,32 @@ schemas: !<!Schemas>
         description: ''
         namespace: ''
     protocol: !<!Protocols> {}
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: '2016-02-29'
+    properties:
+    - !<!Property> 
+      schema: *ref_62
+      serializedName: propBH1
+      language: !<!Languages> 
+        default:
+          name: propBH1
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: MyBaseHelperType
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_37
   - *ref_40
   - *ref_43

--- a/modelerfour/test/scenarios/lro/flattened.yaml
+++ b/modelerfour/test/scenarios/lro/flattened.yaml
@@ -518,6 +518,43 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_5
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_3
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_4
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: Product-properties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_26
     type: object
     apiVersions:
@@ -663,6 +700,43 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_18
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_16
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_17
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SubProduct-properties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> 
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/lro/grouped.yaml
+++ b/modelerfour/test/scenarios/lro/grouped.yaml
@@ -518,6 +518,43 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_5
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_3
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_4
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: Product-properties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_26
     type: object
     apiVersions:
@@ -663,6 +700,43 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_18
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_16
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_17
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SubProduct-properties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> 
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -518,6 +518,43 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_5
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_3
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_4
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: ProductProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_26
     type: object
     apiVersions:
@@ -663,6 +700,43 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_18
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_16
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_17
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SubProductProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> 
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/model-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/model-flattening/flattened.yaml
@@ -461,6 +461,59 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_2
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: p.name
+      language: !<!Languages> 
+        default:
+          name: p.name
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: type
+      language: !<!Languages> 
+        default:
+          name: type
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_11
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_12
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedProduct-properties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_28
     type: object
     apiVersions:
@@ -674,6 +727,67 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_23
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_19
+      required: true
+      serializedName: max_product_display_name
+      language: !<!Languages> 
+        default:
+          name: max_product_display_name
+          description: Display name of product.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_20
+      required: true
+      serializedName: max_product_capacity
+      language: !<!Languages> 
+        default:
+          name: capacity
+          description: 'Capacity of product. For example, 4 people.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      flattenedNames:
+      - max_product_image
+      - generic_value
+      required: false
+      serializedName: generic_value
+      language: !<!Languages> 
+        default:
+          name: generic_value
+          description: Generic URL value.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_22
+      flattenedNames:
+      - max_product_image
+      - '@odata.value'
+      required: false
+      serializedName: '@odata.value'
+      language: !<!Languages> 
+        default:
+          name: '@odata.value'
+          description: URL value.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SimpleProductProperties
+        description: The product documentation.
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_26
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -744,6 +744,59 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_2
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: p.name
+      language: !<!Languages> 
+        default:
+          name: p.name
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: type
+      language: !<!Languages> 
+        default:
+          name: type
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_11
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_12
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedProduct-properties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_28
     type: object
     apiVersions:
@@ -851,6 +904,67 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_18
   - *ref_23
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_19
+      required: true
+      serializedName: max_product_display_name
+      language: !<!Languages> 
+        default:
+          name: max_product_display_name
+          description: Display name of product.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_20
+      required: true
+      serializedName: max_product_capacity
+      language: !<!Languages> 
+        default:
+          name: capacity
+          description: 'Capacity of product. For example, 4 people.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      flattenedNames:
+      - max_product_image
+      - generic_value
+      required: false
+      serializedName: generic_value
+      language: !<!Languages> 
+        default:
+          name: generic_value
+          description: Generic URL value.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_22
+      flattenedNames:
+      - max_product_image
+      - '@odata.value'
+      required: false
+      serializedName: '@odata.value'
+      language: !<!Languages> 
+        default:
+          name: '@odata.value'
+          description: URL value.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SimpleProductProperties
+        description: The product documentation.
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_26
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/model-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/model-flattening/modeler.yaml
@@ -392,8 +392,8 @@ schemas: !<!Schemas>
           serializationFormats:
           - json
           usage:
-          - output
           - input
+          - output
           extensions:
             x-ms-client-flatten: true
           language: !<!Languages> 

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -744,6 +744,59 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_2
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: p.name
+      language: !<!Languages> 
+        default:
+          name: pName
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_10
+      serializedName: type
+      language: !<!Languages> 
+        default:
+          name: type
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_11
+      readOnly: true
+      serializedName: provisioningStateValues
+      language: !<!Languages> 
+        default:
+          name: provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_12
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-client-flatten: true
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: FlattenedProductProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_36
     type: object
     apiVersions:
@@ -851,6 +904,67 @@ schemas: !<!Schemas>
     protocol: !<!Protocols> {}
   - *ref_17
   - *ref_14
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 1.0.0
+    properties:
+    - !<!Property> 
+      schema: *ref_18
+      required: true
+      serializedName: max_product_display_name
+      language: !<!Languages> 
+        default:
+          name: maxProductDisplayName
+          description: Display name of product.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_19
+      required: true
+      serializedName: max_product_capacity
+      language: !<!Languages> 
+        default:
+          name: capacity
+          description: 'Capacity of product. For example, 4 people.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_20
+      flattenedNames:
+      - max_product_image
+      - generic_value
+      required: false
+      serializedName: generic_value
+      language: !<!Languages> 
+        default:
+          name: genericValue
+          description: Generic URL value.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      flattenedNames:
+      - max_product_image
+      - '@odata.value'
+      required: false
+      serializedName: '@odata.value'
+      language: !<!Languages> 
+        default:
+          name: odataValue
+          description: URL value.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: SimpleProductProperties
+        description: The product documentation.
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_34
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/storage/flattened.yaml
+++ b/modelerfour/test/scenarios/storage/flattened.yaml
@@ -683,8 +683,8 @@ schemas: !<!Schemas>
                     serializationFormats:
                     - json
                     usage:
-                    - output
                     - input
+                    - output
                     language: !<!Languages> 
                       default:
                         name: Bar
@@ -700,8 +700,8 @@ schemas: !<!Schemas>
                 serializationFormats:
                 - json
                 usage:
-                - output
                 - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: Foo
@@ -717,8 +717,8 @@ schemas: !<!Schemas>
             serializationFormats:
             - json
             usage:
-            - output
             - input
+            - output
             language: !<!Languages> 
               default:
                 name: Endpoints
@@ -828,8 +828,8 @@ schemas: !<!Schemas>
             serializationFormats:
             - json
             usage:
-            - output
             - input
+            - output
             language: !<!Languages> 
               default:
                 name: CustomDomain
@@ -980,12 +980,185 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_22
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: Gets or sets the account type.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountPropertiesCreateParameters
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_23
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: Gets the status of the storage account at the time the operation was called.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: Gets the type of the storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: primaryEndpoints
+      language: !<!Languages> 
+        default:
+          name: primaryEndpoints
+          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_14
+      serializedName: primaryLocation
+      language: !<!Languages> 
+        default:
+          name: primaryLocation
+          description: Gets the location of the primary for the storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_15
+      serializedName: statusOfPrimary
+      language: !<!Languages> 
+        default:
+          name: statusOfPrimary
+          description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_16
+      serializedName: lastGeoFailoverTime
+      language: !<!Languages> 
+        default:
+          name: lastGeoFailoverTime
+          description: >-
+            Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the
+            accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_17
+      serializedName: secondaryLocation
+      language: !<!Languages> 
+        default:
+          name: secondaryLocation
+          description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_15
+      serializedName: statusOfSecondary
+      language: !<!Languages> 
+        default:
+          name: statusOfSecondary
+          description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_18
+      serializedName: creationTime
+      language: !<!Languages> 
+        default:
+          name: creationTime
+          description: Gets the creation date and time of the storage account in UTC.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      serializedName: customDomain
+      language: !<!Languages> 
+        default:
+          name: customDomain
+          description: Gets the user assigned custom domain assigned to this storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: secondaryEndpoints
+      language: !<!Languages> 
+        default:
+          name: secondaryEndpoints
+          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_13
   - *ref_30
   - *ref_31
   - *ref_21
   - *ref_24
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      serializedName: customDomain
+      language: !<!Languages> 
+        default:
+          name: customDomain
+          description: >-
+            User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom domain name
+            property.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountPropertiesUpdateParameters
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_68
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/storage/grouped.yaml
+++ b/modelerfour/test/scenarios/storage/grouped.yaml
@@ -683,8 +683,8 @@ schemas: !<!Schemas>
                     serializationFormats:
                     - json
                     usage:
-                    - output
                     - input
+                    - output
                     language: !<!Languages> 
                       default:
                         name: Bar
@@ -700,8 +700,8 @@ schemas: !<!Schemas>
                 serializationFormats:
                 - json
                 usage:
-                - output
                 - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: Foo
@@ -717,8 +717,8 @@ schemas: !<!Schemas>
             serializationFormats:
             - json
             usage:
-            - output
             - input
+            - output
             language: !<!Languages> 
               default:
                 name: Endpoints
@@ -828,8 +828,8 @@ schemas: !<!Schemas>
             serializationFormats:
             - json
             usage:
-            - output
             - input
+            - output
             language: !<!Languages> 
               default:
                 name: CustomDomain
@@ -980,12 +980,185 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_22
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: Gets or sets the account type.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountPropertiesCreateParameters
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_23
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: Gets the status of the storage account at the time the operation was called.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: Gets the type of the storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: primaryEndpoints
+      language: !<!Languages> 
+        default:
+          name: primaryEndpoints
+          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_14
+      serializedName: primaryLocation
+      language: !<!Languages> 
+        default:
+          name: primaryLocation
+          description: Gets the location of the primary for the storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_15
+      serializedName: statusOfPrimary
+      language: !<!Languages> 
+        default:
+          name: statusOfPrimary
+          description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_16
+      serializedName: lastGeoFailoverTime
+      language: !<!Languages> 
+        default:
+          name: lastGeoFailoverTime
+          description: >-
+            Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the
+            accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_17
+      serializedName: secondaryLocation
+      language: !<!Languages> 
+        default:
+          name: secondaryLocation
+          description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_15
+      serializedName: statusOfSecondary
+      language: !<!Languages> 
+        default:
+          name: statusOfSecondary
+          description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_18
+      serializedName: creationTime
+      language: !<!Languages> 
+        default:
+          name: creationTime
+          description: Gets the creation date and time of the storage account in UTC.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      serializedName: customDomain
+      language: !<!Languages> 
+        default:
+          name: customDomain
+          description: Gets the user assigned custom domain assigned to this storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: secondaryEndpoints
+      language: !<!Languages> 
+        default:
+          name: secondaryEndpoints
+          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_13
   - *ref_30
   - *ref_31
   - *ref_21
   - *ref_24
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      serializedName: customDomain
+      language: !<!Languages> 
+        default:
+          name: customDomain
+          description: >-
+            User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom domain name
+            property.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountPropertiesUpdateParameters
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_68
     type: object
     apiVersions:

--- a/modelerfour/test/scenarios/storage/modeler.yaml
+++ b/modelerfour/test/scenarios/storage/modeler.yaml
@@ -707,8 +707,8 @@ schemas: !<!Schemas>
                         serializationFormats:
                         - json
                         usage:
-                        - output
                         - input
+                        - output
                         language: !<!Languages> 
                           default:
                             name: Bar
@@ -724,8 +724,8 @@ schemas: !<!Schemas>
                     serializationFormats:
                     - json
                     usage:
-                    - output
                     - input
+                    - output
                     language: !<!Languages> 
                       default:
                         name: Foo
@@ -741,8 +741,8 @@ schemas: !<!Schemas>
                 serializationFormats:
                 - json
                 usage:
-                - output
                 - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: Endpoints
@@ -831,8 +831,8 @@ schemas: !<!Schemas>
                 serializationFormats:
                 - json
                 usage:
-                - output
                 - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: CustomDomain
@@ -856,8 +856,8 @@ schemas: !<!Schemas>
             serializationFormats:
             - json
             usage:
-            - output
             - input
+            - output
             language: !<!Languages> 
               default:
                 name: StorageAccountProperties

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -683,8 +683,8 @@ schemas: !<!Schemas>
                     serializationFormats:
                     - json
                     usage:
-                    - output
                     - input
+                    - output
                     language: !<!Languages> 
                       default:
                         name: Bar
@@ -700,8 +700,8 @@ schemas: !<!Schemas>
                 serializationFormats:
                 - json
                 usage:
-                - output
                 - input
+                - output
                 language: !<!Languages> 
                   default:
                     name: Foo
@@ -717,8 +717,8 @@ schemas: !<!Schemas>
             serializationFormats:
             - json
             usage:
-            - output
             - input
+            - output
             language: !<!Languages> 
               default:
                 name: Endpoints
@@ -828,8 +828,8 @@ schemas: !<!Schemas>
             serializationFormats:
             - json
             usage:
-            - output
             - input
+            - output
             language: !<!Languages> 
               default:
                 name: CustomDomain
@@ -980,12 +980,185 @@ schemas: !<!Schemas>
         namespace: ''
     protocol: !<!Protocols> {}
   - *ref_22
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: Gets or sets the account type.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountPropertiesCreateParameters
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_23
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_9
+      serializedName: provisioningState
+      language: !<!Languages> 
+        default:
+          name: provisioningState
+          description: Gets the status of the storage account at the time the operation was called.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: Gets the type of the storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: primaryEndpoints
+      language: !<!Languages> 
+        default:
+          name: primaryEndpoints
+          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_14
+      serializedName: primaryLocation
+      language: !<!Languages> 
+        default:
+          name: primaryLocation
+          description: Gets the location of the primary for the storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_15
+      serializedName: statusOfPrimary
+      language: !<!Languages> 
+        default:
+          name: statusOfPrimary
+          description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_16
+      serializedName: lastGeoFailoverTime
+      language: !<!Languages> 
+        default:
+          name: lastGeoFailoverTime
+          description: >-
+            Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the
+            accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_17
+      serializedName: secondaryLocation
+      language: !<!Languages> 
+        default:
+          name: secondaryLocation
+          description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_15
+      serializedName: statusOfSecondary
+      language: !<!Languages> 
+        default:
+          name: statusOfSecondary
+          description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_18
+      serializedName: creationTime
+      language: !<!Languages> 
+        default:
+          name: creationTime
+          description: Gets the creation date and time of the storage account in UTC.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      serializedName: customDomain
+      language: !<!Languages> 
+        default:
+          name: customDomain
+          description: Gets the user assigned custom domain assigned to this storage account.
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_13
+      serializedName: secondaryEndpoints
+      language: !<!Languages> 
+        default:
+          name: secondaryEndpoints
+          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountProperties
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - *ref_13
   - *ref_30
   - *ref_31
   - *ref_21
   - *ref_24
+  - !<!ObjectSchema> 
+    type: object
+    apiVersions:
+    - !<!ApiVersion> 
+      version: 2015-05-01-preview
+    properties:
+    - !<!Property> 
+      schema: *ref_8
+      serializedName: accountType
+      language: !<!Languages> 
+        default:
+          name: accountType
+          description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
+      protocol: !<!Protocols> {}
+    - !<!Property> 
+      schema: *ref_21
+      serializedName: customDomain
+      language: !<!Languages> 
+        default:
+          name: customDomain
+          description: >-
+            User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom domain name
+            property.
+      protocol: !<!Protocols> {}
+    serializationFormats:
+    - json
+    usage:
+    - input
+    - output
+    extensions:
+      x-ms-flattened: true
+    language: !<!Languages> 
+      default:
+        name: StorageAccountPropertiesUpdateParameters
+        description: ''
+        namespace: ''
+    protocol: !<!Protocols> {}
   - !<!ObjectSchema> &ref_68
     type: object
     apiVersions:

--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -1,0 +1,369 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from "assert";
+import { suite, test } from "mocha-typescript";
+import { ModelerFour } from "../../modeler/modelerfour";
+import { fail } from "@azure-tools/codegen";
+import { startSession } from "@azure-tools/autorest-extension-base";
+import { values } from "@azure-tools/linq";
+import { CodeModel, Schema, SchemaUsage } from "@azure-tools/codemodel";
+import { Model } from "@azure-tools/openapi";
+import { codeModelSchema } from "@azure-tools/codemodel";
+
+let modelerErrors: any[] = [];
+
+async function createTestSession(config: any, openApiModel: any) {
+  const openApiText = JSON.stringify(openApiModel);
+  const ii = [
+    {
+      model: openApiModel as Model,
+      filename: "openapi-3.json",
+      content: openApiText
+    }
+  ];
+
+  return await startSession<Model>(
+    {
+      ReadFile: async (filename: string): Promise<string> =>
+        (
+          values(ii).first(each => each.filename === filename) ||
+          fail(`missing input '${filename}'`)
+        ).content,
+      GetValue: async (key: string): Promise<any> => {
+        if (!key) {
+          return config;
+        }
+        return config[key];
+      },
+      ListInputs: async (artifactType?: string): Promise<Array<string>> =>
+        ii.map(each => each.filename),
+
+      ProtectFiles: async (path: string): Promise<void> => {
+        // test
+      },
+      WriteFile: (
+        filename: string,
+        content: string,
+        sourceMap?: any,
+        artifactType?: string
+      ): void => {
+        // test
+      },
+      Message: (message: any): void => {
+        // test
+        if (
+          message.Channel === "warning" ||
+          message.Channel === "error" ||
+          message.Channel === "verbose"
+        ) {
+          if (message.Channel === "error") {
+            modelerErrors.push(message);
+          }
+        }
+      },
+      UpdateConfigurationFile: (filename: string, content: string): void => {
+        // test
+      },
+      GetConfigurationFile: async (filename: string): Promise<string> => ""
+    },
+    {},
+    codeModelSchema
+  );
+}
+
+const cfg = {
+  modelerfour: {
+    "flatten-models": true,
+    "flatten-payloads": true,
+    "group-parameters": true,
+    "resolve-schema-name-collisons": true,
+    "additional-checks": true,
+    //'always-create-content-type-parameter': true,
+    naming: {
+      override: {
+        $host: "$host",
+        cmyk: "CMYK"
+      },
+      local: "_ + camel",
+      constantParameter: "pascal"
+    }
+  },
+  "payload-flattening-threshold": 2
+};
+
+export type TestSpecCustomizer = (spec: any) => any;
+
+const InitialTestSpec = {
+  info: {
+    title: "Test OpenAPI 3 Specification",
+    description: "A test document",
+    contact: {
+      name: "Microsoft Corporation",
+      url: "https://microsoft.com",
+      email: "devnull@microsoft.com"
+    },
+    license: "MIT",
+    version: "1.0"
+  },
+  paths: {},
+  components: {
+    schemas: {}
+  }
+};
+
+function createTestSpec(...customizers: TestSpecCustomizer[]): any {
+  return customizers.reduce<any>(
+    (spec: any, customizer: TestSpecCustomizer) => {
+      return customizer(spec);
+    },
+    { ...InitialTestSpec } // Don't modify the original
+  );
+}
+
+function addOperation(
+  spec: any,
+  path: string,
+  operationDict: any,
+  metadata: any = { apiVersions: ["1.0.0"] }
+): void {
+  operationDict = { ...operationDict, ...{ "x-ms-metadata": metadata } };
+  spec.paths[path] = operationDict;
+}
+
+function addSchema(
+  spec: any,
+  name: string,
+  schemaDict: any,
+  metadata: any = { apiVersions: ["1.0.0"] }
+): void {
+  schemaDict = { ...schemaDict, ...{ "x-ms-metadata": metadata } };
+  spec.components.schemas[name] = schemaDict;
+}
+
+async function runModeler(spec: any): Promise<CodeModel> {
+  modelerErrors = [];
+  const session = await createTestSession(cfg, spec);
+  const modeler = await new ModelerFour(session).init();
+
+  assert.equal(modelerErrors.length, 0);
+
+  return modeler.process();
+}
+
+function response(
+  code: number | "default",
+  contentType: string,
+  schema: any,
+  description: string = "The response."
+) {
+  return {
+    [code]: {
+      description,
+      content: {
+        [contentType]: {
+          schema
+        }
+      }
+    }
+  };
+}
+
+function responses(...responses: any[]) {
+  return responses.reduce(
+    (responsesDict, response) => Object.assign(responsesDict, response),
+    {}
+  );
+}
+
+function properties(...properties: any[]) {
+  // TODO: Accept string or property object
+}
+
+function assertSchema(
+  schemaName: string,
+  schemaList: any[] | undefined,
+  accessor: (schema: any) => any,
+  expected: any
+) {
+  assert(
+    schemaList,
+    `Schema list was empty when searching for schema: ${schemaName}`
+  );
+
+  // We've already asserted, but make the compiler happy
+  if (schemaList) {
+    const schema = schemaList.find(s => s.language.default.name === schemaName);
+    assert(schema, `Could not find schema in code model: ${schemaName}`);
+    assert.deepEqual(accessor(schema), expected);
+  }
+}
+
+// @suite
+@suite.only
+class Modeler {
+  @test
+  async "preserves 'info' metadata"() {
+    const spec = createTestSpec();
+    const codeModel = await runModeler(spec);
+
+    assert.strictEqual(codeModel.info.title, InitialTestSpec.info.title);
+    assert.strictEqual(codeModel.info.license, InitialTestSpec.info.license);
+    assert.strictEqual(
+      codeModel.info.description,
+      InitialTestSpec.info.description
+    );
+    assert.strictEqual(
+      codeModel.info.contact?.name,
+      InitialTestSpec.info.contact.name
+    );
+    assert.strictEqual(
+      codeModel.info.contact?.url,
+      InitialTestSpec.info.contact.url
+    );
+    assert.strictEqual(
+      codeModel.info.contact?.email,
+      InitialTestSpec.info.contact.email
+    );
+  }
+
+  @test
+  async "tracks schema usage"() {
+    const testSchema = {
+      type: "object",
+      properties: {
+        "prop-one": {
+          type: "integer",
+          format: "int32"
+        }
+      }
+    };
+
+    const spec = createTestSpec();
+
+    addSchema(spec, "Input", {
+      type: "object",
+      properties: {
+        arrayProperty: {
+          type: "array",
+          items: {
+            $ref: "#/components/schemas/ElementSchema"
+          }
+        }
+      }
+    });
+    addSchema(spec, "OutputItem", {
+      type: "object",
+      properties: {
+        dictionaryProperty: {
+          properties: {
+            foo: {
+              $ref: "#/components/schemas/ElementSchema"
+            }
+          }
+        }
+      }
+    });
+    addSchema(spec, "InputOutput", {
+      type: "object",
+      properties: {
+        property: {
+          $ref: "#/components/schemas/ObjectProperty"
+        }
+      }
+    });
+    addSchema(spec, "ObjectProperty", {
+      type: "object",
+      properties: {
+        foo: {
+          type: "string"
+        }
+      }
+    });
+    addSchema(spec, "ElementSchema", {
+      type: "object",
+      properties: {
+        foo: {
+          type: "string"
+        }
+      }
+    });
+
+    addOperation(spec, "/test", {
+      get: {
+        description: "An operation.",
+        responses: responses(
+          response(200, "application/json", {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/OutputItem"
+            }
+          }),
+          response(202, "application/xml", {
+            $ref: "#/components/schemas/InputOutput"
+          })
+        )
+      },
+      post: {
+        description: "Post it.",
+        parameters: [
+          {
+            name: "inputParam",
+            in: "body",
+            description: "Input parameter",
+            required: true,
+            schema: {
+              $ref: "#/components/schemas/Input"
+            }
+          },
+          {
+            name: "inputOutputParam",
+            in: "body",
+            description: "Input parameter",
+            required: true,
+            schema: {
+              $ref: "#/components/schemas/InputOutput"
+            }
+          }
+        ]
+      }
+    });
+
+    const codeModel = await runModeler(spec);
+
+    // Ensure that usage gets propagated to schemas in request parameters
+    assertSchema("Input", codeModel.schemas.objects, s => s.usage, ["input"]);
+
+    // Ensure that usage gets propagated to properties in response schemas
+    assertSchema("OutputItem", codeModel.schemas.objects, s => s.usage, [
+      "output"
+    ]);
+
+    // Ensure that usage gets propagated to schemas used in both request and response
+    assertSchema(
+      "InputOutput",
+      codeModel.schemas.objects,
+      s => s.usage.sort(),
+      ["input", "output"]
+    );
+
+    // Ensure that usage gets propagated to schems on object properties
+    assertSchema(
+      "ObjectProperty",
+      codeModel.schemas.objects,
+      s => s.usage.sort(),
+      ["input", "output"]
+    );
+
+    // Ensure that usage gets propagated to schemas used as elements of
+    // arrays and dictionary property values
+    assertSchema(
+      "ElementSchema",
+      codeModel.schemas.objects,
+      s => s.usage.sort(),
+      ["input", "output"]
+    );
+  }
+}


### PR DESCRIPTION
This change addresses #249 which reports that schema usage was not being correctly reported on a schema that was referenced as the property of an object schema used in an array.  The issue is caused by a logic bug which caused `ArraySchema` and `DictionarySchema` instances to be skipped, preventing schema usage from being propagated through to their element schemas.

This change also establishes a basic unit testing pattern for modelerfour so that we can directly test  the resulting CodeModel object without the need for file diffing.  Be sure to take a look at `modelerfour/test/unit/modelerfour.test.ts` at the bottom of the PR.

There are a number of changes to the `modelerfour` output for testserver specs, my guess is that there have been changes to the testserver since the last generation which added new schems that are now being reflected in the output.

/cc @pakrym 