### PR TITLE
Loopify recursive checkForDuplicateSchemas call to avoid heap crash

### DIFF
--- a/modelerfour/quality-precheck/prechecker.ts
+++ b/modelerfour/quality-precheck/prechecker.ts
@@ -186,6 +186,8 @@ export class QualityPreChecker {
   checkForDuplicateSchemas(): undefined {
     const errors = new Set<string>();
 
+    this.session.warning('Checking for duplicate schemas, this could take a (long) while.  Run with --verbose for more detail.', ['PreCheck', 'CheckDuplicateSchemas']);
+
     // Returns true if scanning should be restarted
     const innerCheckForDuplicateSchemas = (): any => {
       if (this.input.components && this.input.components.schemas) {

--- a/modelerfour/test/errors/parent-name-conflict/expected.yaml
+++ b/modelerfour/test/errors/parent-name-conflict/expected.yaml
@@ -6,4 +6,4 @@ warning:
 - 'The schema ''ChildHidingParentProperty'' with an undefined type and decalared properties is a bit ambigious. This has been auto-corrected to ''type:object'''
 - 'The schema ''Resource'' with an undefined type and decalared properties is a bit ambigious. This has been auto-corrected to ''type:object'''
 - Schema 'ChildHidingParentProperty' has a property 'name' that is already declared the parent schema 'Resource' but 'readonly' has been changed -- this is not permitted. The property has been removed from ChildHidingParentProperty
-
+- 'Checking for duplicate schemas, this could take a (long) while.  Run with --verbose for more detail.'


### PR DESCRIPTION
This change addresses #285 which reports that running AutoRest with Modelerfour 4.13.351 on the SQL service spec causes a fatal heap allocation error:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 0xa0e670 node::Abort() [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
 2: 0xa0ea9c node::OnFatalError(char const*, char const*) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
 3: 0xb83afe v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
 4: 0xb83e79 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
 5: 0xd32305  [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
 6: 0xd32996 v8::internal::Heap::RecomputeLimits(v8::internal::GarbageCollector) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
 7: 0xd41209 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::GCCallbackFlags) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
 8: 0xd42045 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
 9: 0xd44b1c v8::internal::Heap::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
10: 0xd0bd22 v8::internal::Handle<v8::internal::FixedArray> v8::internal::Factory::NewFixedArrayWithMap<v8::internal::FixedArray>(v8::internal::RootIndex, int, v8::internal::AllocationType) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
11: 0xf2c4b9 v8::internal::HashTable<v8::internal::NameDictionary, v8::internal::NameDictionaryShape>::New(v8::internal::Isolate*, int, v8::internal::AllocationType, v8::internal::MinimumCapacity) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
12: 0xf34c3e v8::internal::Dictionary<v8::internal::NameDictionary, v8::internal::NameDictionaryShape>::Add(v8::internal::Isolate*, v8::internal::Handle<v8::internal::NameDictionary>, v8::internal::Handle<v8::internal::Name>, v8::internal::Handle<v8::internal::Object>, v8::internal::PropertyDetails, int*) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
13: 0xf34db9 v8::internal::BaseNameDictionary<v8::internal::NameDictionary, v8::internal::NameDictionaryShape>::AddNoUpdateNextEnumerationIndex(v8::internal::Isolate*, v8::internal::Handle<v8::internal::NameDictionary>, v8::internal::Handle<v8::internal::Name>, v8::internal::Handle<v8::internal::Object>, v8::internal::PropertyDetails, int*) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
14: 0xf37313 v8::internal::BaseNameDictionary<v8::internal::NameDictionary, v8::internal::NameDictionaryShape>::Add(v8::internal::Isolate*, v8::internal::Handle<v8::internal::NameDictionary>, v8::internal::Handle<v8::internal::Name>, v8::internal::Handle<v8::internal::Object>, v8::internal::PropertyDetails, int*) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
15: 0xefff72 v8::internal::LookupIterator::ApplyTransitionToDataProperty(v8::internal::Handle<v8::internal::JSReceiver>) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
16: 0xf314b1 v8::internal::Object::AddDataProperty(v8::internal::LookupIterator*, v8::internal::Handle<v8::internal::Object>, v8::internal::PropertyAttributes, v8::Maybe<v8::internal::ShouldThrow>, v8::internal::StoreOrigin) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
17: 0xedb110 v8::internal::JSObject::DefineOwnPropertyIgnoreAttributes(v8::internal::LookupIterator*, v8::internal::Handle<v8::internal::Object>, v8::internal::PropertyAttributes, v8::Maybe<v8::internal::ShouldThrow>, v8::internal::JSObject::AccessorInfoHandling) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
18: 0xedb349 v8::internal::JSObject::DefineOwnPropertyIgnoreAttributes(v8::internal::LookupIterator*, v8::internal::Handle<v8::internal::Object>, v8::internal::PropertyAttributes, v8::internal::JSObject::AccessorInfoHandling) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
19: 0xe21ed0 v8::internal::JsonParser<unsigned short>::BuildJsonObject(v8::internal::JsonParser<unsigned short>::JsonContinuation const&, std::vector<v8::internal::JsonProperty, std::allocator<v8::internal::JsonProperty> > const&, v8::internal::Handle<v8::internal::Map>) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
20: 0xe22a83 v8::internal::JsonParser<unsigned short>::ParseJsonValue() [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
21: 0xe2393f v8::internal::JsonParser<unsigned short>::ParseJson() [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
22: 0xc36f05 v8::internal::Builtin_JsonParse(int, unsigned long*, v8::internal::Isolate*) [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
23: 0x13da5f9  [/opt/hostedtoolcache/node/13.14.0/x64/bin/node]
Process() cancelled due to failure 
Invoke: /home/vsts/work/1/s/eng/Generation.psm1:45
Line |
  45 |      Invoke $command
     |      ~~~~~~~~~~~~~~~
     | Command failed to execute: /home/vsts/work/1/s/node_modules/.bin/autorest-beta --require=/home/vsts/work/1/s/readme.md https://github.com/Azure/azure-rest-api-specs/blob/d9cf7c7ed3d674ebd482836e82b274014245ae67/specification/network/resource-manager/readme.md --namespace=network_resource_manager --output-folder=/home/vsts/work/1/s/samples/smoketests/network-resource-manager/network-resource-manager
```

The fix is to convert the recursive invocation of `checkForDuplicateSchemas` into a loop so that the call stack no longer preserves huge amounts of data when processing large service specs.  I do this by creating a nested function called `innerCheckForDuplicateSchemas` that is invoked in a `while` loop and runs until this function returns something other than `true` (which indicates a duplicate was found and the scan should be performed again).