### PR TITLE
Add Exception to usage information

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -1557,8 +1557,13 @@ export class ModelerFour {
               s = (<ConstantSchema>s).valueType;
             }
 
-            // Track the usage of this schema as an output with media type
-            this.trackSchemaUsage(s, { usage: [SchemaContext.Output], serializationFormats: [knownMediaType as KnownMediaType] });
+            if (isErr) {
+              // Track the usage of this schema as an exception with media type
+              this.trackSchemaUsage(s, { usage: [SchemaContext.Exception], serializationFormats: [knownMediaType as KnownMediaType] });
+            } else {
+              // Track the usage of this schema as an output with media type
+              this.trackSchemaUsage(s, { usage: [SchemaContext.Output], serializationFormats: [knownMediaType as KnownMediaType] });
+            }
 
             const rsp = new SchemaResponse(s, {
               extensions: this.interpret.getExtensionProperties(response)

--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/modelerfour",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "description": "AutoRest Modeler Version Four (component)",
   "directories": {
     "doc": "docs"

--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -1,6 +1,10 @@
 # AutoRest Modeler Four 
 
 ## Changelog:
+#### 4.14.x
+  - added `exception` SchemaContext for `usage` when used as an exception response
+  - changed `output` SchemaContext for `usage` to no longer include exception response uses
+
 #### 4.13.x 
   - add security info (checks to see if `input.components?.securitySchemes` has any content)
   - sync version of m4 and perks/codemodel == 4.13.x

--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -582,7 +582,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -582,7 +582,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/a-playground/modeler.yaml
+++ b/modelerfour/test/scenarios/a-playground/modeler.yaml
@@ -582,7 +582,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -582,7 +582,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/additionalProperties/flattened.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/flattened.yaml
@@ -287,7 +287,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/additionalProperties/grouped.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/grouped.yaml
@@ -287,7 +287,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/additionalProperties/modeler.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/modeler.yaml
@@ -287,7 +287,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/additionalProperties/namer.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/namer.yaml
@@ -287,7 +287,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-parameter-grouping/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/flattened.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
@@ -404,7 +404,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-parameter-grouping/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/modeler.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
@@ -404,7 +404,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-report/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-report/flattened.yaml
@@ -86,7 +86,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-report/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-report/grouped.yaml
@@ -86,7 +86,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-report/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-report/modeler.yaml
@@ -86,7 +86,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-report/namer.yaml
+++ b/modelerfour/test/scenarios/azure-report/namer.yaml
@@ -86,7 +86,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
@@ -272,7 +272,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
@@ -272,7 +272,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
@@ -289,7 +289,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -272,7 +272,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-resource/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource/flattened.yaml
@@ -272,7 +272,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-resource/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource/grouped.yaml
@@ -272,7 +272,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-resource/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource/modeler.yaml
@@ -289,7 +289,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -272,7 +272,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-special-properties/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/flattened.yaml
@@ -150,7 +150,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
@@ -194,7 +194,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-special-properties/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/modeler.yaml
@@ -150,7 +150,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/azure-special-properties/namer.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/namer.yaml
@@ -194,7 +194,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/blob-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/blob-storage/flattened.yaml
@@ -9658,7 +9658,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: StorageError
@@ -10881,7 +10881,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - xml
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: DataLakeStorageErrorInner
@@ -10897,7 +10897,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: DataLakeStorageError

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -14598,7 +14598,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: StorageError
@@ -15821,7 +15821,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - xml
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: DataLakeStorageErrorInner
@@ -15837,7 +15837,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: DataLakeStorageError

--- a/modelerfour/test/scenarios/blob-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/blob-storage/modeler.yaml
@@ -9658,7 +9658,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: StorageError
@@ -10881,7 +10881,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - xml
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: DataLakeStorageErrorInner
@@ -10897,7 +10897,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: DataLakeStorageError

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -14598,7 +14598,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: StorageError
@@ -15821,7 +15821,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - xml
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: DataLakeStorageErrorInner
@@ -15837,7 +15837,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: DataLakeStorageError

--- a/modelerfour/test/scenarios/body-array/flattened.yaml
+++ b/modelerfour/test/scenarios/body-array/flattened.yaml
@@ -312,7 +312,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-array/grouped.yaml
+++ b/modelerfour/test/scenarios/body-array/grouped.yaml
@@ -312,7 +312,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-array/modeler.yaml
+++ b/modelerfour/test/scenarios/body-array/modeler.yaml
@@ -312,7 +312,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-array/namer.yaml
+++ b/modelerfour/test/scenarios/body-array/namer.yaml
@@ -312,7 +312,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-boolean.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/flattened.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-boolean.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/grouped.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-boolean.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/modeler.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-boolean/flattened.yaml
+++ b/modelerfour/test/scenarios/body-boolean/flattened.yaml
@@ -101,7 +101,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-boolean/grouped.yaml
+++ b/modelerfour/test/scenarios/body-boolean/grouped.yaml
@@ -101,7 +101,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-boolean/modeler.yaml
+++ b/modelerfour/test/scenarios/body-boolean/modeler.yaml
@@ -101,7 +101,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-boolean/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean/namer.yaml
@@ -101,7 +101,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-byte/flattened.yaml
+++ b/modelerfour/test/scenarios/body-byte/flattened.yaml
@@ -68,7 +68,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-byte/grouped.yaml
+++ b/modelerfour/test/scenarios/body-byte/grouped.yaml
@@ -68,7 +68,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-byte/modeler.yaml
+++ b/modelerfour/test/scenarios/body-byte/modeler.yaml
@@ -68,7 +68,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-byte/namer.yaml
+++ b/modelerfour/test/scenarios/body-byte/namer.yaml
@@ -68,7 +68,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -587,7 +587,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -587,7 +587,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-complex/modeler.yaml
+++ b/modelerfour/test/scenarios/body-complex/modeler.yaml
@@ -587,7 +587,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -587,7 +587,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-date/flattened.yaml
+++ b/modelerfour/test/scenarios/body-date/flattened.yaml
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-date/grouped.yaml
+++ b/modelerfour/test/scenarios/body-date/grouped.yaml
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-date/modeler.yaml
+++ b/modelerfour/test/scenarios/body-date/modeler.yaml
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-date/namer.yaml
+++ b/modelerfour/test/scenarios/body-date/namer.yaml
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/flattened.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/flattened.yaml
@@ -82,7 +82,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/grouped.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/grouped.yaml
@@ -82,7 +82,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/modeler.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/modeler.yaml
@@ -82,7 +82,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
@@ -82,7 +82,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-datetime/flattened.yaml
+++ b/modelerfour/test/scenarios/body-datetime/flattened.yaml
@@ -95,7 +95,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-datetime/grouped.yaml
+++ b/modelerfour/test/scenarios/body-datetime/grouped.yaml
@@ -95,7 +95,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-datetime/modeler.yaml
+++ b/modelerfour/test/scenarios/body-datetime/modeler.yaml
@@ -95,7 +95,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-datetime/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime/namer.yaml
@@ -95,7 +95,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-dictionary/flattened.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/flattened.yaml
@@ -426,7 +426,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-dictionary/grouped.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/grouped.yaml
@@ -426,7 +426,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-dictionary/modeler.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/modeler.yaml
@@ -426,7 +426,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-dictionary/namer.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/namer.yaml
@@ -426,7 +426,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-duration/flattened.yaml
+++ b/modelerfour/test/scenarios/body-duration/flattened.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-duration/grouped.yaml
+++ b/modelerfour/test/scenarios/body-duration/grouped.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-duration/modeler.yaml
+++ b/modelerfour/test/scenarios/body-duration/modeler.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-duration/namer.yaml
+++ b/modelerfour/test/scenarios/body-duration/namer.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-file/flattened.yaml
+++ b/modelerfour/test/scenarios/body-file/flattened.yaml
@@ -56,7 +56,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-file/grouped.yaml
+++ b/modelerfour/test/scenarios/body-file/grouped.yaml
@@ -56,7 +56,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-file/modeler.yaml
+++ b/modelerfour/test/scenarios/body-file/modeler.yaml
@@ -56,7 +56,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-file/namer.yaml
+++ b/modelerfour/test/scenarios/body-file/namer.yaml
@@ -56,7 +56,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-integer/flattened.yaml
+++ b/modelerfour/test/scenarios/body-integer/flattened.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-integer/grouped.yaml
+++ b/modelerfour/test/scenarios/body-integer/grouped.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-integer/modeler.yaml
+++ b/modelerfour/test/scenarios/body-integer/modeler.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-integer/namer.yaml
+++ b/modelerfour/test/scenarios/body-integer/namer.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-number.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/flattened.yaml
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-number.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/grouped.yaml
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-number.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/modeler.yaml
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-number.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/namer.yaml
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-number/flattened.yaml
+++ b/modelerfour/test/scenarios/body-number/flattened.yaml
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-number/grouped.yaml
+++ b/modelerfour/test/scenarios/body-number/grouped.yaml
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-number/modeler.yaml
+++ b/modelerfour/test/scenarios/body-number/modeler.yaml
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-number/namer.yaml
+++ b/modelerfour/test/scenarios/body-number/namer.yaml
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-string.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/flattened.yaml
@@ -185,7 +185,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-string.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/grouped.yaml
@@ -185,7 +185,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-string.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/modeler.yaml
@@ -185,7 +185,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-string.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/namer.yaml
@@ -185,7 +185,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-string/flattened.yaml
+++ b/modelerfour/test/scenarios/body-string/flattened.yaml
@@ -159,7 +159,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-string/grouped.yaml
+++ b/modelerfour/test/scenarios/body-string/grouped.yaml
@@ -159,7 +159,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-string/modeler.yaml
+++ b/modelerfour/test/scenarios/body-string/modeler.yaml
@@ -159,7 +159,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/body-string/namer.yaml
+++ b/modelerfour/test/scenarios/body-string/namer.yaml
@@ -159,7 +159,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/complex-model/flattened.yaml
+++ b/modelerfour/test/scenarios/complex-model/flattened.yaml
@@ -264,7 +264,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/complex-model/grouped.yaml
+++ b/modelerfour/test/scenarios/complex-model/grouped.yaml
@@ -264,7 +264,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/complex-model/modeler.yaml
+++ b/modelerfour/test/scenarios/complex-model/modeler.yaml
@@ -264,7 +264,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -264,7 +264,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/flattened.yaml
@@ -88,7 +88,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/grouped.yaml
@@ -88,7 +88,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/modeler.yaml
@@ -88,7 +88,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
@@ -88,7 +88,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/flattened.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/grouped.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/modeler.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
@@ -67,7 +67,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/datalake-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/flattened.yaml
@@ -2131,7 +2131,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: DataLakeStorageErrorInner
@@ -2147,7 +2147,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: DataLakeStorageError

--- a/modelerfour/test/scenarios/datalake-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/grouped.yaml
@@ -2131,7 +2131,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: DataLakeStorageErrorInner
@@ -2147,7 +2147,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: DataLakeStorageError

--- a/modelerfour/test/scenarios/datalake-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/modeler.yaml
@@ -2131,7 +2131,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: DataLakeStorageErrorInner
@@ -2147,7 +2147,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: DataLakeStorageError

--- a/modelerfour/test/scenarios/datalake-storage/namer.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/namer.yaml
@@ -2131,7 +2131,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: DataLakeStorageErrorInner
@@ -2147,7 +2147,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: DataLakeStorageError

--- a/modelerfour/test/scenarios/header/flattened.yaml
+++ b/modelerfour/test/scenarios/header/flattened.yaml
@@ -221,7 +221,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/header/grouped.yaml
+++ b/modelerfour/test/scenarios/header/grouped.yaml
@@ -221,7 +221,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/header/modeler.yaml
+++ b/modelerfour/test/scenarios/header/modeler.yaml
@@ -221,7 +221,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/header/namer.yaml
+++ b/modelerfour/test/scenarios/header/namer.yaml
@@ -221,7 +221,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/flattened.yaml
@@ -250,7 +250,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error
@@ -287,6 +287,7 @@ schemas: !<!Schemas>
               - json
             usage:
               - output
+              - exception
             language: !<!Languages> 
               default:
                 name: B
@@ -308,6 +309,7 @@ schemas: !<!Schemas>
         - json
       usage:
         - output
+        - exception
       language: !<!Languages> 
         default:
           name: MyException

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/grouped.yaml
@@ -250,7 +250,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error
@@ -287,6 +287,7 @@ schemas: !<!Schemas>
               - json
             usage:
               - output
+              - exception
             language: !<!Languages> 
               default:
                 name: B
@@ -308,6 +309,7 @@ schemas: !<!Schemas>
         - json
       usage:
         - output
+        - exception
       language: !<!Languages> 
         default:
           name: MyException

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/modeler.yaml
@@ -250,7 +250,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error
@@ -287,6 +287,7 @@ schemas: !<!Schemas>
               - json
             usage:
               - output
+              - exception
             language: !<!Languages> 
               default:
                 name: B
@@ -308,6 +309,7 @@ schemas: !<!Schemas>
         - json
       usage:
         - output
+        - exception
       language: !<!Languages> 
         default:
           name: MyException

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
@@ -250,7 +250,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error
@@ -287,6 +287,7 @@ schemas: !<!Schemas>
               - json
             usage:
               - output
+              - exception
             language: !<!Languages> 
               default:
                 name: B
@@ -308,6 +309,7 @@ schemas: !<!Schemas>
         - json
       usage:
         - output
+        - exception
       language: !<!Languages> 
         default:
           name: MyException

--- a/modelerfour/test/scenarios/httpInfrastructure/flattened.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/flattened.yaml
@@ -240,7 +240,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error
@@ -277,6 +277,7 @@ schemas: !<!Schemas>
               - json
             usage:
               - output
+              - exception
             language: !<!Languages> 
               default:
                 name: B
@@ -298,6 +299,7 @@ schemas: !<!Schemas>
         - json
       usage:
         - output
+        - exception
       language: !<!Languages> 
         default:
           name: MyException

--- a/modelerfour/test/scenarios/httpInfrastructure/grouped.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/grouped.yaml
@@ -240,7 +240,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error
@@ -277,6 +277,7 @@ schemas: !<!Schemas>
               - json
             usage:
               - output
+              - exception
             language: !<!Languages> 
               default:
                 name: B
@@ -298,6 +299,7 @@ schemas: !<!Schemas>
         - json
       usage:
         - output
+        - exception
       language: !<!Languages> 
         default:
           name: MyException

--- a/modelerfour/test/scenarios/httpInfrastructure/modeler.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/modeler.yaml
@@ -240,7 +240,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error
@@ -277,6 +277,7 @@ schemas: !<!Schemas>
               - json
             usage:
               - output
+              - exception
             language: !<!Languages> 
               default:
                 name: B
@@ -298,6 +299,7 @@ schemas: !<!Schemas>
         - json
       usage:
         - output
+        - exception
       language: !<!Languages> 
         default:
           name: MyException

--- a/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
@@ -240,7 +240,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error
@@ -277,6 +277,7 @@ schemas: !<!Schemas>
               - json
             usage:
               - output
+              - exception
             language: !<!Languages> 
               default:
                 name: B
@@ -298,6 +299,7 @@ schemas: !<!Schemas>
         - json
       usage:
         - output
+        - exception
       language: !<!Languages> 
         default:
           name: MyException

--- a/modelerfour/test/scenarios/keyvault/flattened.yaml
+++ b/modelerfour/test/scenarios/keyvault/flattened.yaml
@@ -2701,6 +2701,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
+              - exception
               - output
             language: !<!Languages> 
               default:
@@ -2718,7 +2719,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: KeyVaultError

--- a/modelerfour/test/scenarios/keyvault/grouped.yaml
+++ b/modelerfour/test/scenarios/keyvault/grouped.yaml
@@ -2701,6 +2701,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
+              - exception
               - output
             language: !<!Languages> 
               default:
@@ -2718,7 +2719,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: KeyVaultError

--- a/modelerfour/test/scenarios/keyvault/modeler.yaml
+++ b/modelerfour/test/scenarios/keyvault/modeler.yaml
@@ -2701,6 +2701,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
+              - exception
               - output
             language: !<!Languages> 
               default:
@@ -2718,7 +2719,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: KeyVaultError

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -2701,6 +2701,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
+              - exception
               - output
             language: !<!Languages> 
               default:
@@ -2718,7 +2719,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: KeyVaultError

--- a/modelerfour/test/scenarios/lro/flattened.yaml
+++ b/modelerfour/test/scenarios/lro/flattened.yaml
@@ -543,7 +543,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       extensions:
         x-ms-external: true
       language: !<!Languages> 

--- a/modelerfour/test/scenarios/lro/grouped.yaml
+++ b/modelerfour/test/scenarios/lro/grouped.yaml
@@ -543,7 +543,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       extensions:
         x-ms-external: true
       language: !<!Languages> 

--- a/modelerfour/test/scenarios/lro/modeler.yaml
+++ b/modelerfour/test/scenarios/lro/modeler.yaml
@@ -566,7 +566,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       extensions:
         x-ms-external: true
       language: !<!Languages> 

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -543,7 +543,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       extensions:
         x-ms-external: true
       language: !<!Languages> 

--- a/modelerfour/test/scenarios/model-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/model-flattening/flattened.yaml
@@ -453,7 +453,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -736,7 +736,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/model-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/model-flattening/modeler.yaml
@@ -469,7 +469,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -736,7 +736,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v1/flattened.yaml
+++ b/modelerfour/test/scenarios/multiapi-v1/flattened.yaml
@@ -99,7 +99,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v1/grouped.yaml
+++ b/modelerfour/test/scenarios/multiapi-v1/grouped.yaml
@@ -99,7 +99,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v1/modeler.yaml
+++ b/modelerfour/test/scenarios/multiapi-v1/modeler.yaml
@@ -99,7 +99,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v1/namer.yaml
+++ b/modelerfour/test/scenarios/multiapi-v1/namer.yaml
@@ -99,7 +99,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v2/flattened.yaml
+++ b/modelerfour/test/scenarios/multiapi-v2/flattened.yaml
@@ -155,7 +155,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v2/grouped.yaml
+++ b/modelerfour/test/scenarios/multiapi-v2/grouped.yaml
@@ -155,7 +155,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v2/modeler.yaml
+++ b/modelerfour/test/scenarios/multiapi-v2/modeler.yaml
@@ -155,7 +155,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v2/namer.yaml
+++ b/modelerfour/test/scenarios/multiapi-v2/namer.yaml
@@ -155,7 +155,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v3/flattened.yaml
+++ b/modelerfour/test/scenarios/multiapi-v3/flattened.yaml
@@ -169,7 +169,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v3/grouped.yaml
+++ b/modelerfour/test/scenarios/multiapi-v3/grouped.yaml
@@ -169,7 +169,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v3/modeler.yaml
+++ b/modelerfour/test/scenarios/multiapi-v3/modeler.yaml
@@ -169,7 +169,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/multiapi-v3/namer.yaml
+++ b/modelerfour/test/scenarios/multiapi-v3/namer.yaml
@@ -169,7 +169,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/report/flattened.yaml
+++ b/modelerfour/test/scenarios/report/flattened.yaml
@@ -86,7 +86,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/report/grouped.yaml
+++ b/modelerfour/test/scenarios/report/grouped.yaml
@@ -86,7 +86,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/report/modeler.yaml
+++ b/modelerfour/test/scenarios/report/modeler.yaml
@@ -86,7 +86,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/report/namer.yaml
+++ b/modelerfour/test/scenarios/report/namer.yaml
@@ -86,7 +86,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/required-optional/flattened.yaml
+++ b/modelerfour/test/scenarios/required-optional/flattened.yaml
@@ -147,7 +147,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/required-optional/grouped.yaml
+++ b/modelerfour/test/scenarios/required-optional/grouped.yaml
@@ -147,7 +147,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/required-optional/modeler.yaml
+++ b/modelerfour/test/scenarios/required-optional/modeler.yaml
@@ -147,7 +147,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/required-optional/namer.yaml
+++ b/modelerfour/test/scenarios/required-optional/namer.yaml
@@ -147,7 +147,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/flattened.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/flattened.yaml
@@ -129,7 +129,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/grouped.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/grouped.yaml
@@ -129,7 +129,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/modeler.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/modeler.yaml
@@ -129,7 +129,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
@@ -129,7 +129,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/text-analytics/flattened.yaml
+++ b/modelerfour/test/scenarios/text-analytics/flattened.yaml
@@ -1055,6 +1055,7 @@ schemas: !<!Schemas>
                             - json
                           usage:
                             - output
+                            - exception
                           language: !<!Languages> 
                             default:
                               name: InnerError
@@ -1090,6 +1091,7 @@ schemas: !<!Schemas>
                     serializationFormats:
                       - json
                     usage:
+                      - exception
                       - output
                     language: !<!Languages> 
                       default:

--- a/modelerfour/test/scenarios/text-analytics/grouped.yaml
+++ b/modelerfour/test/scenarios/text-analytics/grouped.yaml
@@ -1055,6 +1055,7 @@ schemas: !<!Schemas>
                             - json
                           usage:
                             - output
+                            - exception
                           language: !<!Languages> 
                             default:
                               name: InnerError
@@ -1090,6 +1091,7 @@ schemas: !<!Schemas>
                     serializationFormats:
                       - json
                     usage:
+                      - exception
                       - output
                     language: !<!Languages> 
                       default:

--- a/modelerfour/test/scenarios/text-analytics/modeler.yaml
+++ b/modelerfour/test/scenarios/text-analytics/modeler.yaml
@@ -1055,6 +1055,7 @@ schemas: !<!Schemas>
                             - json
                           usage:
                             - output
+                            - exception
                           language: !<!Languages> 
                             default:
                               name: InnerError
@@ -1090,6 +1091,7 @@ schemas: !<!Schemas>
                     serializationFormats:
                       - json
                     usage:
+                      - exception
                       - output
                     language: !<!Languages> 
                       default:

--- a/modelerfour/test/scenarios/text-analytics/namer.yaml
+++ b/modelerfour/test/scenarios/text-analytics/namer.yaml
@@ -1055,6 +1055,7 @@ schemas: !<!Schemas>
                             - json
                           usage:
                             - output
+                            - exception
                           language: !<!Languages> 
                             default:
                               name: InnerError
@@ -1090,6 +1091,7 @@ schemas: !<!Schemas>
                     serializationFormats:
                       - json
                     usage:
+                      - exception
                       - output
                     language: !<!Languages> 
                       default:

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
@@ -76,7 +76,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
@@ -76,7 +76,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
@@ -76,7 +76,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
@@ -76,7 +76,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/url/flattened.yaml
+++ b/modelerfour/test/scenarios/url/flattened.yaml
@@ -444,7 +444,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/url/grouped.yaml
+++ b/modelerfour/test/scenarios/url/grouped.yaml
@@ -444,7 +444,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/url/modeler.yaml
+++ b/modelerfour/test/scenarios/url/modeler.yaml
@@ -444,7 +444,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/url/namer.yaml
+++ b/modelerfour/test/scenarios/url/namer.yaml
@@ -444,7 +444,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/validation/flattened.yaml
+++ b/modelerfour/test/scenarios/validation/flattened.yaml
@@ -438,7 +438,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/validation/grouped.yaml
+++ b/modelerfour/test/scenarios/validation/grouped.yaml
@@ -438,7 +438,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/validation/modeler.yaml
+++ b/modelerfour/test/scenarios/validation/modeler.yaml
@@ -438,7 +438,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/validation/namer.yaml
+++ b/modelerfour/test/scenarios/validation/namer.yaml
@@ -438,7 +438,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/xml-service/flattened.yaml
+++ b/modelerfour/test/scenarios/xml-service/flattened.yaml
@@ -1368,7 +1368,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/xml-service/grouped.yaml
+++ b/modelerfour/test/scenarios/xml-service/grouped.yaml
@@ -1368,7 +1368,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/xml-service/modeler.yaml
+++ b/modelerfour/test/scenarios/xml-service/modeler.yaml
@@ -1368,7 +1368,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -1368,7 +1368,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - xml
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: Error

--- a/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   extensions:
                     x-ms-discriminator-value: InvalidResourceLink
                   language: !<!Languages> 
@@ -284,7 +284,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   language: !<!Languages> 
                     default:
                       name: AnimalNotFound
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: NotFoundErrorBase
@@ -354,7 +354,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: BaseError
@@ -424,7 +424,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   language: !<!Languages> 
                     default:
                       name: PetHungryOrThirstyError
@@ -466,7 +466,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: PetSadError
@@ -497,7 +497,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: PetActionError

--- a/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   extensions:
                     x-ms-discriminator-value: InvalidResourceLink
                   language: !<!Languages> 
@@ -284,7 +284,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   language: !<!Languages> 
                     default:
                       name: AnimalNotFound
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: NotFoundErrorBase
@@ -354,7 +354,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: BaseError
@@ -424,7 +424,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   language: !<!Languages> 
                     default:
                       name: PetHungryOrThirstyError
@@ -466,7 +466,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: PetSadError
@@ -497,7 +497,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: PetActionError

--- a/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   extensions:
                     x-ms-discriminator-value: InvalidResourceLink
                   language: !<!Languages> 
@@ -284,7 +284,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   language: !<!Languages> 
                     default:
                       name: AnimalNotFound
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: NotFoundErrorBase
@@ -354,7 +354,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: BaseError
@@ -424,7 +424,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   language: !<!Languages> 
                     default:
                       name: PetHungryOrThirstyError
@@ -466,7 +466,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: PetSadError
@@ -497,7 +497,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: PetActionError

--- a/modelerfour/test/scenarios/xms-error-responses/namer.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/namer.yaml
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   extensions:
                     x-ms-discriminator-value: InvalidResourceLink
                   language: !<!Languages> 
@@ -284,7 +284,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   language: !<!Languages> 
                     default:
                       name: AnimalNotFound
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: NotFoundErrorBase
@@ -354,7 +354,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: BaseError
@@ -424,7 +424,7 @@ schemas: !<!Schemas>
                   serializationFormats:
                     - json
                   usage:
-                    - output
+                    - exception
                   language: !<!Languages> 
                     default:
                       name: PetHungryOrThirstyError
@@ -466,7 +466,7 @@ schemas: !<!Schemas>
             serializationFormats:
               - json
             usage:
-              - output
+              - exception
             language: !<!Languages> 
               default:
                 name: PetSadError
@@ -497,7 +497,7 @@ schemas: !<!Schemas>
       serializationFormats:
         - json
       usage:
-        - output
+        - exception
       language: !<!Languages> 
         default:
           name: PetActionError


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.modelerfour/issues/296

Made non-exceptional responses as Output usage and exceptional responses as Exception.

This is a **breaking change** for generators using the `usage` node

(I need to test this still. Will do that tomorrow.)