### PR TITLE
Propagate `nullable` properties from OpenAPI 3 to CodeModel schemas

### DIFF
--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -19,7 +19,7 @@
     "watch": "tsc -p . --watch",
     "build": "tsc -p .",
     "prepack": "npm run static-link && npm run build",
-    "test": "npm run build && mocha dist/test  --timeout=200000"
+    "test": "npm run build && mocha dist/test --timeout=200000 && mocha dist/test/unit"
   },
   "repository": {
     "type": "git",

--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -383,6 +383,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -383,6 +383,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/a-playground/modeler.yaml
+++ b/modelerfour/test/scenarios/a-playground/modeler.yaml
@@ -383,6 +383,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_67
       type: dictionary
       elementType: *ref_12
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -383,6 +383,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryWrapperDefaultProgram

--- a/modelerfour/test/scenarios/additionalProperties/flattened.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/flattened.yaml
@@ -145,6 +145,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPString
@@ -153,6 +154,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInProperties-additionalProperties
@@ -161,6 +163,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_16
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
@@ -169,6 +172,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_19
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString-additionalProperties

--- a/modelerfour/test/scenarios/additionalProperties/grouped.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/grouped.yaml
@@ -145,6 +145,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPString
@@ -153,6 +154,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInProperties-additionalProperties
@@ -161,6 +163,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_16
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
@@ -169,6 +172,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_19
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString-additionalProperties

--- a/modelerfour/test/scenarios/additionalProperties/modeler.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/modeler.yaml
@@ -145,6 +145,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_13
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPString
@@ -153,6 +154,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInProperties-additionalProperties
@@ -161,6 +163,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_19
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
@@ -169,6 +172,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_18
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString-additionalProperties

--- a/modelerfour/test/scenarios/additionalProperties/namer.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/namer.yaml
@@ -145,6 +145,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPString
@@ -153,6 +154,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesAdditionalProperties
@@ -161,6 +163,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_16
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
@@ -169,6 +172,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_19
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPStringAdditionalProperties

--- a/modelerfour/test/scenarios/advisor/flattened.yaml
+++ b/modelerfour/test/scenarios/advisor/flattened.yaml
@@ -546,6 +546,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_45
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: RecommendationProperties-extendedProperties

--- a/modelerfour/test/scenarios/advisor/grouped.yaml
+++ b/modelerfour/test/scenarios/advisor/grouped.yaml
@@ -546,6 +546,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_45
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: RecommendationProperties-extendedProperties

--- a/modelerfour/test/scenarios/advisor/modeler.yaml
+++ b/modelerfour/test/scenarios/advisor/modeler.yaml
@@ -546,6 +546,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_61
       type: dictionary
       elementType: *ref_30
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: RecommendationProperties-extendedProperties

--- a/modelerfour/test/scenarios/advisor/namer.yaml
+++ b/modelerfour/test/scenarios/advisor/namer.yaml
@@ -546,6 +546,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_45
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: RecommendationPropertiesExtendedProperties

--- a/modelerfour/test/scenarios/azure-report/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-report/flattened.yaml
@@ -55,6 +55,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·obr50g·report-azure·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/azure-report/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-report/grouped.yaml
@@ -55,6 +55,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·obr50g·report-azure·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/azure-report/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-report/modeler.yaml
@@ -55,6 +55,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_6
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·obr50g·report-azure·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/azure-report/namer.yaml
+++ b/modelerfour/test/scenarios/azure-report/namer.yaml
@@ -55,6 +55,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger

--- a/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
@@ -104,6 +104,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceX-tags
@@ -232,6 +233,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -240,6 +242,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
@@ -104,6 +104,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceX-tags
@@ -232,6 +233,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -240,6 +242,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
@@ -104,6 +104,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceX-tags
@@ -249,6 +250,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -257,6 +259,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_13
       type: dictionary
       elementType: *ref_8
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -104,6 +104,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceXTags
@@ -232,6 +233,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfFlattenedProduct
@@ -240,6 +242,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollectionDictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource/flattened.yaml
@@ -104,6 +104,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -232,6 +233,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -240,6 +242,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource/grouped.yaml
@@ -104,6 +104,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -232,6 +233,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -240,6 +242,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource/modeler.yaml
@@ -104,6 +104,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -249,6 +250,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -257,6 +259,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_13
       type: dictionary
       elementType: *ref_8
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -104,6 +104,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceTags
@@ -232,6 +233,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfFlattenedProduct
@@ -240,6 +242,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollectionDictionaryofresources

--- a/modelerfour/test/scenarios/blob-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/blob-storage/flattened.yaml
@@ -7397,6 +7397,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_42
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ContainerMetadata
@@ -7405,6 +7406,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_90
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: BlobMetadata

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -7397,6 +7397,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_42
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ContainerMetadata
@@ -7405,6 +7406,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_90
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: BlobMetadata

--- a/modelerfour/test/scenarios/blob-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/blob-storage/modeler.yaml
@@ -7397,6 +7397,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_131
       type: dictionary
       elementType: *ref_26
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ContainerMetadata
@@ -7405,6 +7406,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_65
       type: dictionary
       elementType: *ref_64
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: BlobMetadata

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -7397,6 +7397,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_138
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ContainerMetadata
@@ -7405,6 +7406,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_186
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: BlobMetadata

--- a/modelerfour/test/scenarios/body-array/flattened.yaml
+++ b/modelerfour/test/scenarios/body-array/flattened.yaml
@@ -202,6 +202,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_25
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·p8a977·array-dictionary-null·get·responses·200·content·application-json·schema·items

--- a/modelerfour/test/scenarios/body-array/grouped.yaml
+++ b/modelerfour/test/scenarios/body-array/grouped.yaml
@@ -202,6 +202,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_25
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·p8a977·array-dictionary-null·get·responses·200·content·application-json·schema·items

--- a/modelerfour/test/scenarios/body-array/modeler.yaml
+++ b/modelerfour/test/scenarios/body-array/modeler.yaml
@@ -202,6 +202,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_25
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·p8a977·array-dictionary-null·get·responses·200·content·application-json·schema·items

--- a/modelerfour/test/scenarios/body-array/namer.yaml
+++ b/modelerfour/test/scenarios/body-array/namer.yaml
@@ -202,6 +202,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_25
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfString

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -388,6 +388,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -388,6 +388,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/body-complex/modeler.yaml
+++ b/modelerfour/test/scenarios/body-complex/modeler.yaml
@@ -388,6 +388,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_67
       type: dictionary
       elementType: *ref_12
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -388,6 +388,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryWrapperDefaultProgram

--- a/modelerfour/test/scenarios/body-dictionary/flattened.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/flattened.yaml
@@ -129,6 +129,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
@@ -137,6 +138,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
@@ -145,6 +147,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_28
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
@@ -153,6 +156,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_31
       type: dictionary
       elementType: *ref_3
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
@@ -161,6 +165,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_4
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -169,6 +174,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_35
       type: dictionary
       elementType: *ref_5
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -186,6 +192,7 @@ schemas: !<!Schemas>
             name: date
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
@@ -204,6 +211,7 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
@@ -222,6 +230,7 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
@@ -239,6 +248,7 @@ schemas: !<!Schemas>
             name: duration
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
@@ -257,6 +267,7 @@ schemas: !<!Schemas>
             name: paths·lgwr7z·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
@@ -275,6 +286,7 @@ schemas: !<!Schemas>
             name: paths·ul7uf·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
@@ -315,6 +327,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
@@ -333,6 +346,7 @@ schemas: !<!Schemas>
             name: paths·1y9iid6·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
@@ -351,6 +365,7 @@ schemas: !<!Schemas>
             name: paths·afa1hv·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
@@ -369,6 +384,7 @@ schemas: !<!Schemas>
             name: paths·1dxz488·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema

--- a/modelerfour/test/scenarios/body-dictionary/grouped.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/grouped.yaml
@@ -129,6 +129,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
@@ -137,6 +138,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
@@ -145,6 +147,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_28
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
@@ -153,6 +156,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_31
       type: dictionary
       elementType: *ref_3
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
@@ -161,6 +165,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_4
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -169,6 +174,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_35
       type: dictionary
       elementType: *ref_5
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -186,6 +192,7 @@ schemas: !<!Schemas>
             name: date
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
@@ -204,6 +211,7 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
@@ -222,6 +230,7 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
@@ -239,6 +248,7 @@ schemas: !<!Schemas>
             name: duration
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
@@ -257,6 +267,7 @@ schemas: !<!Schemas>
             name: paths·lgwr7z·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
@@ -275,6 +286,7 @@ schemas: !<!Schemas>
             name: paths·ul7uf·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
@@ -315,6 +327,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
@@ -333,6 +346,7 @@ schemas: !<!Schemas>
             name: paths·1y9iid6·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
@@ -351,6 +365,7 @@ schemas: !<!Schemas>
             name: paths·afa1hv·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
@@ -369,6 +384,7 @@ schemas: !<!Schemas>
             name: paths·1dxz488·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema

--- a/modelerfour/test/scenarios/body-dictionary/modeler.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/modeler.yaml
@@ -129,6 +129,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_23
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
@@ -137,6 +138,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
@@ -145,6 +147,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_28
       type: dictionary
       elementType: *ref_11
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
@@ -153,6 +156,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_31
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
@@ -161,6 +165,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_3
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -169,6 +174,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_35
       type: dictionary
       elementType: *ref_4
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -186,6 +192,7 @@ schemas: !<!Schemas>
             name: date
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
@@ -204,6 +211,7 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
@@ -222,6 +230,7 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
@@ -239,6 +248,7 @@ schemas: !<!Schemas>
             name: duration
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
@@ -257,6 +267,7 @@ schemas: !<!Schemas>
             name: paths·lgwr7z·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
@@ -275,6 +286,7 @@ schemas: !<!Schemas>
             name: paths·ul7uf·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
@@ -315,6 +327,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
@@ -333,6 +346,7 @@ schemas: !<!Schemas>
             name: paths·1y9iid6·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
@@ -351,6 +365,7 @@ schemas: !<!Schemas>
             name: paths·afa1hv·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
@@ -369,6 +384,7 @@ schemas: !<!Schemas>
             name: paths·1dxz488·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema

--- a/modelerfour/test/scenarios/body-dictionary/namer.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/namer.yaml
@@ -129,6 +129,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger
@@ -137,6 +138,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfString
@@ -145,6 +147,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_28
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfBoolean
@@ -153,6 +156,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_31
       type: dictionary
       elementType: *ref_3
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger
@@ -161,6 +165,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_4
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfNumber
@@ -169,6 +174,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_35
       type: dictionary
       elementType: *ref_5
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfNumber
@@ -186,6 +192,7 @@ schemas: !<!Schemas>
             name: Date
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfDate
@@ -204,6 +211,7 @@ schemas: !<!Schemas>
             name: DateTime
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfDateTime
@@ -222,6 +230,7 @@ schemas: !<!Schemas>
             name: DateTime
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfDateTime
@@ -239,6 +248,7 @@ schemas: !<!Schemas>
             name: Duration
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfDuration
@@ -257,6 +267,7 @@ schemas: !<!Schemas>
             name: ByteArray
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfByteArray
@@ -275,6 +286,7 @@ schemas: !<!Schemas>
             name: ByteArray
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfByteArray
@@ -315,6 +327,7 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfWidget
@@ -333,6 +346,7 @@ schemas: !<!Schemas>
             name: ArrayOfGet200ApplicationJsonAdditionalPropertiesItem
             description: Array of Get200ApplicationJsonAdditionalPropertiesItem
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfpaths1Y9Iid6DictionaryArrayNullGetResponses200ContentApplicationJsonSchemaAdditionalproperties
@@ -351,6 +365,7 @@ schemas: !<!Schemas>
             name: ArrayOfString
             description: Array of String
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfpathsAfa1HvDictionaryArrayEmptyGetResponses200ContentApplicationJsonSchemaAdditionalproperties
@@ -369,6 +384,7 @@ schemas: !<!Schemas>
             name: ArrayOfPutContentSchemaItemsItem
             description: Array of PutContentSchemaItemsItem
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfpaths1Dxz488DictionaryArrayValidPutRequestbodyContentApplicationJsonSchemaAdditionalproperties

--- a/modelerfour/test/scenarios/cognitive-search/flattened.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/flattened.yaml
@@ -817,6 +817,7 @@ schemas: !<!Schemas>
             name: components·1039crn·schemas·documentsearchresult·properties·search-facets·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Facets
@@ -843,6 +844,7 @@ schemas: !<!Schemas>
             name: components·1fouik0·schemas·searchresult·properties·search-highlights·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Highlights
@@ -1403,6 +1405,7 @@ schemas: !<!Schemas>
               properties:
                 - !<!Property> 
                   schema: *ref_47
+                  nullable: false
                   serializedName: '@search.action'
                   language: !<!Languages> 
                     default:

--- a/modelerfour/test/scenarios/cognitive-search/grouped.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/grouped.yaml
@@ -817,6 +817,7 @@ schemas: !<!Schemas>
             name: components·1039crn·schemas·documentsearchresult·properties·search-facets·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Facets
@@ -843,6 +844,7 @@ schemas: !<!Schemas>
             name: components·1fouik0·schemas·searchresult·properties·search-highlights·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Highlights
@@ -2506,6 +2508,7 @@ schemas: !<!Schemas>
               properties:
                 - !<!Property> 
                   schema: *ref_47
+                  nullable: false
                   serializedName: '@search.action'
                   language: !<!Languages> 
                     default:

--- a/modelerfour/test/scenarios/cognitive-search/modeler.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/modeler.yaml
@@ -817,6 +817,7 @@ schemas: !<!Schemas>
             name: components·1039crn·schemas·documentsearchresult·properties·search-facets·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Facets
@@ -843,6 +844,7 @@ schemas: !<!Schemas>
             name: components·1fouik0·schemas·searchresult·properties·search-highlights·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Highlights
@@ -1403,6 +1405,7 @@ schemas: !<!Schemas>
               properties:
                 - !<!Property> 
                   schema: *ref_29
+                  nullable: false
                   serializedName: '@search.action'
                   language: !<!Languages> 
                     default:

--- a/modelerfour/test/scenarios/cognitive-search/namer.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/namer.yaml
@@ -817,6 +817,7 @@ schemas: !<!Schemas>
             name: ArrayOfFacetResult
             description: Array of FacetResult
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Facets
@@ -843,6 +844,7 @@ schemas: !<!Schemas>
             name: ArrayOfSearchResultSearchHighlightsItemsItem
             description: Array of SearchResultSearchHighlightsItemsItem
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Highlights
@@ -2506,6 +2508,7 @@ schemas: !<!Schemas>
               properties:
                 - !<!Property> 
                   schema: *ref_78
+                  nullable: false
                   serializedName: '@search.action'
                   language: !<!Languages> 
                     default:

--- a/modelerfour/test/scenarios/complex-model/flattened.yaml
+++ b/modelerfour/test/scenarios/complex-model/flattened.yaml
@@ -182,6 +182,7 @@ schemas: !<!Schemas>
             name: components·5px1as·schemas·catalogdictionaryofarray·properties·productdictionaryofarray·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryOfArray-productDictionaryOfArray
@@ -190,6 +191,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_10
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionary-productDictionary
@@ -198,6 +200,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_11
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogArrayOfDictionary-productArrayOfDictionaryItem

--- a/modelerfour/test/scenarios/complex-model/grouped.yaml
+++ b/modelerfour/test/scenarios/complex-model/grouped.yaml
@@ -182,6 +182,7 @@ schemas: !<!Schemas>
             name: components·5px1as·schemas·catalogdictionaryofarray·properties·productdictionaryofarray·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryOfArray-productDictionaryOfArray
@@ -190,6 +191,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_10
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionary-productDictionary
@@ -198,6 +200,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_11
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogArrayOfDictionary-productArrayOfDictionaryItem

--- a/modelerfour/test/scenarios/complex-model/modeler.yaml
+++ b/modelerfour/test/scenarios/complex-model/modeler.yaml
@@ -182,6 +182,7 @@ schemas: !<!Schemas>
             name: components·5px1as·schemas·catalogdictionaryofarray·properties·productdictionaryofarray·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryOfArray-productDictionaryOfArray
@@ -190,6 +191,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_13
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionary-productDictionary
@@ -198,6 +200,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_14
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogArrayOfDictionary-productArrayOfDictionaryItem

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -182,6 +182,7 @@ schemas: !<!Schemas>
             name: ArrayOfProduct
             description: Array of Product
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryOfArrayProductDictionaryOfArray
@@ -190,6 +191,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_10
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryProductDictionary
@@ -198,6 +200,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_11
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogArrayOfDictionaryProductArrayOfDictionaryItem

--- a/modelerfour/test/scenarios/keyvault/flattened.yaml
+++ b/modelerfour/test/scenarios/keyvault/flattened.yaml
@@ -1557,6 +1557,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyCreateParameters-tags
@@ -1565,6 +1566,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_36
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyBundle-tags
@@ -1573,6 +1575,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_43
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyImportParameters-tags
@@ -1581,6 +1584,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_44
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyUpdateParameters-tags
@@ -1589,6 +1593,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_49
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyItem-tags
@@ -1597,6 +1602,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_64
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretSetParameters-tags
@@ -1605,6 +1611,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_74
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretBundle-tags
@@ -1613,6 +1620,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_78
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretUpdateParameters-tags
@@ -1621,6 +1629,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_83
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretItem-tags
@@ -1629,6 +1638,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_96
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateItem-tags
@@ -1637,6 +1647,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_124
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateBundle-tags
@@ -1645,6 +1656,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_158
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateCreateParameters-tags
@@ -1653,6 +1665,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_168
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateImportParameters-tags
@@ -1661,6 +1674,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_169
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateUpdateParameters-tags
@@ -1669,6 +1683,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_171
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateMergeParameters-tags
@@ -1677,6 +1692,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_183
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountItem-tags
@@ -1685,6 +1701,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_195
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageBundle-tags
@@ -1693,6 +1710,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_201
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountCreateParameters-tags
@@ -1701,6 +1719,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_204
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountUpdateParameters-tags
@@ -1709,6 +1728,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_213
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionItem-tags
@@ -1717,6 +1737,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_225
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionBundle-tags
@@ -1725,6 +1746,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_228
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionCreateParameters-tags
@@ -1733,6 +1755,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_231
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionUpdateParameters-tags
@@ -2230,6 +2253,7 @@ schemas: !<!Schemas>
                         properties:
                           - !<!Property> 
                             schema: *ref_7
+                            nullable: false
                             readOnly: true
                             serializedName: recoveryLevel
                             language: !<!Languages> 
@@ -2263,6 +2287,7 @@ schemas: !<!Schemas>
                         properties:
                           - !<!Property> 
                             schema: *ref_7
+                            nullable: false
                             readOnly: true
                             serializedName: recoveryLevel
                             language: !<!Languages> 
@@ -2346,6 +2371,7 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_7
+                nullable: false
                 readOnly: true
                 serializedName: recoveryLevel
                 language: !<!Languages> 
@@ -5450,6 +5476,7 @@ schemas: !<!Schemas>
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: *ref_7
+                        nullable: false
                         readOnly: true
                         serializedName: recoveryLevel
                         language: !<!Languages> 
@@ -6028,6 +6055,7 @@ schemas: !<!Schemas>
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: *ref_7
+                        nullable: false
                         readOnly: true
                         serializedName: recoveryLevel
                         language: !<!Languages> 

--- a/modelerfour/test/scenarios/keyvault/grouped.yaml
+++ b/modelerfour/test/scenarios/keyvault/grouped.yaml
@@ -1557,6 +1557,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyCreateParameters-tags
@@ -1565,6 +1566,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_36
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyBundle-tags
@@ -1573,6 +1575,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_43
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyImportParameters-tags
@@ -1581,6 +1584,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_44
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyUpdateParameters-tags
@@ -1589,6 +1593,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_49
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyItem-tags
@@ -1597,6 +1602,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_64
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretSetParameters-tags
@@ -1605,6 +1611,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_74
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretBundle-tags
@@ -1613,6 +1620,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_78
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretUpdateParameters-tags
@@ -1621,6 +1629,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_83
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretItem-tags
@@ -1629,6 +1638,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_96
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateItem-tags
@@ -1637,6 +1647,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_124
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateBundle-tags
@@ -1645,6 +1656,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_158
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateCreateParameters-tags
@@ -1653,6 +1665,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_168
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateImportParameters-tags
@@ -1661,6 +1674,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_169
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateUpdateParameters-tags
@@ -1669,6 +1683,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_171
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateMergeParameters-tags
@@ -1677,6 +1692,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_183
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountItem-tags
@@ -1685,6 +1701,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_195
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageBundle-tags
@@ -1693,6 +1710,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_201
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountCreateParameters-tags
@@ -1701,6 +1719,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_204
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountUpdateParameters-tags
@@ -1709,6 +1728,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_213
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionItem-tags
@@ -1717,6 +1737,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_225
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionBundle-tags
@@ -1725,6 +1746,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_228
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionCreateParameters-tags
@@ -1733,6 +1755,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_231
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionUpdateParameters-tags
@@ -2230,6 +2253,7 @@ schemas: !<!Schemas>
                         properties:
                           - !<!Property> 
                             schema: *ref_7
+                            nullable: false
                             readOnly: true
                             serializedName: recoveryLevel
                             language: !<!Languages> 
@@ -2263,6 +2287,7 @@ schemas: !<!Schemas>
                         properties:
                           - !<!Property> 
                             schema: *ref_7
+                            nullable: false
                             readOnly: true
                             serializedName: recoveryLevel
                             language: !<!Languages> 
@@ -2346,6 +2371,7 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_7
+                nullable: false
                 readOnly: true
                 serializedName: recoveryLevel
                 language: !<!Languages> 
@@ -5450,6 +5476,7 @@ schemas: !<!Schemas>
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: *ref_7
+                        nullable: false
                         readOnly: true
                         serializedName: recoveryLevel
                         language: !<!Languages> 
@@ -6028,6 +6055,7 @@ schemas: !<!Schemas>
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: *ref_7
+                        nullable: false
                         readOnly: true
                         serializedName: recoveryLevel
                         language: !<!Languages> 

--- a/modelerfour/test/scenarios/keyvault/modeler.yaml
+++ b/modelerfour/test/scenarios/keyvault/modeler.yaml
@@ -1557,6 +1557,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_204
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyCreateParameters-tags
@@ -1565,6 +1566,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_205
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyBundle-tags
@@ -1573,6 +1575,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_206
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyImportParameters-tags
@@ -1581,6 +1584,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_207
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyUpdateParameters-tags
@@ -1589,6 +1593,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_208
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyItem-tags
@@ -1597,6 +1602,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_209
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretSetParameters-tags
@@ -1605,6 +1611,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_210
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretBundle-tags
@@ -1613,6 +1620,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_211
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretUpdateParameters-tags
@@ -1621,6 +1629,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_212
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretItem-tags
@@ -1629,6 +1638,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_213
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateItem-tags
@@ -1637,6 +1647,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_214
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateBundle-tags
@@ -1645,6 +1656,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_215
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateCreateParameters-tags
@@ -1653,6 +1665,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_216
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateImportParameters-tags
@@ -1661,6 +1674,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_217
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateUpdateParameters-tags
@@ -1669,6 +1683,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_218
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateMergeParameters-tags
@@ -1677,6 +1692,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_219
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountItem-tags
@@ -1685,6 +1701,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_220
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageBundle-tags
@@ -1693,6 +1710,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_221
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountCreateParameters-tags
@@ -1701,6 +1719,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_222
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountUpdateParameters-tags
@@ -1709,6 +1728,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_223
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionItem-tags
@@ -1717,6 +1737,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_224
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionBundle-tags
@@ -1725,6 +1746,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_225
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionCreateParameters-tags
@@ -1733,6 +1755,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_226
       type: dictionary
       elementType: *ref_6
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionUpdateParameters-tags
@@ -2230,6 +2253,7 @@ schemas: !<!Schemas>
                         properties:
                           - !<!Property> 
                             schema: *ref_2
+                            nullable: false
                             readOnly: true
                             serializedName: recoveryLevel
                             language: !<!Languages> 
@@ -2263,6 +2287,7 @@ schemas: !<!Schemas>
                         properties:
                           - !<!Property> 
                             schema: *ref_2
+                            nullable: false
                             readOnly: true
                             serializedName: recoveryLevel
                             language: !<!Languages> 
@@ -2346,6 +2371,7 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_2
+                nullable: false
                 readOnly: true
                 serializedName: recoveryLevel
                 language: !<!Languages> 
@@ -5450,6 +5476,7 @@ schemas: !<!Schemas>
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: *ref_2
+                        nullable: false
                         readOnly: true
                         serializedName: recoveryLevel
                         language: !<!Languages> 
@@ -6028,6 +6055,7 @@ schemas: !<!Schemas>
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: *ref_2
+                        nullable: false
                         readOnly: true
                         serializedName: recoveryLevel
                         language: !<!Languages> 

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -1557,6 +1557,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyCreateParametersTags
@@ -1565,6 +1566,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_36
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyBundleTags
@@ -1573,6 +1575,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_43
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyImportParametersTags
@@ -1581,6 +1584,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_44
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyUpdateParametersTags
@@ -1589,6 +1593,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_49
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyItemTags
@@ -1597,6 +1602,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_64
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretSetParametersTags
@@ -1605,6 +1611,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_74
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretBundleTags
@@ -1613,6 +1620,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_78
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretUpdateParametersTags
@@ -1621,6 +1629,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_83
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretItemTags
@@ -1629,6 +1638,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_96
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateItemTags
@@ -1637,6 +1647,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_124
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateBundleTags
@@ -1645,6 +1656,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_158
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateCreateParametersTags
@@ -1653,6 +1665,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_168
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateImportParametersTags
@@ -1661,6 +1674,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_169
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateUpdateParametersTags
@@ -1669,6 +1683,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_171
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateMergeParametersTags
@@ -1677,6 +1692,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_183
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountItemTags
@@ -1685,6 +1701,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_195
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageBundleTags
@@ -1693,6 +1710,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_201
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountCreateParametersTags
@@ -1701,6 +1719,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_204
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountUpdateParametersTags
@@ -1709,6 +1728,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_213
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionItemTags
@@ -1717,6 +1737,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_225
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionBundleTags
@@ -1725,6 +1746,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_228
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionCreateParametersTags
@@ -1733,6 +1755,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_231
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionUpdateParametersTags
@@ -2230,6 +2253,7 @@ schemas: !<!Schemas>
                         properties:
                           - !<!Property> 
                             schema: *ref_7
+                            nullable: false
                             readOnly: true
                             serializedName: recoveryLevel
                             language: !<!Languages> 
@@ -2263,6 +2287,7 @@ schemas: !<!Schemas>
                         properties:
                           - !<!Property> 
                             schema: *ref_7
+                            nullable: false
                             readOnly: true
                             serializedName: recoveryLevel
                             language: !<!Languages> 
@@ -2346,6 +2371,7 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_7
+                nullable: false
                 readOnly: true
                 serializedName: recoveryLevel
                 language: !<!Languages> 
@@ -5450,6 +5476,7 @@ schemas: !<!Schemas>
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: *ref_7
+                        nullable: false
                         readOnly: true
                         serializedName: recoveryLevel
                         language: !<!Languages> 
@@ -6028,6 +6055,7 @@ schemas: !<!Schemas>
                         protocol: !<!Protocols> {}
                       - !<!Property> 
                         schema: *ref_7
+                        nullable: false
                         readOnly: true
                         serializedName: recoveryLevel
                         language: !<!Languages> 

--- a/modelerfour/test/scenarios/lro/flattened.yaml
+++ b/modelerfour/test/scenarios/lro/flattened.yaml
@@ -400,6 +400,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_8
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/lro/grouped.yaml
+++ b/modelerfour/test/scenarios/lro/grouped.yaml
@@ -400,6 +400,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_8
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/lro/modeler.yaml
+++ b/modelerfour/test/scenarios/lro/modeler.yaml
@@ -400,6 +400,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_20
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -400,6 +400,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_8
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceTags

--- a/modelerfour/test/scenarios/model-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/model-flattening/flattened.yaml
@@ -267,6 +267,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -405,6 +406,7 @@ schemas: !<!Schemas>
             description: Flattened product.
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1r824xk·model_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -413,6 +415,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_17
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -267,6 +267,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -405,6 +406,7 @@ schemas: !<!Schemas>
             description: Flattened product.
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1r824xk·model_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -413,6 +415,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_17
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/model-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/model-flattening/modeler.yaml
@@ -267,6 +267,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -421,6 +422,7 @@ schemas: !<!Schemas>
             description: Flattened product.
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1r824xk·model_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -429,6 +431,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_27
       type: dictionary
       elementType: *ref_10
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -267,6 +267,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceTags
@@ -405,6 +406,7 @@ schemas: !<!Schemas>
             description: Flattened product.
             namespace: ''
         protocol: !<!Protocols> {}
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfFlattenedProduct
@@ -413,6 +415,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_2
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollectionDictionaryofresources

--- a/modelerfour/test/scenarios/parameter-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/flattened.yaml
@@ -36,6 +36,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_1
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: AvailabilitySetUpdateParameters-tags

--- a/modelerfour/test/scenarios/parameter-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/grouped.yaml
@@ -36,6 +36,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_1
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: AvailabilitySetUpdateParameters-tags

--- a/modelerfour/test/scenarios/parameter-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/modeler.yaml
@@ -36,6 +36,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_1
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: AvailabilitySetUpdateParameters-tags

--- a/modelerfour/test/scenarios/parameter-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/namer.yaml
@@ -36,6 +36,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_1
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: AvailabilitySetUpdateParametersTags

--- a/modelerfour/test/scenarios/report/flattened.yaml
+++ b/modelerfour/test/scenarios/report/flattened.yaml
@@ -55,6 +55,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ifo91j·report·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/report/grouped.yaml
+++ b/modelerfour/test/scenarios/report/grouped.yaml
@@ -55,6 +55,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ifo91j·report·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/report/modeler.yaml
+++ b/modelerfour/test/scenarios/report/modeler.yaml
@@ -55,6 +55,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_6
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ifo91j·report·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/report/namer.yaml
+++ b/modelerfour/test/scenarios/report/namer.yaml
@@ -55,6 +55,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger

--- a/modelerfour/test/scenarios/storage/flattened.yaml
+++ b/modelerfour/test/scenarios/storage/flattened.yaml
@@ -441,6 +441,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_29
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/storage/grouped.yaml
+++ b/modelerfour/test/scenarios/storage/grouped.yaml
@@ -441,6 +441,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_29
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/storage/modeler.yaml
+++ b/modelerfour/test/scenarios/storage/modeler.yaml
@@ -441,6 +441,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_41
       type: dictionary
       elementType: *ref_8
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -441,6 +441,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_29
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceTags

--- a/modelerfour/test/scenarios/text-analytics/flattened.yaml
+++ b/modelerfour/test/scenarios/text-analytics/flattened.yaml
@@ -681,6 +681,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_21
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: InnerError-details

--- a/modelerfour/test/scenarios/text-analytics/grouped.yaml
+++ b/modelerfour/test/scenarios/text-analytics/grouped.yaml
@@ -681,6 +681,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_21
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: InnerError-details

--- a/modelerfour/test/scenarios/text-analytics/modeler.yaml
+++ b/modelerfour/test/scenarios/text-analytics/modeler.yaml
@@ -681,6 +681,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_94
       type: dictionary
       elementType: *ref_13
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: InnerError-details

--- a/modelerfour/test/scenarios/text-analytics/namer.yaml
+++ b/modelerfour/test/scenarios/text-analytics/namer.yaml
@@ -681,6 +681,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_21
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: InnerErrorDetails

--- a/modelerfour/test/scenarios/xml-service/flattened.yaml
+++ b/modelerfour/test/scenarios/xml-service/flattened.yaml
@@ -1013,6 +1013,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_32
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Metadata

--- a/modelerfour/test/scenarios/xml-service/grouped.yaml
+++ b/modelerfour/test/scenarios/xml-service/grouped.yaml
@@ -1013,6 +1013,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_32
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Metadata

--- a/modelerfour/test/scenarios/xml-service/modeler.yaml
+++ b/modelerfour/test/scenarios/xml-service/modeler.yaml
@@ -1013,6 +1013,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_67
       type: dictionary
       elementType: *ref_25
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Metadata

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -1013,6 +1013,7 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_32
       type: dictionary
       elementType: *ref_1
+      nullableItems: false
       language: !<!Languages> 
         default:
           name: Metadata


### PR DESCRIPTION
Issue #269 reports that `x-nullable` extensions in Swagger inputs don't have any effect on the outputted CodeModel. This change merely propagates the value for `nullable` on OpenAPI 3 schemas to their CodeModel counterparts.  Let me know if I missed any cases!