### PR TITLE
Allow unexpected 'format' values for 'integer' type

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -864,7 +864,10 @@ export class ModelerFour {
             return this.processNumberSchema(name, schema)
 
           default:
-            this.session.error(`Integer schema '${name}' with unknown format: '${schema.format}' is not valid`, ['Modeler'], schema);
+            // According to the OpenAPI v3 spec, an unexpected format should be ignored,
+            // so treat this as an `integer` with no format.
+            this.session.warning(`Integer schema '${name}' with unknown format: '${schema.format}' is not valid.  Treating it as 'int32'.`, ['Modeler'], schema);
+            return this.processIntegerSchema(name, schema);
         }
         break;
 

--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -367,6 +367,34 @@ class Modeler {
   }
 
   @test
+  async "allows integer schemas with unexpected 'format'"() {
+    const spec = createTestSpec();
+
+    addSchema(spec, "Int16", {
+      type: "integer",
+      format: "int16"
+    });
+
+    addSchema(spec, "Goose", {
+      type: "integer",
+      format: "goose"
+    });
+
+    addSchema(spec, "Int64", {
+      type: "integer",
+      format: "int64"
+    });
+
+    const codeModel = await runModeler(spec);
+
+    assertSchema("Int16", codeModel.schemas.numbers, s => s.precision, 32);
+    assertSchema("Goose", codeModel.schemas.numbers, s => s.precision, 32);
+
+    // Make sure a legitimate format is detected correctly
+    assertSchema("Int64", codeModel.schemas.numbers, s => s.precision, 64);
+  }
+
+  @test
   async "propagates 'nullable' to properties, parameters, and collections"() {
     const spec = createTestSpec();
 


### PR DESCRIPTION
This change removes an exception that we previously threw when an `integer` schema has an unexpected `format` value.  According to @darrellmiller in issue #299, the OpenAPI v3 specification states that unexpected `format` values should be treated as the default (`int32` in this case):

> However, to support documentation needs, the format property is an open string-valued property, and can have any value. Formats such as "email", "uuid", **and so on, MAY be used even though undefined by this specification**

I've added a unit test to exercise this functionality a bit to ensure that valid formats are treated correctly an unexpected formats are defaulted back to `int32`.