### PR TITLE
Fix recursive traversal of allOf/anyOf/oneOf in object schemas

### DIFF
--- a/modelerfour/prenamer/prenamer.ts
+++ b/modelerfour/prenamer/prenamer.ts
@@ -286,7 +286,7 @@ export class PreNamer {
     }
 
     for (const operationGroup of this.codeModel.operationGroups) {
-      setNameAllowEmpty(operationGroup, this.format.operationGroup, operationGroup.$key, this.format.override);
+      setNameAllowEmpty(operationGroup, this.format.operationGroup, operationGroup.$key, this.format.override, { removeDuplicates: false });
       for (const operation of operationGroup.operations) {
         setName(operation, this.format.operation, '', this.format.override);
 

--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -144,10 +144,10 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: pet-name
+          name: siamese-breed
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_30
+    - !<!StringSchema> &ref_31
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -157,7 +157,7 @@ schemas: !<!Schemas>
           name: cat-color
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_26
+    - !<!StringSchema> &ref_27
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -167,14 +167,14 @@ schemas: !<!Schemas>
           name: dog-food
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_28
+    - !<!StringSchema> &ref_30
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: siamese-breed
+          name: pet-name
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_38
@@ -1010,63 +1010,77 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_31
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: '2016-02-29'
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
-            properties:
-              - !<!Property> 
-                schema: *ref_26
-                serializedName: food
-                language: !<!Languages> 
-                  default:
-                    name: food
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: dog
-                description: ''
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_27
+          - !<!ObjectSchema> &ref_28
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: '2016-02-29'
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_29
+                - *ref_25
+              immediate:
+                - *ref_25
+            parents: !<!Relations> 
+              all:
+                - !<!ObjectSchema> &ref_26
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
-                      - *ref_27
+                      - !<!ObjectSchema> &ref_29
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: '2016-02-29'
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_26
+                          immediate:
+                            - *ref_26
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_27
+                            serializedName: food
+                            language: !<!Languages> 
+                              default:
+                                name: food
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: dog
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      - *ref_28
                       - *ref_25
                     immediate:
-                      - *ref_27
+                      - *ref_29
+                      - *ref_28
                   properties:
                     - !<!Property> 
-                      schema: *ref_28
-                      serializedName: breed
+                      schema: *ref_6
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: breed
+                          name: id
+                          description: ''
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_30
+                      serializedName: name
+                      language: !<!Languages> 
+                        default:
+                          name: name
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -1076,20 +1090,15 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: siamese
+                      name: pet
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_29
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
+                - *ref_26
             properties:
               - !<!Property> 
-                schema: *ref_30
+                schema: *ref_31
                 serializedName: color
                 language: !<!Languages> 
                   default:
@@ -1102,7 +1111,7 @@ schemas: !<!Schemas>
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  elementType: *ref_31
+                  elementType: *ref_29
                   language: !<!Languages> 
                     default:
                       name: cat-hates
@@ -1125,25 +1134,16 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_29
+          - *ref_26
         immediate:
-          - *ref_31
-          - *ref_27
+          - *ref_28
       properties:
         - !<!Property> 
-          schema: *ref_6
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: ''
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_32
-          serializedName: name
+          serializedName: breed
           language: !<!Languages> 
             default:
-              name: name
+              name: breed
               description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
@@ -1153,13 +1153,13 @@ schemas: !<!Schemas>
         - input
       language: !<!Languages> 
         default:
-          name: pet
+          name: siamese
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
-    - *ref_31
+    - *ref_28
     - *ref_29
+    - *ref_26
     - !<!ObjectSchema> &ref_35
       type: object
       apiVersions:
@@ -4350,7 +4350,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -4391,7 +4391,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_146
-                schema: *ref_29
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -144,10 +144,10 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: pet-name
+          name: siamese-breed
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_30
+    - !<!StringSchema> &ref_31
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -157,7 +157,7 @@ schemas: !<!Schemas>
           name: cat-color
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_26
+    - !<!StringSchema> &ref_27
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -167,14 +167,14 @@ schemas: !<!Schemas>
           name: dog-food
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_28
+    - !<!StringSchema> &ref_30
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: siamese-breed
+          name: pet-name
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_38
@@ -1010,63 +1010,77 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_31
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: '2016-02-29'
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
-            properties:
-              - !<!Property> 
-                schema: *ref_26
-                serializedName: food
-                language: !<!Languages> 
-                  default:
-                    name: food
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: dog
-                description: ''
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_27
+          - !<!ObjectSchema> &ref_28
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: '2016-02-29'
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_29
+                - *ref_25
+              immediate:
+                - *ref_25
+            parents: !<!Relations> 
+              all:
+                - !<!ObjectSchema> &ref_26
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
-                      - *ref_27
+                      - !<!ObjectSchema> &ref_29
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: '2016-02-29'
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_26
+                          immediate:
+                            - *ref_26
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_27
+                            serializedName: food
+                            language: !<!Languages> 
+                              default:
+                                name: food
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: dog
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      - *ref_28
                       - *ref_25
                     immediate:
-                      - *ref_27
+                      - *ref_29
+                      - *ref_28
                   properties:
                     - !<!Property> 
-                      schema: *ref_28
-                      serializedName: breed
+                      schema: *ref_6
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: breed
+                          name: id
+                          description: ''
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_30
+                      serializedName: name
+                      language: !<!Languages> 
+                        default:
+                          name: name
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -1076,20 +1090,15 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: siamese
+                      name: pet
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_29
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
+                - *ref_26
             properties:
               - !<!Property> 
-                schema: *ref_30
+                schema: *ref_31
                 serializedName: color
                 language: !<!Languages> 
                   default:
@@ -1102,7 +1111,7 @@ schemas: !<!Schemas>
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  elementType: *ref_31
+                  elementType: *ref_29
                   language: !<!Languages> 
                     default:
                       name: cat-hates
@@ -1125,25 +1134,16 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_29
+          - *ref_26
         immediate:
-          - *ref_31
-          - *ref_27
+          - *ref_28
       properties:
         - !<!Property> 
-          schema: *ref_6
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: ''
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_32
-          serializedName: name
+          serializedName: breed
           language: !<!Languages> 
             default:
-              name: name
+              name: breed
               description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
@@ -1153,13 +1153,13 @@ schemas: !<!Schemas>
         - input
       language: !<!Languages> 
         default:
-          name: pet
+          name: siamese
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
-    - *ref_31
+    - *ref_28
     - *ref_29
+    - *ref_26
     - !<!ObjectSchema> &ref_35
       type: object
       apiVersions:
@@ -4350,7 +4350,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -4391,7 +4391,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_146
-                schema: *ref_29
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/a-playground/modeler.yaml
+++ b/modelerfour/test/scenarios/a-playground/modeler.yaml
@@ -144,17 +144,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: pet-name
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_16
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      language: !<!Languages> 
-        default:
-          name: cat-color
+          name: siamese-breed
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_14
@@ -164,17 +154,27 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: dog-food
+          name: cat-color
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_18
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: siamese-breed
+          name: dog-food
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_16
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      language: !<!Languages> 
+        default:
+          name: pet-name
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_21
@@ -1005,68 +1005,82 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_15
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_17
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: '2016-02-29'
-            parents: !<!Relations> 
-              all:
-                - *ref_15
-              immediate:
-                - *ref_15
-            properties:
-              - !<!Property> 
-                schema: *ref_14
-                serializedName: food
-                language: !<!Languages> 
-                  default:
-                    name: food
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: dog
-                description: ''
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_19
+          - !<!ObjectSchema> &ref_18
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: '2016-02-29'
             children: !<!Relations> 
               all:
+                - *ref_19
+              immediate:
+                - *ref_19
+            parents: !<!Relations> 
+              all:
                 - !<!ObjectSchema> &ref_20
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
+                      - !<!ObjectSchema> &ref_17
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: '2016-02-29'
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_20
+                          immediate:
+                            - *ref_20
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_15
+                            serializedName: food
+                            language: !<!Languages> 
+                              default:
+                                name: food
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: dog
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      - *ref_18
                       - *ref_19
-                      - *ref_15
                     immediate:
-                      - *ref_19
+                      - *ref_17
+                      - *ref_18
                   properties:
                     - !<!Property> 
-                      schema: *ref_18
-                      serializedName: breed
+                      schema: *ref_3
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: breed
+                          name: id
+                          description: ''
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_16
+                      serializedName: name
+                      language: !<!Languages> 
+                        default:
+                          name: name
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -1076,20 +1090,15 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: siamese
+                      name: pet
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
                 - *ref_20
-            parents: !<!Relations> 
-              all:
-                - *ref_15
-              immediate:
-                - *ref_15
             properties:
               - !<!Property> 
-                schema: *ref_16
+                schema: *ref_14
                 serializedName: color
                 language: !<!Languages> 
                   default:
@@ -1127,23 +1136,14 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           - *ref_20
         immediate:
-          - *ref_17
-          - *ref_19
+          - *ref_18
       properties:
         - !<!Property> 
-          schema: *ref_3
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: ''
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_13
-          serializedName: name
+          serializedName: breed
           language: !<!Languages> 
             default:
-              name: name
+              name: breed
               description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
@@ -1153,11 +1153,11 @@ schemas: !<!Schemas>
         - input
       language: !<!Languages> 
         default:
-          name: pet
+          name: siamese
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_19
+    - *ref_18
     - *ref_17
     - *ref_20
     - !<!ObjectSchema> &ref_23
@@ -4109,7 +4109,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -4150,7 +4150,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_104
-                schema: *ref_20
+                schema: *ref_19
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -144,10 +144,10 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: PetName
+          name: SiameseBreed
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_30
+    - !<!StringSchema> &ref_31
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -157,7 +157,7 @@ schemas: !<!Schemas>
           name: CatColor
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_26
+    - !<!StringSchema> &ref_27
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -167,14 +167,14 @@ schemas: !<!Schemas>
           name: DogFood
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_28
+    - !<!StringSchema> &ref_30
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: SiameseBreed
+          name: PetName
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_38
@@ -1010,63 +1010,77 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_31
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: '2016-02-29'
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
-            properties:
-              - !<!Property> 
-                schema: *ref_26
-                serializedName: food
-                language: !<!Languages> 
-                  default:
-                    name: food
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: Dog
-                description: ''
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_27
+          - !<!ObjectSchema> &ref_28
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: '2016-02-29'
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_29
+                - *ref_25
+              immediate:
+                - *ref_25
+            parents: !<!Relations> 
+              all:
+                - !<!ObjectSchema> &ref_26
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
-                      - *ref_27
+                      - !<!ObjectSchema> &ref_29
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: '2016-02-29'
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_26
+                          immediate:
+                            - *ref_26
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_27
+                            serializedName: food
+                            language: !<!Languages> 
+                              default:
+                                name: food
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: Dog
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      - *ref_28
                       - *ref_25
                     immediate:
-                      - *ref_27
+                      - *ref_29
+                      - *ref_28
                   properties:
                     - !<!Property> 
-                      schema: *ref_28
-                      serializedName: breed
+                      schema: *ref_6
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: breed
+                          name: id
+                          description: ''
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_30
+                      serializedName: name
+                      language: !<!Languages> 
+                        default:
+                          name: name
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -1076,20 +1090,15 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: Siamese
+                      name: Pet
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_29
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
+                - *ref_26
             properties:
               - !<!Property> 
-                schema: *ref_30
+                schema: *ref_31
                 serializedName: color
                 language: !<!Languages> 
                   default:
@@ -1102,7 +1111,7 @@ schemas: !<!Schemas>
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  elementType: *ref_31
+                  elementType: *ref_29
                   language: !<!Languages> 
                     default:
                       name: CatHates
@@ -1125,25 +1134,16 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_29
+          - *ref_26
         immediate:
-          - *ref_31
-          - *ref_27
+          - *ref_28
       properties:
         - !<!Property> 
-          schema: *ref_6
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: ''
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_32
-          serializedName: name
+          serializedName: breed
           language: !<!Languages> 
             default:
-              name: name
+              name: breed
               description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
@@ -1153,13 +1153,13 @@ schemas: !<!Schemas>
         - input
       language: !<!Languages> 
         default:
-          name: Pet
+          name: Siamese
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
-    - *ref_31
+    - *ref_28
     - *ref_29
+    - *ref_26
     - !<!ObjectSchema> &ref_35
       type: object
       apiVersions:
@@ -4350,7 +4350,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -4391,7 +4391,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_146
-                schema: *ref_29
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/advisor/flattened.yaml
+++ b/modelerfour/test/scenarios/advisor/flattened.yaml
@@ -223,36 +223,6 @@ schemas: !<!Schemas>
           name: ResourceRecommendationBaseListResult-nextLink
           description: The link used to get the next page of recommendations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_31
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-id
-          description: The resource ID.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_32
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-name
-          description: The name of the resource.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-type
-          description: The type of the resource.
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_36
       type: string
       apiVersions:
@@ -302,6 +272,36 @@ schemas: !<!Schemas>
         default:
           name: ShortDescription-solution
           description: The remediation action suggested by the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_31
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-id
+          description: The resource ID.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_32
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-name
+          description: The name of the resource.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_33
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-type
+          description: The type of the resource.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_47
       type: string
@@ -1258,9 +1258,9 @@ schemas: !<!Schemas>
           description: The list of Advisor recommendations.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
     - *ref_26
     - *ref_46
+    - *ref_27
     - !<!ObjectSchema> &ref_88
       type: object
       apiVersions:

--- a/modelerfour/test/scenarios/advisor/grouped.yaml
+++ b/modelerfour/test/scenarios/advisor/grouped.yaml
@@ -223,36 +223,6 @@ schemas: !<!Schemas>
           name: ResourceRecommendationBaseListResult-nextLink
           description: The link used to get the next page of recommendations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_31
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-id
-          description: The resource ID.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_32
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-name
-          description: The name of the resource.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-type
-          description: The type of the resource.
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_36
       type: string
       apiVersions:
@@ -302,6 +272,36 @@ schemas: !<!Schemas>
         default:
           name: ShortDescription-solution
           description: The remediation action suggested by the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_31
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-id
+          description: The resource ID.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_32
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-name
+          description: The name of the resource.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_33
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-type
+          description: The type of the resource.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_47
       type: string
@@ -1258,9 +1258,9 @@ schemas: !<!Schemas>
           description: The list of Advisor recommendations.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
     - *ref_26
     - *ref_46
+    - *ref_27
     - !<!ObjectSchema> &ref_88
       type: object
       apiVersions:

--- a/modelerfour/test/scenarios/advisor/modeler.yaml
+++ b/modelerfour/test/scenarios/advisor/modeler.yaml
@@ -223,36 +223,6 @@ schemas: !<!Schemas>
           name: ResourceRecommendationBaseListResult-nextLink
           description: The link used to get the next page of recommendations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_31
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-id
-          description: The resource ID.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_32
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-name
-          description: The name of the resource.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: Resource-type
-          description: The type of the resource.
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_24
       type: string
       apiVersions:
@@ -302,6 +272,36 @@ schemas: !<!Schemas>
         default:
           name: ShortDescription-solution
           description: The remediation action suggested by the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_31
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-id
+          description: The resource ID.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_32
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-name
+          description: The name of the resource.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_33
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: Resource-type
+          description: The type of the resource.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_41
       type: string
@@ -1285,10 +1285,10 @@ schemas: !<!Schemas>
           description: The list of Advisor recommendations.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_37
     - *ref_34
     - *ref_39
     - *ref_40
+    - *ref_37
     - !<!ObjectSchema> &ref_91
       type: object
       apiVersions:

--- a/modelerfour/test/scenarios/advisor/namer.yaml
+++ b/modelerfour/test/scenarios/advisor/namer.yaml
@@ -223,36 +223,6 @@ schemas: !<!Schemas>
           name: ResourceRecommendationBaseListResultNextLink
           description: The link used to get the next page of recommendations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_31
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: ResourceId
-          description: The resource ID.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_32
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: ResourceName
-          description: The name of the resource.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      language: !<!Languages> 
-        default:
-          name: ResourceType
-          description: The type of the resource.
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_36
       type: string
       apiVersions:
@@ -302,6 +272,36 @@ schemas: !<!Schemas>
         default:
           name: ShortDescriptionSolution
           description: The remediation action suggested by the recommendation.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_31
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: ResourceId
+          description: The resource ID.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_32
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: ResourceName
+          description: The name of the resource.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_33
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      language: !<!Languages> 
+        default:
+          name: ResourceType
+          description: The type of the resource.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_47
       type: string
@@ -1258,9 +1258,9 @@ schemas: !<!Schemas>
           description: The list of Advisor recommendations.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
     - *ref_26
     - *ref_46
+    - *ref_27
     - !<!ObjectSchema> &ref_88
       type: object
       apiVersions:

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -137,10 +137,10 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: pet-name
+          name: siamese-breed
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_30
+    - !<!StringSchema> &ref_31
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -150,7 +150,7 @@ schemas: !<!Schemas>
           name: cat-color
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_26
+    - !<!StringSchema> &ref_27
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -160,14 +160,14 @@ schemas: !<!Schemas>
           name: dog-food
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_28
+    - !<!StringSchema> &ref_30
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: siamese-breed
+          name: pet-name
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_38
@@ -1015,63 +1015,77 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_31
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: '2016-02-29'
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
-            properties:
-              - !<!Property> 
-                schema: *ref_26
-                serializedName: food
-                language: !<!Languages> 
-                  default:
-                    name: food
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: dog
-                description: ''
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_27
+          - !<!ObjectSchema> &ref_28
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: '2016-02-29'
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_29
+                - *ref_25
+              immediate:
+                - *ref_25
+            parents: !<!Relations> 
+              all:
+                - !<!ObjectSchema> &ref_26
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
-                      - *ref_27
+                      - !<!ObjectSchema> &ref_29
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: '2016-02-29'
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_26
+                          immediate:
+                            - *ref_26
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_27
+                            serializedName: food
+                            language: !<!Languages> 
+                              default:
+                                name: food
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: dog
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      - *ref_28
                       - *ref_25
                     immediate:
-                      - *ref_27
+                      - *ref_29
+                      - *ref_28
                   properties:
                     - !<!Property> 
-                      schema: *ref_28
-                      serializedName: breed
+                      schema: *ref_6
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: breed
+                          name: id
+                          description: ''
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_30
+                      serializedName: name
+                      language: !<!Languages> 
+                        default:
+                          name: name
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -1081,20 +1095,15 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: siamese
+                      name: pet
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_29
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
+                - *ref_26
             properties:
               - !<!Property> 
-                schema: *ref_30
+                schema: *ref_31
                 serializedName: color
                 language: !<!Languages> 
                   default:
@@ -1107,7 +1116,7 @@ schemas: !<!Schemas>
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  elementType: *ref_31
+                  elementType: *ref_29
                   language: !<!Languages> 
                     default:
                       name: cat-hates
@@ -1130,25 +1139,16 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_29
+          - *ref_26
         immediate:
-          - *ref_31
-          - *ref_27
+          - *ref_28
       properties:
         - !<!Property> 
-          schema: *ref_6
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: ''
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_32
-          serializedName: name
+          serializedName: breed
           language: !<!Languages> 
             default:
-              name: name
+              name: breed
               description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
@@ -1158,13 +1158,13 @@ schemas: !<!Schemas>
         - input
       language: !<!Languages> 
         default:
-          name: pet
+          name: siamese
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
-    - *ref_31
+    - *ref_28
     - *ref_29
+    - *ref_26
     - !<!ObjectSchema> &ref_35
       type: object
       apiVersions:
@@ -4339,7 +4339,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -4380,7 +4380,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_144
-                schema: *ref_29
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -137,10 +137,10 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: pet-name
+          name: siamese-breed
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_30
+    - !<!StringSchema> &ref_31
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -150,7 +150,7 @@ schemas: !<!Schemas>
           name: cat-color
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_26
+    - !<!StringSchema> &ref_27
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -160,14 +160,14 @@ schemas: !<!Schemas>
           name: dog-food
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_28
+    - !<!StringSchema> &ref_30
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: siamese-breed
+          name: pet-name
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_38
@@ -1015,63 +1015,77 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_31
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: '2016-02-29'
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
-            properties:
-              - !<!Property> 
-                schema: *ref_26
-                serializedName: food
-                language: !<!Languages> 
-                  default:
-                    name: food
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: dog
-                description: ''
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_27
+          - !<!ObjectSchema> &ref_28
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: '2016-02-29'
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_29
+                - *ref_25
+              immediate:
+                - *ref_25
+            parents: !<!Relations> 
+              all:
+                - !<!ObjectSchema> &ref_26
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
-                      - *ref_27
+                      - !<!ObjectSchema> &ref_29
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: '2016-02-29'
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_26
+                          immediate:
+                            - *ref_26
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_27
+                            serializedName: food
+                            language: !<!Languages> 
+                              default:
+                                name: food
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: dog
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      - *ref_28
                       - *ref_25
                     immediate:
-                      - *ref_27
+                      - *ref_29
+                      - *ref_28
                   properties:
                     - !<!Property> 
-                      schema: *ref_28
-                      serializedName: breed
+                      schema: *ref_6
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: breed
+                          name: id
+                          description: ''
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_30
+                      serializedName: name
+                      language: !<!Languages> 
+                        default:
+                          name: name
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -1081,20 +1095,15 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: siamese
+                      name: pet
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_29
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
+                - *ref_26
             properties:
               - !<!Property> 
-                schema: *ref_30
+                schema: *ref_31
                 serializedName: color
                 language: !<!Languages> 
                   default:
@@ -1107,7 +1116,7 @@ schemas: !<!Schemas>
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  elementType: *ref_31
+                  elementType: *ref_29
                   language: !<!Languages> 
                     default:
                       name: cat-hates
@@ -1130,25 +1139,16 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_29
+          - *ref_26
         immediate:
-          - *ref_31
-          - *ref_27
+          - *ref_28
       properties:
         - !<!Property> 
-          schema: *ref_6
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: ''
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_32
-          serializedName: name
+          serializedName: breed
           language: !<!Languages> 
             default:
-              name: name
+              name: breed
               description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
@@ -1158,13 +1158,13 @@ schemas: !<!Schemas>
         - input
       language: !<!Languages> 
         default:
-          name: pet
+          name: siamese
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
-    - *ref_31
+    - *ref_28
     - *ref_29
+    - *ref_26
     - !<!ObjectSchema> &ref_35
       type: object
       apiVersions:
@@ -4339,7 +4339,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -4380,7 +4380,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_144
-                schema: *ref_29
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-complex/modeler.yaml
+++ b/modelerfour/test/scenarios/body-complex/modeler.yaml
@@ -137,17 +137,7 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: pet-name
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_16
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      language: !<!Languages> 
-        default:
-          name: cat-color
+          name: siamese-breed
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_14
@@ -157,17 +147,27 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: dog-food
+          name: cat-color
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_18
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: siamese-breed
+          name: dog-food
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_16
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      language: !<!Languages> 
+        default:
+          name: pet-name
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_21
@@ -1010,68 +1010,82 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_15
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_17
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: '2016-02-29'
-            parents: !<!Relations> 
-              all:
-                - *ref_15
-              immediate:
-                - *ref_15
-            properties:
-              - !<!Property> 
-                schema: *ref_14
-                serializedName: food
-                language: !<!Languages> 
-                  default:
-                    name: food
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: dog
-                description: ''
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_19
+          - !<!ObjectSchema> &ref_18
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: '2016-02-29'
             children: !<!Relations> 
               all:
+                - *ref_19
+              immediate:
+                - *ref_19
+            parents: !<!Relations> 
+              all:
                 - !<!ObjectSchema> &ref_20
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
+                      - !<!ObjectSchema> &ref_17
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: '2016-02-29'
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_20
+                          immediate:
+                            - *ref_20
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_15
+                            serializedName: food
+                            language: !<!Languages> 
+                              default:
+                                name: food
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: dog
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      - *ref_18
                       - *ref_19
-                      - *ref_15
                     immediate:
-                      - *ref_19
+                      - *ref_17
+                      - *ref_18
                   properties:
                     - !<!Property> 
-                      schema: *ref_18
-                      serializedName: breed
+                      schema: *ref_3
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: breed
+                          name: id
+                          description: ''
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_16
+                      serializedName: name
+                      language: !<!Languages> 
+                        default:
+                          name: name
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -1081,20 +1095,15 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: siamese
+                      name: pet
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
                 - *ref_20
-            parents: !<!Relations> 
-              all:
-                - *ref_15
-              immediate:
-                - *ref_15
             properties:
               - !<!Property> 
-                schema: *ref_16
+                schema: *ref_14
                 serializedName: color
                 language: !<!Languages> 
                   default:
@@ -1132,23 +1141,14 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           - *ref_20
         immediate:
-          - *ref_17
-          - *ref_19
+          - *ref_18
       properties:
         - !<!Property> 
-          schema: *ref_3
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: ''
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_13
-          serializedName: name
+          serializedName: breed
           language: !<!Languages> 
             default:
-              name: name
+              name: breed
               description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
@@ -1158,11 +1158,11 @@ schemas: !<!Schemas>
         - input
       language: !<!Languages> 
         default:
-          name: pet
+          name: siamese
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_19
+    - *ref_18
     - *ref_17
     - *ref_20
     - !<!ObjectSchema> &ref_23
@@ -4098,7 +4098,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -4139,7 +4139,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_102
-                schema: *ref_20
+                schema: *ref_19
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -137,10 +137,10 @@ schemas: !<!Schemas>
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: PetName
+          name: SiameseBreed
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_30
+    - !<!StringSchema> &ref_31
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -150,7 +150,7 @@ schemas: !<!Schemas>
           name: CatColor
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_26
+    - !<!StringSchema> &ref_27
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -160,14 +160,14 @@ schemas: !<!Schemas>
           name: DogFood
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_28
+    - !<!StringSchema> &ref_30
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       language: !<!Languages> 
         default:
-          name: SiameseBreed
+          name: PetName
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_38
@@ -1015,63 +1015,77 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_31
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: '2016-02-29'
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
-            properties:
-              - !<!Property> 
-                schema: *ref_26
-                serializedName: food
-                language: !<!Languages> 
-                  default:
-                    name: food
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: Dog
-                description: ''
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_27
+          - !<!ObjectSchema> &ref_28
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: '2016-02-29'
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_29
+                - *ref_25
+              immediate:
+                - *ref_25
+            parents: !<!Relations> 
+              all:
+                - !<!ObjectSchema> &ref_26
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
-                      - *ref_27
+                      - !<!ObjectSchema> &ref_29
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: '2016-02-29'
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_26
+                          immediate:
+                            - *ref_26
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_27
+                            serializedName: food
+                            language: !<!Languages> 
+                              default:
+                                name: food
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: Dog
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      - *ref_28
                       - *ref_25
                     immediate:
-                      - *ref_27
+                      - *ref_29
+                      - *ref_28
                   properties:
                     - !<!Property> 
-                      schema: *ref_28
-                      serializedName: breed
+                      schema: *ref_6
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: breed
+                          name: id
+                          description: ''
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_30
+                      serializedName: name
+                      language: !<!Languages> 
+                        default:
+                          name: name
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -1081,20 +1095,15 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: Siamese
+                      name: Pet
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_29
-            parents: !<!Relations> 
-              all:
-                - *ref_25
-              immediate:
-                - *ref_25
+                - *ref_26
             properties:
               - !<!Property> 
-                schema: *ref_30
+                schema: *ref_31
                 serializedName: color
                 language: !<!Languages> 
                   default:
@@ -1107,7 +1116,7 @@ schemas: !<!Schemas>
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2016-02-29'
-                  elementType: *ref_31
+                  elementType: *ref_29
                   language: !<!Languages> 
                     default:
                       name: CatHates
@@ -1130,25 +1139,16 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_29
+          - *ref_26
         immediate:
-          - *ref_31
-          - *ref_27
+          - *ref_28
       properties:
         - !<!Property> 
-          schema: *ref_6
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: ''
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_32
-          serializedName: name
+          serializedName: breed
           language: !<!Languages> 
             default:
-              name: name
+              name: breed
               description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
@@ -1158,13 +1158,13 @@ schemas: !<!Schemas>
         - input
       language: !<!Languages> 
         default:
-          name: Pet
+          name: Siamese
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_27
-    - *ref_31
+    - *ref_28
     - *ref_29
+    - *ref_26
     - !<!ObjectSchema> &ref_35
       type: object
       apiVersions:
@@ -4339,7 +4339,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -4380,7 +4380,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_144
-                schema: *ref_29
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/keyvault/flattened.yaml
+++ b/modelerfour/test/scenarios/keyvault/flattened.yaml
@@ -56,21 +56,21 @@ schemas: !<!Schemas>
           name: boolean
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_106
+    - !<!BooleanSchema> &ref_104
       type: boolean
       language: !<!Languages> 
         default:
           name: boolean
           description: Indicates if the private key can be exported.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_107
+    - !<!BooleanSchema> &ref_105
       type: boolean
       language: !<!Languages> 
         default:
           name: boolean
           description: Indicates if the same key pair will be used on certificate renewal.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_121
+    - !<!BooleanSchema> &ref_119
       type: boolean
       language: !<!Languages> 
         default:
@@ -98,7 +98,7 @@ schemas: !<!Schemas>
           name: boolean
           description: the enabled state of the object.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_193
+    - !<!BooleanSchema> &ref_191
       type: boolean
       language: !<!Languages> 
         default:
@@ -127,7 +127,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_115
+    - !<!NumberSchema> &ref_113
       type: integer
       minimum: 0
       precision: 32
@@ -136,7 +136,7 @@ schemas: !<!Schemas>
           name: ValidityInMonths
           description: The duration that the certificate is valid in months.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_116
+    - !<!NumberSchema> &ref_114
       type: integer
       maximum: 99
       minimum: 1
@@ -146,7 +146,7 @@ schemas: !<!Schemas>
           name: integer
           description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_117
+    - !<!NumberSchema> &ref_115
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -433,7 +433,17 @@ schemas: !<!Schemas>
           name: CertificateListResult-nextLink
           description: The URL to get the next set of certificates.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_102
+    - !<!StringSchema> &ref_124
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedCertificateBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -443,7 +453,7 @@ schemas: !<!Schemas>
           name: CertificateBundle-id
           description: The certificate id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_103
+    - !<!StringSchema> &ref_101
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -453,7 +463,7 @@ schemas: !<!Schemas>
           name: CertificateBundle-kid
           description: The key id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_104
+    - !<!StringSchema> &ref_102
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +473,7 @@ schemas: !<!Schemas>
           name: CertificateBundle-sid
           description: The secret id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_105
+    - !<!StringSchema> &ref_103
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -473,7 +483,7 @@ schemas: !<!Schemas>
           name: CertificatePolicy-id
           description: The certificate id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_108
+    - !<!StringSchema> &ref_106
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -483,7 +493,7 @@ schemas: !<!Schemas>
           name: SecretProperties-contentType
           description: The media type (MIME type).
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_109
+    - !<!StringSchema> &ref_107
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -493,7 +503,7 @@ schemas: !<!Schemas>
           name: X509CertificateProperties-subject
           description: The subject name. Should be a valid X509 distinguished Name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_110
+    - !<!StringSchema> &ref_108
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -503,7 +513,7 @@ schemas: !<!Schemas>
           name: X509CertificateProperties-ekusItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_111
+    - !<!StringSchema> &ref_109
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -513,7 +523,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-emailsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_112
+    - !<!StringSchema> &ref_110
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -523,7 +533,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-dns_namesItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_113
+    - !<!StringSchema> &ref_111
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -533,7 +543,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-upnsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_119
+    - !<!StringSchema> &ref_117
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -543,7 +553,7 @@ schemas: !<!Schemas>
           name: IssuerParameters-name
           description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_120
+    - !<!StringSchema> &ref_118
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -553,7 +563,7 @@ schemas: !<!Schemas>
           name: CertificateType
           description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_123
+    - !<!StringSchema> &ref_121
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -562,16 +572,6 @@ schemas: !<!Schemas>
         default:
           name: CertificateBundle-contentType
           description: The content type of the secret.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_100
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedCertificateBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_134
       type: string
@@ -894,7 +894,17 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_190
+    - !<!StringSchema> &ref_195
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedStorageBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_188
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -904,7 +914,7 @@ schemas: !<!Schemas>
           name: StorageBundle-id
           description: The storage account id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_191
+    - !<!StringSchema> &ref_189
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -914,7 +924,7 @@ schemas: !<!Schemas>
           name: StorageBundle-resourceId
           description: The storage account resource id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_192
+    - !<!StringSchema> &ref_190
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -924,7 +934,7 @@ schemas: !<!Schemas>
           name: StorageBundle-activeKeyName
           description: The current active storage account key name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_194
+    - !<!StringSchema> &ref_192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -933,16 +943,6 @@ schemas: !<!Schemas>
         default:
           name: StorageBundle-regenerationPeriod
           description: The key regeneration time duration specified in ISO-8601 format.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_188
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedStorageBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_198
       type: string
@@ -1054,7 +1054,17 @@ schemas: !<!Schemas>
           name: DeletedSasDefinitionListResult-nextLink
           description: The URL to get the next set of deleted SAS definitions.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_220
+    - !<!StringSchema> &ref_225
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedSasDefinitionBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_218
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1064,7 +1074,7 @@ schemas: !<!Schemas>
           name: SasDefinitionBundle-id
           description: The SAS definition id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_221
+    - !<!StringSchema> &ref_219
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1074,7 +1084,7 @@ schemas: !<!Schemas>
           name: SecretId
           description: Storage account SAS definition secret id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_220
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1084,7 +1094,7 @@ schemas: !<!Schemas>
           name: SasDefinitionBundle-templateUri
           description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_224
+    - !<!StringSchema> &ref_222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1093,16 +1103,6 @@ schemas: !<!Schemas>
         default:
           name: SasDefinitionBundle-validityPeriod
           description: The validity period of SAS tokens created according to the SAS definition.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_218
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedSasDefinitionBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_226
       type: string
@@ -1427,7 +1427,7 @@ schemas: !<!Schemas>
           name: JsonWebKeySignatureAlgorithm
           description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_114
+    - !<!ChoiceSchema> &ref_112
       choices:
         - !<!ChoiceValue> 
           value: digitalSignature
@@ -1493,7 +1493,7 @@ schemas: !<!Schemas>
           name: KeyUsageType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_223
+    - !<!ChoiceSchema> &ref_221
       choices:
         - !<!ChoiceValue> 
           value: account
@@ -1518,7 +1518,7 @@ schemas: !<!Schemas>
           description: The type of SAS token the SAS definition will create.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_118
+    - !<!SealedChoiceSchema> &ref_116
       choices:
         - !<!ChoiceValue> 
           value: EmailContacts
@@ -1644,7 +1644,7 @@ schemas: !<!Schemas>
           name: CertificateItem-tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_124
+    - !<!DictionarySchema> &ref_122
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -1698,7 +1698,7 @@ schemas: !<!Schemas>
           name: StorageAccountItem-tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_195
+    - !<!DictionarySchema> &ref_193
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -1734,7 +1734,7 @@ schemas: !<!Schemas>
           name: SasDefinitionItem-tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_225
+    - !<!DictionarySchema> &ref_223
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -2004,7 +2004,7 @@ schemas: !<!Schemas>
           name: X509Thumbprint
           description: Thumbprint of the certificate.
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_122
+    - !<!ByteArraySchema> &ref_120
       type: byte-array
       format: byte
       apiVersions:
@@ -2427,8 +2427,8 @@ schemas: !<!Schemas>
           description: The key create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
     - *ref_5
+    - *ref_6
     - !<!ObjectSchema> &ref_17
       type: object
       apiVersions:
@@ -3880,14 +3880,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_101
+          - !<!ObjectSchema> &ref_123
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_99
               immediate:
@@ -3895,88 +3895,6 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_100
-                serializedName: recoveryId
-                language: !<!Languages> 
-                  default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_92
-                readOnly: true
-                serializedName: scheduledPurgeDate
-                language: !<!Languages> 
-                  default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the certificate is scheduled to be purged, in UTC'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_93
-                readOnly: true
-                serializedName: deletedDate
-                language: !<!Languages> 
-                  default:
-                    name: deletedDate
-                    description: 'The time when the certificate was deleted, in UTC'
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-            language: !<!Languages> 
-              default:
-                name: DeletedCertificateBundle
-                description: 'A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
-                namespace: ''
-            protocol: !<!Protocols> {}
-        immediate:
-          - *ref_101
-      properties:
-        - !<!Property> 
-          schema: *ref_102
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The certificate id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_103
-          readOnly: true
-          serializedName: kid
-          language: !<!Languages> 
-            default:
-              name: kid
-              description: The key id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_104
-          readOnly: true
-          serializedName: sid
-          language: !<!Languages> 
-            default:
-              name: sid
-              description: The secret id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_97
-          readOnly: true
-          serializedName: x5t
-          language: !<!Languages> 
-            default:
-              name: X509Thumbprint
-              description: Thumbprint of the certificate.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: !<!ObjectSchema> &ref_125
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 7.0-preview
-            properties:
-              - !<!Property> 
-                schema: *ref_105
                 readOnly: true
                 serializedName: id
                 language: !<!Languages> 
@@ -3985,194 +3903,94 @@ schemas: !<!Schemas>
                     description: The certificate id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_126
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_106
-                      serializedName: exportable
-                      language: !<!Languages> 
-                        default:
-                          name: exportable
-                          description: Indicates if the private key can be exported.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_2
-                      serializedName: kty
-                      language: !<!Languages> 
-                        default:
-                          name: keyType
-                          description: The type of key pair to be used for the certificate.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_3
-                      serializedName: key_size
-                      language: !<!Languages> 
-                        default:
-                          name: key_size
-                          description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_107
-                      serializedName: reuse_key
-                      language: !<!Languages> 
-                        default:
-                          name: reuse_key
-                          description: Indicates if the same key pair will be used on certificate renewal.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_16
-                      serializedName: crv
-                      language: !<!Languages> 
-                        default:
-                          name: curve
-                          description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: KeyProperties
-                      description: Properties of the key pair backing a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: key_props
+                schema: *ref_101
+                readOnly: true
+                serializedName: kid
                 language: !<!Languages> 
                   default:
-                    name: KeyProperties
-                    description: Properties of the key backing a certificate.
+                    name: kid
+                    description: The key id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_127
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_108
-                      serializedName: contentType
-                      language: !<!Languages> 
-                        default:
-                          name: contentType
-                          description: The media type (MIME type).
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: SecretProperties
-                      description: Properties of the key backing a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: secret_props
+                schema: *ref_102
+                readOnly: true
+                serializedName: sid
                 language: !<!Languages> 
                   default:
-                    name: SecretProperties
-                    description: Properties of the secret backing a certificate.
+                    name: sid
+                    description: The secret id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_128
+                schema: *ref_97
+                readOnly: true
+                serializedName: x5t
+                language: !<!Languages> 
+                  default:
+                    name: X509Thumbprint
+                    description: Thumbprint of the certificate.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: !<!ObjectSchema> &ref_125
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 7.0-preview
                   properties:
                     - !<!Property> 
-                      schema: *ref_109
-                      serializedName: subject
+                      schema: *ref_103
+                      readOnly: true
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: subject
-                          description: The subject name. Should be a valid X509 distinguished Name.
+                          name: id
+                          description: The certificate id.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: !<!ArraySchema> &ref_241
-                        type: array
-                        apiVersions:
-                          - !<!ApiVersion> 
-                            version: 7.0-preview
-                        elementType: *ref_110
-                        language: !<!Languages> 
-                          default:
-                            name: X509CertificateProperties-ekus
-                            description: The enhanced key usage.
-                        protocol: !<!Protocols> {}
-                      serializedName: ekus
-                      language: !<!Languages> 
-                        default:
-                          name: ekus
-                          description: The enhanced key usage.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_129
+                      schema: !<!ObjectSchema> &ref_126
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 7.0-preview
                         properties:
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_242
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_111
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-emails
-                                  description: Email addresses.
-                              protocol: !<!Protocols> {}
-                            serializedName: emails
+                            schema: *ref_104
+                            serializedName: exportable
                             language: !<!Languages> 
                               default:
-                                name: emails
-                                description: Email addresses.
+                                name: exportable
+                                description: Indicates if the private key can be exported.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_243
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_112
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-dns_names
-                                  description: Domain names.
-                              protocol: !<!Protocols> {}
-                            serializedName: dns_names
+                            schema: *ref_2
+                            serializedName: kty
                             language: !<!Languages> 
                               default:
-                                name: dns_names
-                                description: Domain names.
+                                name: keyType
+                                description: The type of key pair to be used for the certificate.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_244
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_113
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-upns
-                                  description: User principal names.
-                              protocol: !<!Protocols> {}
-                            serializedName: upns
+                            schema: *ref_3
+                            serializedName: key_size
                             language: !<!Languages> 
                               default:
-                                name: upns
-                                description: User principal names.
+                                name: key_size
+                                description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_105
+                            serializedName: reuse_key
+                            language: !<!Languages> 
+                              default:
+                                name: reuse_key
+                                description: Indicates if the same key pair will be used on certificate renewal.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_16
+                            serializedName: crv
+                            language: !<!Languages> 
+                              default:
+                                name: curve
+                                description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -4181,93 +3999,285 @@ schemas: !<!Schemas>
                           - input
                         language: !<!Languages> 
                           default:
-                            name: SubjectAlternativeNames
-                            description: The subject alternate names of a X509 object.
+                            name: KeyProperties
+                            description: Properties of the key pair backing a certificate.
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: sans
+                      serializedName: key_props
                       language: !<!Languages> 
                         default:
-                          name: SubjectAlternativeNames
-                          description: The subject alternative names.
+                          name: KeyProperties
+                          description: Properties of the key backing a certificate.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: !<!ArraySchema> &ref_245
+                      schema: !<!ObjectSchema> &ref_127
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_106
+                            serializedName: contentType
+                            language: !<!Languages> 
+                              default:
+                                name: contentType
+                                description: The media type (MIME type).
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: SecretProperties
+                            description: Properties of the key backing a certificate.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      serializedName: secret_props
+                      language: !<!Languages> 
+                        default:
+                          name: SecretProperties
+                          description: Properties of the secret backing a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_128
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_107
+                            serializedName: subject
+                            language: !<!Languages> 
+                              default:
+                                name: subject
+                                description: The subject name. Should be a valid X509 distinguished Name.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ArraySchema> &ref_241
+                              type: array
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              elementType: *ref_108
+                              language: !<!Languages> 
+                                default:
+                                  name: X509CertificateProperties-ekus
+                                  description: The enhanced key usage.
+                              protocol: !<!Protocols> {}
+                            serializedName: ekus
+                            language: !<!Languages> 
+                              default:
+                                name: ekus
+                                description: The enhanced key usage.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ObjectSchema> &ref_129
+                              type: object
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              properties:
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_242
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_109
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-emails
+                                        description: Email addresses.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: emails
+                                  language: !<!Languages> 
+                                    default:
+                                      name: emails
+                                      description: Email addresses.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_243
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_110
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-dns_names
+                                        description: Domain names.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: dns_names
+                                  language: !<!Languages> 
+                                    default:
+                                      name: dns_names
+                                      description: Domain names.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_244
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_111
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-upns
+                                        description: User principal names.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: upns
+                                  language: !<!Languages> 
+                                    default:
+                                      name: upns
+                                      description: User principal names.
+                                  protocol: !<!Protocols> {}
+                              serializationFormats:
+                                - json
+                              usage:
+                                - output
+                                - input
+                              language: !<!Languages> 
+                                default:
+                                  name: SubjectAlternativeNames
+                                  description: The subject alternate names of a X509 object.
+                                  namespace: ''
+                              protocol: !<!Protocols> {}
+                            serializedName: sans
+                            language: !<!Languages> 
+                              default:
+                                name: SubjectAlternativeNames
+                                description: The subject alternative names.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ArraySchema> &ref_245
+                              type: array
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              elementType: *ref_112
+                              language: !<!Languages> 
+                                default:
+                                  name: X509CertificateProperties-key_usage
+                                  description: List of key usages.
+                              protocol: !<!Protocols> {}
+                            serializedName: key_usage
+                            language: !<!Languages> 
+                              default:
+                                name: key_usage
+                                description: List of key usages.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_113
+                            serializedName: validity_months
+                            language: !<!Languages> 
+                              default:
+                                name: ValidityInMonths
+                                description: The duration that the certificate is valid in months.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: X509CertificateProperties
+                            description: Properties of the X509 component of a certificate.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      serializedName: x509_props
+                      language: !<!Languages> 
+                        default:
+                          name: X509CertificateProperties
+                          description: Properties of the X509 component of a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ArraySchema> &ref_246
                         type: array
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 7.0-preview
-                        elementType: *ref_114
-                        language: !<!Languages> 
-                          default:
-                            name: X509CertificateProperties-key_usage
-                            description: List of key usages.
-                        protocol: !<!Protocols> {}
-                      serializedName: key_usage
-                      language: !<!Languages> 
-                        default:
-                          name: key_usage
-                          description: List of key usages.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_115
-                      serializedName: validity_months
-                      language: !<!Languages> 
-                        default:
-                          name: ValidityInMonths
-                          description: The duration that the certificate is valid in months.
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: X509CertificateProperties
-                      description: Properties of the X509 component of a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: x509_props
-                language: !<!Languages> 
-                  default:
-                    name: X509CertificateProperties
-                    description: Properties of the X509 component of a certificate.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ArraySchema> &ref_246
-                  type: array
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  elementType: !<!ObjectSchema> &ref_130
-                    type: object
-                    apiVersions:
-                      - !<!ApiVersion> 
-                        version: 7.0-preview
-                    properties:
-                      - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_131
+                        elementType: !<!ObjectSchema> &ref_130
                           type: object
                           apiVersions:
                             - !<!ApiVersion> 
                               version: 7.0-preview
                           properties:
                             - !<!Property> 
-                              schema: *ref_116
-                              serializedName: lifetime_percentage
+                              schema: !<!ObjectSchema> &ref_131
+                                type: object
+                                apiVersions:
+                                  - !<!ApiVersion> 
+                                    version: 7.0-preview
+                                properties:
+                                  - !<!Property> 
+                                    schema: *ref_114
+                                    serializedName: lifetime_percentage
+                                    language: !<!Languages> 
+                                      default:
+                                        name: lifetime_percentage
+                                        description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+                                    protocol: !<!Protocols> {}
+                                  - !<!Property> 
+                                    schema: *ref_115
+                                    serializedName: days_before_expiry
+                                    language: !<!Languages> 
+                                      default:
+                                        name: days_before_expiry
+                                        description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
+                                    protocol: !<!Protocols> {}
+                                serializationFormats:
+                                  - json
+                                usage:
+                                  - output
+                                  - input
+                                language: !<!Languages> 
+                                  default:
+                                    name: Trigger
+                                    description: A condition to be satisfied for an action to be executed.
+                                    namespace: ''
+                                protocol: !<!Protocols> {}
+                              serializedName: trigger
                               language: !<!Languages> 
                                 default:
-                                  name: lifetime_percentage
-                                  description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+                                  name: trigger
+                                  description: The condition that will execute the action.
                               protocol: !<!Protocols> {}
                             - !<!Property> 
-                              schema: *ref_117
-                              serializedName: days_before_expiry
+                              schema: !<!ObjectSchema> &ref_132
+                                type: object
+                                apiVersions:
+                                  - !<!ApiVersion> 
+                                    version: 7.0-preview
+                                properties:
+                                  - !<!Property> 
+                                    schema: *ref_116
+                                    serializedName: action_type
+                                    language: !<!Languages> 
+                                      default:
+                                        name: action_type
+                                        description: The type of the action.
+                                    protocol: !<!Protocols> {}
+                                serializationFormats:
+                                  - json
+                                usage:
+                                  - output
+                                  - input
+                                language: !<!Languages> 
+                                  default:
+                                    name: Action
+                                    description: The action that will be executed.
+                                    namespace: ''
+                                protocol: !<!Protocols> {}
+                              serializedName: action
                               language: !<!Languages> 
                                 default:
-                                  name: days_before_expiry
-                                  description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
+                                  name: action
+                                  description: The action that will be executed.
                               protocol: !<!Protocols> {}
                           serializationFormats:
                             - json
@@ -4276,100 +4286,76 @@ schemas: !<!Schemas>
                             - input
                           language: !<!Languages> 
                             default:
-                              name: Trigger
-                              description: A condition to be satisfied for an action to be executed.
+                              name: LifetimeAction
+                              description: Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
                               namespace: ''
                           protocol: !<!Protocols> {}
-                        serializedName: trigger
                         language: !<!Languages> 
                           default:
-                            name: trigger
-                            description: The condition that will execute the action.
+                            name: CertificatePolicy-lifetime_actions
+                            description: Actions that will be performed by Key Vault over the lifetime of a certificate.
                         protocol: !<!Protocols> {}
-                      - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_132
-                          type: object
-                          apiVersions:
-                            - !<!ApiVersion> 
-                              version: 7.0-preview
-                          properties:
-                            - !<!Property> 
-                              schema: *ref_118
-                              serializedName: action_type
-                              language: !<!Languages> 
-                                default:
-                                  name: action_type
-                                  description: The type of the action.
-                              protocol: !<!Protocols> {}
-                          serializationFormats:
-                            - json
-                          usage:
-                            - output
-                            - input
-                          language: !<!Languages> 
-                            default:
-                              name: Action
-                              description: The action that will be executed.
-                              namespace: ''
-                          protocol: !<!Protocols> {}
-                        serializedName: action
+                      serializedName: lifetime_actions
+                      language: !<!Languages> 
+                        default:
+                          name: lifetime_actions
+                          description: Actions that will be performed by Key Vault over the lifetime of a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_133
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_117
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_118
+                            serializedName: cty
+                            language: !<!Languages> 
+                              default:
+                                name: CertificateType
+                                description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_119
+                            serializedName: cert_transparency
+                            language: !<!Languages> 
+                              default:
+                                name: CertificateTransparency
+                                description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
                         language: !<!Languages> 
                           default:
-                            name: action
-                            description: The action that will be executed.
+                            name: IssuerParameters
+                            description: Parameters for the issuer of the X509 component of a certificate.
+                            namespace: ''
                         protocol: !<!Protocols> {}
-                    serializationFormats:
-                      - json
-                    usage:
-                      - output
-                      - input
-                    language: !<!Languages> 
-                      default:
-                        name: LifetimeAction
-                        description: Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
-                        namespace: ''
-                    protocol: !<!Protocols> {}
-                  language: !<!Languages> 
-                    default:
-                      name: CertificatePolicy-lifetime_actions
-                      description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-                  protocol: !<!Protocols> {}
-                serializedName: lifetime_actions
-                language: !<!Languages> 
-                  default:
-                    name: lifetime_actions
-                    description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_133
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_119
-                      serializedName: name
+                      serializedName: issuer
                       language: !<!Languages> 
                         default:
-                          name: name
-                          description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
+                          name: IssuerParameters
+                          description: Parameters for the issuer of the X509 component of a certificate.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_120
-                      serializedName: cty
+                      schema: *ref_9
+                      serializedName: attributes
                       language: !<!Languages> 
                         default:
-                          name: CertificateType
-                          description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_121
-                      serializedName: cert_transparency
-                      language: !<!Languages> 
-                        default:
-                          name: CertificateTransparency
-                          description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
+                          name: attributes
+                          description: The certificate attributes.
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
@@ -4378,15 +4364,32 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: IssuerParameters
-                      description: Parameters for the issuer of the X509 component of a certificate.
+                      name: CertificatePolicy
+                      description: Management policy for a certificate.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                serializedName: issuer
+                readOnly: true
+                serializedName: policy
                 language: !<!Languages> 
                   default:
-                    name: IssuerParameters
-                    description: Parameters for the issuer of the X509 component of a certificate.
+                    name: policy
+                    description: The management policy.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_120
+                serializedName: cer
+                language: !<!Languages> 
+                  default:
+                    name: cer
+                    description: CER contents of x509 certificate.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_121
+                serializedName: contentType
+                language: !<!Languages> 
+                  default:
+                    name: contentType
+                    description: The content type of the secret.
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_9
@@ -4396,55 +4399,52 @@ schemas: !<!Schemas>
                     name: attributes
                     description: The certificate attributes.
                 protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_122
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
+                protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - output
-              - input
             language: !<!Languages> 
               default:
-                name: CertificatePolicy
-                description: Management policy for a certificate.
+                name: CertificateBundle
+                description: A certificate bundle consists of a certificate (X509) plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
-          readOnly: true
-          serializedName: policy
-          language: !<!Languages> 
-            default:
-              name: policy
-              description: The management policy.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_122
-          serializedName: cer
-          language: !<!Languages> 
-            default:
-              name: cer
-              description: CER contents of x509 certificate.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_123
-          serializedName: contentType
-          language: !<!Languages> 
-            default:
-              name: contentType
-              description: The content type of the secret.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_9
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The certificate attributes.
-          protocol: !<!Protocols> {}
+        immediate:
+          - *ref_123
+      properties:
         - !<!Property> 
           schema: *ref_124
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_92
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the certificate is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_93
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the certificate was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -4452,10 +4452,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: CertificateBundle
-          description: A certificate bundle consists of a certificate (X509) plus its attributes.
+          name: DeletedCertificateBundle
+          description: 'A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
+    - *ref_123
     - *ref_125
     - *ref_126
     - *ref_127
@@ -4465,7 +4466,6 @@ schemas: !<!Schemas>
     - *ref_131
     - *ref_132
     - *ref_133
-    - *ref_101
     - !<!ObjectSchema> &ref_435
       type: object
       apiVersions:
@@ -5607,14 +5607,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_189
+          - !<!ObjectSchema> &ref_194
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_187
               immediate:
@@ -5622,29 +5622,66 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_188
-                serializedName: recoveryId
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+                    name: id
+                    description: The storage account id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_177
+                schema: *ref_189
                 readOnly: true
-                serializedName: scheduledPurgeDate
+                serializedName: resourceId
                 language: !<!Languages> 
                   default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the storage account is scheduled to be purged, in UTC'
+                    name: resourceId
+                    description: The storage account resource id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_178
+                schema: *ref_190
                 readOnly: true
-                serializedName: deletedDate
+                serializedName: activeKeyName
                 language: !<!Languages> 
                   default:
-                    name: deletedDate
-                    description: 'The time when the storage account was deleted, in UTC'
+                    name: activeKeyName
+                    description: The current active storage account key name.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_191
+                readOnly: true
+                serializedName: autoRegenerateKey
+                language: !<!Languages> 
+                  default:
+                    name: autoRegenerateKey
+                    description: whether keyvault should manage the storage account for the user.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_192
+                readOnly: true
+                serializedName: regenerationPeriod
+                language: !<!Languages> 
+                  default:
+                    name: regenerationPeriod
+                    description: The key regeneration time duration specified in ISO-8601 format.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_185
+                readOnly: true
+                serializedName: attributes
+                language: !<!Languages> 
+                  default:
+                    name: attributes
+                    description: The storage account attributes.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_193
+                readOnly: true
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -5652,75 +5689,38 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: DeletedStorageBundle
-                description: 'A deleted storage account bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
+                name: StorageBundle
+                description: A Storage account bundle consists of key vault storage account details plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_189
+          - *ref_194
       properties:
         - !<!Property> 
-          schema: *ref_190
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The storage account id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_191
-          readOnly: true
-          serializedName: resourceId
-          language: !<!Languages> 
-            default:
-              name: resourceId
-              description: The storage account resource id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_192
-          readOnly: true
-          serializedName: activeKeyName
-          language: !<!Languages> 
-            default:
-              name: activeKeyName
-              description: The current active storage account key name.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_193
-          readOnly: true
-          serializedName: autoRegenerateKey
-          language: !<!Languages> 
-            default:
-              name: autoRegenerateKey
-              description: whether keyvault should manage the storage account for the user.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_194
-          readOnly: true
-          serializedName: regenerationPeriod
-          language: !<!Languages> 
-            default:
-              name: regenerationPeriod
-              description: The key regeneration time duration specified in ISO-8601 format.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_185
-          readOnly: true
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The storage account attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_195
-          readOnly: true
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_177
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the storage account is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_178
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the storage account was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -5728,11 +5728,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: StorageBundle
-          description: A Storage account bundle consists of key vault storage account details plus its attributes.
+          name: DeletedStorageBundle
+          description: 'A deleted storage account bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_189
+    - *ref_194
     - !<!ObjectSchema> &ref_574
       type: object
       apiVersions:
@@ -5808,7 +5808,7 @@ schemas: !<!Schemas>
               description: Current active storage account key name.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_588
-          schema: *ref_193
+          schema: *ref_191
           required: true
           serializedName: autoRegenerateKey
           language: !<!Languages> 
@@ -5868,7 +5868,7 @@ schemas: !<!Schemas>
               description: The current active storage account key name.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_603
-          schema: *ref_193
+          schema: *ref_191
           serializedName: autoRegenerateKey
           language: !<!Languages> 
             default:
@@ -6186,14 +6186,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_219
+          - !<!ObjectSchema> &ref_224
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_217
               immediate:
@@ -6201,29 +6201,66 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_218
-                serializedName: recoveryId
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+                    name: id
+                    description: The SAS definition id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_208
+                schema: *ref_219
                 readOnly: true
-                serializedName: scheduledPurgeDate
+                serializedName: sid
                 language: !<!Languages> 
                   default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the SAS definition is scheduled to be purged, in UTC'
+                    name: SecretId
+                    description: Storage account SAS definition secret id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_209
+                schema: *ref_220
                 readOnly: true
-                serializedName: deletedDate
+                serializedName: templateUri
                 language: !<!Languages> 
                   default:
-                    name: deletedDate
-                    description: 'The time when the SAS definition was deleted, in UTC'
+                    name: templateUri
+                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_221
+                readOnly: true
+                serializedName: sasType
+                language: !<!Languages> 
+                  default:
+                    name: sasType
+                    description: The type of SAS token the SAS definition will create.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_222
+                readOnly: true
+                serializedName: validityPeriod
+                language: !<!Languages> 
+                  default:
+                    name: validityPeriod
+                    description: The validity period of SAS tokens created according to the SAS definition.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_215
+                readOnly: true
+                serializedName: attributes
+                language: !<!Languages> 
+                  default:
+                    name: attributes
+                    description: The SAS definition attributes.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_223
+                readOnly: true
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -6231,75 +6268,38 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: DeletedSasDefinitionBundle
-                description: 'A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
+                name: SasDefinitionBundle
+                description: A SAS definition bundle consists of key vault SAS definition details plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_219
+          - *ref_224
       properties:
         - !<!Property> 
-          schema: *ref_220
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The SAS definition id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_221
-          readOnly: true
-          serializedName: sid
-          language: !<!Languages> 
-            default:
-              name: SecretId
-              description: Storage account SAS definition secret id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_222
-          readOnly: true
-          serializedName: templateUri
-          language: !<!Languages> 
-            default:
-              name: templateUri
-              description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_223
-          readOnly: true
-          serializedName: sasType
-          language: !<!Languages> 
-            default:
-              name: sasType
-              description: The type of SAS token the SAS definition will create.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_224
-          readOnly: true
-          serializedName: validityPeriod
-          language: !<!Languages> 
-            default:
-              name: validityPeriod
-              description: The validity period of SAS tokens created according to the SAS definition.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_215
-          readOnly: true
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The SAS definition attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_225
-          readOnly: true
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_208
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the SAS definition is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_209
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the SAS definition was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -6307,11 +6307,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: SasDefinitionBundle
-          description: A SAS definition bundle consists of key vault SAS definition details plus its attributes.
+          name: DeletedSasDefinitionBundle
+          description: 'A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_219
+    - *ref_224
     - !<!ObjectSchema> &ref_640
       type: object
       apiVersions:
@@ -6328,7 +6328,7 @@ schemas: !<!Schemas>
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_643
-          schema: *ref_223
+          schema: *ref_221
           required: true
           serializedName: sasType
           language: !<!Languages> 
@@ -6388,7 +6388,7 @@ schemas: !<!Schemas>
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_658
-          schema: *ref_223
+          schema: *ref_221
           serializedName: sasType
           language: !<!Languages> 
             default:
@@ -10827,7 +10827,7 @@ operationGroups:
           - *ref_434
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -12215,7 +12215,7 @@ operationGroups:
           - *ref_498
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -12836,7 +12836,7 @@ operationGroups:
           - *ref_517
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -12964,7 +12964,7 @@ operationGroups:
           - *ref_520
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13467,7 +13467,7 @@ operationGroups:
           - *ref_540
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13717,7 +13717,7 @@ operationGroups:
           - *ref_548
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13981,7 +13981,7 @@ operationGroups:
           - *ref_554
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -14211,7 +14211,7 @@ operationGroups:
           - *ref_558
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -14589,7 +14589,7 @@ operationGroups:
           - *ref_567
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_189
+            schema: *ref_187
             language: !<!Languages> 
               default:
                 name: ''
@@ -14793,7 +14793,7 @@ operationGroups:
           - *ref_571
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15018,7 +15018,7 @@ operationGroups:
           - *ref_579
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15129,7 +15129,7 @@ operationGroups:
           - *ref_581
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_189
+            schema: *ref_187
             language: !<!Languages> 
               default:
                 name: ''
@@ -15239,7 +15239,7 @@ operationGroups:
           - *ref_583
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15373,7 +15373,7 @@ operationGroups:
                     description: Current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_594
-                schema: *ref_193
+                schema: *ref_191
                 implementation: Method
                 originalParameter: *ref_585
                 pathToProperty: []
@@ -15444,7 +15444,7 @@ operationGroups:
           - *ref_599
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15575,7 +15575,7 @@ operationGroups:
                     description: The current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_608
-                schema: *ref_193
+                schema: *ref_191
                 implementation: Method
                 originalParameter: *ref_601
                 pathToProperty: []
@@ -15641,7 +15641,7 @@ operationGroups:
           - *ref_613
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15784,7 +15784,7 @@ operationGroups:
           - *ref_619
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -16165,7 +16165,7 @@ operationGroups:
           - *ref_630
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_219
+            schema: *ref_217
             language: !<!Languages> 
               default:
                 name: ''
@@ -16287,7 +16287,7 @@ operationGroups:
           - *ref_633
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16406,7 +16406,7 @@ operationGroups:
           - *ref_636
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_219
+            schema: *ref_217
             language: !<!Languages> 
               default:
                 name: ''
@@ -16527,7 +16527,7 @@ operationGroups:
           - *ref_639
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16659,7 +16659,7 @@ operationGroups:
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_648
-                schema: *ref_223
+                schema: *ref_221
                 implementation: Method
                 originalParameter: *ref_641
                 pathToProperty: []
@@ -16730,7 +16730,7 @@ operationGroups:
           - *ref_654
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16867,7 +16867,7 @@ operationGroups:
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_663
-                schema: *ref_223
+                schema: *ref_221
                 implementation: Method
                 originalParameter: *ref_656
                 pathToProperty: []
@@ -16934,7 +16934,7 @@ operationGroups:
           - *ref_669
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/keyvault/grouped.yaml
+++ b/modelerfour/test/scenarios/keyvault/grouped.yaml
@@ -56,21 +56,21 @@ schemas: !<!Schemas>
           name: boolean
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_106
+    - !<!BooleanSchema> &ref_104
       type: boolean
       language: !<!Languages> 
         default:
           name: boolean
           description: Indicates if the private key can be exported.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_107
+    - !<!BooleanSchema> &ref_105
       type: boolean
       language: !<!Languages> 
         default:
           name: boolean
           description: Indicates if the same key pair will be used on certificate renewal.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_121
+    - !<!BooleanSchema> &ref_119
       type: boolean
       language: !<!Languages> 
         default:
@@ -98,7 +98,7 @@ schemas: !<!Schemas>
           name: boolean
           description: the enabled state of the object.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_193
+    - !<!BooleanSchema> &ref_191
       type: boolean
       language: !<!Languages> 
         default:
@@ -127,7 +127,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_115
+    - !<!NumberSchema> &ref_113
       type: integer
       minimum: 0
       precision: 32
@@ -136,7 +136,7 @@ schemas: !<!Schemas>
           name: ValidityInMonths
           description: The duration that the certificate is valid in months.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_116
+    - !<!NumberSchema> &ref_114
       type: integer
       maximum: 99
       minimum: 1
@@ -146,7 +146,7 @@ schemas: !<!Schemas>
           name: integer
           description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_117
+    - !<!NumberSchema> &ref_115
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -433,7 +433,17 @@ schemas: !<!Schemas>
           name: CertificateListResult-nextLink
           description: The URL to get the next set of certificates.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_102
+    - !<!StringSchema> &ref_124
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedCertificateBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -443,7 +453,7 @@ schemas: !<!Schemas>
           name: CertificateBundle-id
           description: The certificate id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_103
+    - !<!StringSchema> &ref_101
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -453,7 +463,7 @@ schemas: !<!Schemas>
           name: CertificateBundle-kid
           description: The key id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_104
+    - !<!StringSchema> &ref_102
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +473,7 @@ schemas: !<!Schemas>
           name: CertificateBundle-sid
           description: The secret id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_105
+    - !<!StringSchema> &ref_103
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -473,7 +483,7 @@ schemas: !<!Schemas>
           name: CertificatePolicy-id
           description: The certificate id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_108
+    - !<!StringSchema> &ref_106
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -483,7 +493,7 @@ schemas: !<!Schemas>
           name: SecretProperties-contentType
           description: The media type (MIME type).
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_109
+    - !<!StringSchema> &ref_107
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -493,7 +503,7 @@ schemas: !<!Schemas>
           name: X509CertificateProperties-subject
           description: The subject name. Should be a valid X509 distinguished Name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_110
+    - !<!StringSchema> &ref_108
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -503,7 +513,7 @@ schemas: !<!Schemas>
           name: X509CertificateProperties-ekusItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_111
+    - !<!StringSchema> &ref_109
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -513,7 +523,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-emailsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_112
+    - !<!StringSchema> &ref_110
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -523,7 +533,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-dns_namesItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_113
+    - !<!StringSchema> &ref_111
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -533,7 +543,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-upnsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_119
+    - !<!StringSchema> &ref_117
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -543,7 +553,7 @@ schemas: !<!Schemas>
           name: IssuerParameters-name
           description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_120
+    - !<!StringSchema> &ref_118
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -553,7 +563,7 @@ schemas: !<!Schemas>
           name: CertificateType
           description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_123
+    - !<!StringSchema> &ref_121
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -562,16 +572,6 @@ schemas: !<!Schemas>
         default:
           name: CertificateBundle-contentType
           description: The content type of the secret.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_100
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedCertificateBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_134
       type: string
@@ -894,7 +894,17 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_190
+    - !<!StringSchema> &ref_195
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedStorageBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_188
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -904,7 +914,7 @@ schemas: !<!Schemas>
           name: StorageBundle-id
           description: The storage account id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_191
+    - !<!StringSchema> &ref_189
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -914,7 +924,7 @@ schemas: !<!Schemas>
           name: StorageBundle-resourceId
           description: The storage account resource id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_192
+    - !<!StringSchema> &ref_190
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -924,7 +934,7 @@ schemas: !<!Schemas>
           name: StorageBundle-activeKeyName
           description: The current active storage account key name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_194
+    - !<!StringSchema> &ref_192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -933,16 +943,6 @@ schemas: !<!Schemas>
         default:
           name: StorageBundle-regenerationPeriod
           description: The key regeneration time duration specified in ISO-8601 format.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_188
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedStorageBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_198
       type: string
@@ -1054,7 +1054,17 @@ schemas: !<!Schemas>
           name: DeletedSasDefinitionListResult-nextLink
           description: The URL to get the next set of deleted SAS definitions.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_220
+    - !<!StringSchema> &ref_225
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedSasDefinitionBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_218
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1064,7 +1074,7 @@ schemas: !<!Schemas>
           name: SasDefinitionBundle-id
           description: The SAS definition id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_221
+    - !<!StringSchema> &ref_219
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1074,7 +1084,7 @@ schemas: !<!Schemas>
           name: SecretId
           description: Storage account SAS definition secret id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_220
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1084,7 +1094,7 @@ schemas: !<!Schemas>
           name: SasDefinitionBundle-templateUri
           description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_224
+    - !<!StringSchema> &ref_222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1093,16 +1103,6 @@ schemas: !<!Schemas>
         default:
           name: SasDefinitionBundle-validityPeriod
           description: The validity period of SAS tokens created according to the SAS definition.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_218
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedSasDefinitionBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_226
       type: string
@@ -1427,7 +1427,7 @@ schemas: !<!Schemas>
           name: JsonWebKeySignatureAlgorithm
           description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_114
+    - !<!ChoiceSchema> &ref_112
       choices:
         - !<!ChoiceValue> 
           value: digitalSignature
@@ -1493,7 +1493,7 @@ schemas: !<!Schemas>
           name: KeyUsageType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_223
+    - !<!ChoiceSchema> &ref_221
       choices:
         - !<!ChoiceValue> 
           value: account
@@ -1518,7 +1518,7 @@ schemas: !<!Schemas>
           description: The type of SAS token the SAS definition will create.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_118
+    - !<!SealedChoiceSchema> &ref_116
       choices:
         - !<!ChoiceValue> 
           value: EmailContacts
@@ -1644,7 +1644,7 @@ schemas: !<!Schemas>
           name: CertificateItem-tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_124
+    - !<!DictionarySchema> &ref_122
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -1698,7 +1698,7 @@ schemas: !<!Schemas>
           name: StorageAccountItem-tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_195
+    - !<!DictionarySchema> &ref_193
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -1734,7 +1734,7 @@ schemas: !<!Schemas>
           name: SasDefinitionItem-tags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_225
+    - !<!DictionarySchema> &ref_223
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -2004,7 +2004,7 @@ schemas: !<!Schemas>
           name: X509Thumbprint
           description: Thumbprint of the certificate.
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_122
+    - !<!ByteArraySchema> &ref_120
       type: byte-array
       format: byte
       apiVersions:
@@ -2427,8 +2427,8 @@ schemas: !<!Schemas>
           description: The key create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
     - *ref_5
+    - *ref_6
     - !<!ObjectSchema> &ref_17
       type: object
       apiVersions:
@@ -3880,14 +3880,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_101
+          - !<!ObjectSchema> &ref_123
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_99
               immediate:
@@ -3895,88 +3895,6 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_100
-                serializedName: recoveryId
-                language: !<!Languages> 
-                  default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_92
-                readOnly: true
-                serializedName: scheduledPurgeDate
-                language: !<!Languages> 
-                  default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the certificate is scheduled to be purged, in UTC'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_93
-                readOnly: true
-                serializedName: deletedDate
-                language: !<!Languages> 
-                  default:
-                    name: deletedDate
-                    description: 'The time when the certificate was deleted, in UTC'
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-            language: !<!Languages> 
-              default:
-                name: DeletedCertificateBundle
-                description: 'A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
-                namespace: ''
-            protocol: !<!Protocols> {}
-        immediate:
-          - *ref_101
-      properties:
-        - !<!Property> 
-          schema: *ref_102
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The certificate id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_103
-          readOnly: true
-          serializedName: kid
-          language: !<!Languages> 
-            default:
-              name: kid
-              description: The key id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_104
-          readOnly: true
-          serializedName: sid
-          language: !<!Languages> 
-            default:
-              name: sid
-              description: The secret id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_97
-          readOnly: true
-          serializedName: x5t
-          language: !<!Languages> 
-            default:
-              name: X509Thumbprint
-              description: Thumbprint of the certificate.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: !<!ObjectSchema> &ref_125
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 7.0-preview
-            properties:
-              - !<!Property> 
-                schema: *ref_105
                 readOnly: true
                 serializedName: id
                 language: !<!Languages> 
@@ -3985,194 +3903,94 @@ schemas: !<!Schemas>
                     description: The certificate id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_126
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_106
-                      serializedName: exportable
-                      language: !<!Languages> 
-                        default:
-                          name: exportable
-                          description: Indicates if the private key can be exported.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_2
-                      serializedName: kty
-                      language: !<!Languages> 
-                        default:
-                          name: keyType
-                          description: The type of key pair to be used for the certificate.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_3
-                      serializedName: key_size
-                      language: !<!Languages> 
-                        default:
-                          name: key_size
-                          description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_107
-                      serializedName: reuse_key
-                      language: !<!Languages> 
-                        default:
-                          name: reuse_key
-                          description: Indicates if the same key pair will be used on certificate renewal.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_16
-                      serializedName: crv
-                      language: !<!Languages> 
-                        default:
-                          name: curve
-                          description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: KeyProperties
-                      description: Properties of the key pair backing a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: key_props
+                schema: *ref_101
+                readOnly: true
+                serializedName: kid
                 language: !<!Languages> 
                   default:
-                    name: KeyProperties
-                    description: Properties of the key backing a certificate.
+                    name: kid
+                    description: The key id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_127
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_108
-                      serializedName: contentType
-                      language: !<!Languages> 
-                        default:
-                          name: contentType
-                          description: The media type (MIME type).
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: SecretProperties
-                      description: Properties of the key backing a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: secret_props
+                schema: *ref_102
+                readOnly: true
+                serializedName: sid
                 language: !<!Languages> 
                   default:
-                    name: SecretProperties
-                    description: Properties of the secret backing a certificate.
+                    name: sid
+                    description: The secret id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_128
+                schema: *ref_97
+                readOnly: true
+                serializedName: x5t
+                language: !<!Languages> 
+                  default:
+                    name: X509Thumbprint
+                    description: Thumbprint of the certificate.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: !<!ObjectSchema> &ref_125
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 7.0-preview
                   properties:
                     - !<!Property> 
-                      schema: *ref_109
-                      serializedName: subject
+                      schema: *ref_103
+                      readOnly: true
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: subject
-                          description: The subject name. Should be a valid X509 distinguished Name.
+                          name: id
+                          description: The certificate id.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: !<!ArraySchema> &ref_241
-                        type: array
-                        apiVersions:
-                          - !<!ApiVersion> 
-                            version: 7.0-preview
-                        elementType: *ref_110
-                        language: !<!Languages> 
-                          default:
-                            name: X509CertificateProperties-ekus
-                            description: The enhanced key usage.
-                        protocol: !<!Protocols> {}
-                      serializedName: ekus
-                      language: !<!Languages> 
-                        default:
-                          name: ekus
-                          description: The enhanced key usage.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_129
+                      schema: !<!ObjectSchema> &ref_126
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 7.0-preview
                         properties:
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_242
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_111
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-emails
-                                  description: Email addresses.
-                              protocol: !<!Protocols> {}
-                            serializedName: emails
+                            schema: *ref_104
+                            serializedName: exportable
                             language: !<!Languages> 
                               default:
-                                name: emails
-                                description: Email addresses.
+                                name: exportable
+                                description: Indicates if the private key can be exported.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_243
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_112
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-dns_names
-                                  description: Domain names.
-                              protocol: !<!Protocols> {}
-                            serializedName: dns_names
+                            schema: *ref_2
+                            serializedName: kty
                             language: !<!Languages> 
                               default:
-                                name: dns_names
-                                description: Domain names.
+                                name: keyType
+                                description: The type of key pair to be used for the certificate.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_244
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_113
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-upns
-                                  description: User principal names.
-                              protocol: !<!Protocols> {}
-                            serializedName: upns
+                            schema: *ref_3
+                            serializedName: key_size
                             language: !<!Languages> 
                               default:
-                                name: upns
-                                description: User principal names.
+                                name: key_size
+                                description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_105
+                            serializedName: reuse_key
+                            language: !<!Languages> 
+                              default:
+                                name: reuse_key
+                                description: Indicates if the same key pair will be used on certificate renewal.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_16
+                            serializedName: crv
+                            language: !<!Languages> 
+                              default:
+                                name: curve
+                                description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -4181,93 +3999,285 @@ schemas: !<!Schemas>
                           - input
                         language: !<!Languages> 
                           default:
-                            name: SubjectAlternativeNames
-                            description: The subject alternate names of a X509 object.
+                            name: KeyProperties
+                            description: Properties of the key pair backing a certificate.
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: sans
+                      serializedName: key_props
                       language: !<!Languages> 
                         default:
-                          name: SubjectAlternativeNames
-                          description: The subject alternative names.
+                          name: KeyProperties
+                          description: Properties of the key backing a certificate.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: !<!ArraySchema> &ref_245
+                      schema: !<!ObjectSchema> &ref_127
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_106
+                            serializedName: contentType
+                            language: !<!Languages> 
+                              default:
+                                name: contentType
+                                description: The media type (MIME type).
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: SecretProperties
+                            description: Properties of the key backing a certificate.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      serializedName: secret_props
+                      language: !<!Languages> 
+                        default:
+                          name: SecretProperties
+                          description: Properties of the secret backing a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_128
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_107
+                            serializedName: subject
+                            language: !<!Languages> 
+                              default:
+                                name: subject
+                                description: The subject name. Should be a valid X509 distinguished Name.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ArraySchema> &ref_241
+                              type: array
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              elementType: *ref_108
+                              language: !<!Languages> 
+                                default:
+                                  name: X509CertificateProperties-ekus
+                                  description: The enhanced key usage.
+                              protocol: !<!Protocols> {}
+                            serializedName: ekus
+                            language: !<!Languages> 
+                              default:
+                                name: ekus
+                                description: The enhanced key usage.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ObjectSchema> &ref_129
+                              type: object
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              properties:
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_242
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_109
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-emails
+                                        description: Email addresses.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: emails
+                                  language: !<!Languages> 
+                                    default:
+                                      name: emails
+                                      description: Email addresses.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_243
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_110
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-dns_names
+                                        description: Domain names.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: dns_names
+                                  language: !<!Languages> 
+                                    default:
+                                      name: dns_names
+                                      description: Domain names.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_244
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_111
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-upns
+                                        description: User principal names.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: upns
+                                  language: !<!Languages> 
+                                    default:
+                                      name: upns
+                                      description: User principal names.
+                                  protocol: !<!Protocols> {}
+                              serializationFormats:
+                                - json
+                              usage:
+                                - output
+                                - input
+                              language: !<!Languages> 
+                                default:
+                                  name: SubjectAlternativeNames
+                                  description: The subject alternate names of a X509 object.
+                                  namespace: ''
+                              protocol: !<!Protocols> {}
+                            serializedName: sans
+                            language: !<!Languages> 
+                              default:
+                                name: SubjectAlternativeNames
+                                description: The subject alternative names.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ArraySchema> &ref_245
+                              type: array
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              elementType: *ref_112
+                              language: !<!Languages> 
+                                default:
+                                  name: X509CertificateProperties-key_usage
+                                  description: List of key usages.
+                              protocol: !<!Protocols> {}
+                            serializedName: key_usage
+                            language: !<!Languages> 
+                              default:
+                                name: key_usage
+                                description: List of key usages.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_113
+                            serializedName: validity_months
+                            language: !<!Languages> 
+                              default:
+                                name: ValidityInMonths
+                                description: The duration that the certificate is valid in months.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: X509CertificateProperties
+                            description: Properties of the X509 component of a certificate.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      serializedName: x509_props
+                      language: !<!Languages> 
+                        default:
+                          name: X509CertificateProperties
+                          description: Properties of the X509 component of a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ArraySchema> &ref_246
                         type: array
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 7.0-preview
-                        elementType: *ref_114
-                        language: !<!Languages> 
-                          default:
-                            name: X509CertificateProperties-key_usage
-                            description: List of key usages.
-                        protocol: !<!Protocols> {}
-                      serializedName: key_usage
-                      language: !<!Languages> 
-                        default:
-                          name: key_usage
-                          description: List of key usages.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_115
-                      serializedName: validity_months
-                      language: !<!Languages> 
-                        default:
-                          name: ValidityInMonths
-                          description: The duration that the certificate is valid in months.
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: X509CertificateProperties
-                      description: Properties of the X509 component of a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: x509_props
-                language: !<!Languages> 
-                  default:
-                    name: X509CertificateProperties
-                    description: Properties of the X509 component of a certificate.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ArraySchema> &ref_246
-                  type: array
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  elementType: !<!ObjectSchema> &ref_130
-                    type: object
-                    apiVersions:
-                      - !<!ApiVersion> 
-                        version: 7.0-preview
-                    properties:
-                      - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_131
+                        elementType: !<!ObjectSchema> &ref_130
                           type: object
                           apiVersions:
                             - !<!ApiVersion> 
                               version: 7.0-preview
                           properties:
                             - !<!Property> 
-                              schema: *ref_116
-                              serializedName: lifetime_percentage
+                              schema: !<!ObjectSchema> &ref_131
+                                type: object
+                                apiVersions:
+                                  - !<!ApiVersion> 
+                                    version: 7.0-preview
+                                properties:
+                                  - !<!Property> 
+                                    schema: *ref_114
+                                    serializedName: lifetime_percentage
+                                    language: !<!Languages> 
+                                      default:
+                                        name: lifetime_percentage
+                                        description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+                                    protocol: !<!Protocols> {}
+                                  - !<!Property> 
+                                    schema: *ref_115
+                                    serializedName: days_before_expiry
+                                    language: !<!Languages> 
+                                      default:
+                                        name: days_before_expiry
+                                        description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
+                                    protocol: !<!Protocols> {}
+                                serializationFormats:
+                                  - json
+                                usage:
+                                  - output
+                                  - input
+                                language: !<!Languages> 
+                                  default:
+                                    name: Trigger
+                                    description: A condition to be satisfied for an action to be executed.
+                                    namespace: ''
+                                protocol: !<!Protocols> {}
+                              serializedName: trigger
                               language: !<!Languages> 
                                 default:
-                                  name: lifetime_percentage
-                                  description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+                                  name: trigger
+                                  description: The condition that will execute the action.
                               protocol: !<!Protocols> {}
                             - !<!Property> 
-                              schema: *ref_117
-                              serializedName: days_before_expiry
+                              schema: !<!ObjectSchema> &ref_132
+                                type: object
+                                apiVersions:
+                                  - !<!ApiVersion> 
+                                    version: 7.0-preview
+                                properties:
+                                  - !<!Property> 
+                                    schema: *ref_116
+                                    serializedName: action_type
+                                    language: !<!Languages> 
+                                      default:
+                                        name: action_type
+                                        description: The type of the action.
+                                    protocol: !<!Protocols> {}
+                                serializationFormats:
+                                  - json
+                                usage:
+                                  - output
+                                  - input
+                                language: !<!Languages> 
+                                  default:
+                                    name: Action
+                                    description: The action that will be executed.
+                                    namespace: ''
+                                protocol: !<!Protocols> {}
+                              serializedName: action
                               language: !<!Languages> 
                                 default:
-                                  name: days_before_expiry
-                                  description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
+                                  name: action
+                                  description: The action that will be executed.
                               protocol: !<!Protocols> {}
                           serializationFormats:
                             - json
@@ -4276,100 +4286,76 @@ schemas: !<!Schemas>
                             - input
                           language: !<!Languages> 
                             default:
-                              name: Trigger
-                              description: A condition to be satisfied for an action to be executed.
+                              name: LifetimeAction
+                              description: Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
                               namespace: ''
                           protocol: !<!Protocols> {}
-                        serializedName: trigger
                         language: !<!Languages> 
                           default:
-                            name: trigger
-                            description: The condition that will execute the action.
+                            name: CertificatePolicy-lifetime_actions
+                            description: Actions that will be performed by Key Vault over the lifetime of a certificate.
                         protocol: !<!Protocols> {}
-                      - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_132
-                          type: object
-                          apiVersions:
-                            - !<!ApiVersion> 
-                              version: 7.0-preview
-                          properties:
-                            - !<!Property> 
-                              schema: *ref_118
-                              serializedName: action_type
-                              language: !<!Languages> 
-                                default:
-                                  name: action_type
-                                  description: The type of the action.
-                              protocol: !<!Protocols> {}
-                          serializationFormats:
-                            - json
-                          usage:
-                            - output
-                            - input
-                          language: !<!Languages> 
-                            default:
-                              name: Action
-                              description: The action that will be executed.
-                              namespace: ''
-                          protocol: !<!Protocols> {}
-                        serializedName: action
+                      serializedName: lifetime_actions
+                      language: !<!Languages> 
+                        default:
+                          name: lifetime_actions
+                          description: Actions that will be performed by Key Vault over the lifetime of a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_133
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_117
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_118
+                            serializedName: cty
+                            language: !<!Languages> 
+                              default:
+                                name: CertificateType
+                                description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_119
+                            serializedName: cert_transparency
+                            language: !<!Languages> 
+                              default:
+                                name: CertificateTransparency
+                                description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
                         language: !<!Languages> 
                           default:
-                            name: action
-                            description: The action that will be executed.
+                            name: IssuerParameters
+                            description: Parameters for the issuer of the X509 component of a certificate.
+                            namespace: ''
                         protocol: !<!Protocols> {}
-                    serializationFormats:
-                      - json
-                    usage:
-                      - output
-                      - input
-                    language: !<!Languages> 
-                      default:
-                        name: LifetimeAction
-                        description: Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
-                        namespace: ''
-                    protocol: !<!Protocols> {}
-                  language: !<!Languages> 
-                    default:
-                      name: CertificatePolicy-lifetime_actions
-                      description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-                  protocol: !<!Protocols> {}
-                serializedName: lifetime_actions
-                language: !<!Languages> 
-                  default:
-                    name: lifetime_actions
-                    description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_133
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_119
-                      serializedName: name
+                      serializedName: issuer
                       language: !<!Languages> 
                         default:
-                          name: name
-                          description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
+                          name: IssuerParameters
+                          description: Parameters for the issuer of the X509 component of a certificate.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_120
-                      serializedName: cty
+                      schema: *ref_9
+                      serializedName: attributes
                       language: !<!Languages> 
                         default:
-                          name: CertificateType
-                          description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_121
-                      serializedName: cert_transparency
-                      language: !<!Languages> 
-                        default:
-                          name: CertificateTransparency
-                          description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
+                          name: attributes
+                          description: The certificate attributes.
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
@@ -4378,15 +4364,32 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: IssuerParameters
-                      description: Parameters for the issuer of the X509 component of a certificate.
+                      name: CertificatePolicy
+                      description: Management policy for a certificate.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                serializedName: issuer
+                readOnly: true
+                serializedName: policy
                 language: !<!Languages> 
                   default:
-                    name: IssuerParameters
-                    description: Parameters for the issuer of the X509 component of a certificate.
+                    name: policy
+                    description: The management policy.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_120
+                serializedName: cer
+                language: !<!Languages> 
+                  default:
+                    name: cer
+                    description: CER contents of x509 certificate.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_121
+                serializedName: contentType
+                language: !<!Languages> 
+                  default:
+                    name: contentType
+                    description: The content type of the secret.
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_9
@@ -4396,55 +4399,52 @@ schemas: !<!Schemas>
                     name: attributes
                     description: The certificate attributes.
                 protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_122
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
+                protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - output
-              - input
             language: !<!Languages> 
               default:
-                name: CertificatePolicy
-                description: Management policy for a certificate.
+                name: CertificateBundle
+                description: A certificate bundle consists of a certificate (X509) plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
-          readOnly: true
-          serializedName: policy
-          language: !<!Languages> 
-            default:
-              name: policy
-              description: The management policy.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_122
-          serializedName: cer
-          language: !<!Languages> 
-            default:
-              name: cer
-              description: CER contents of x509 certificate.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_123
-          serializedName: contentType
-          language: !<!Languages> 
-            default:
-              name: contentType
-              description: The content type of the secret.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_9
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The certificate attributes.
-          protocol: !<!Protocols> {}
+        immediate:
+          - *ref_123
+      properties:
         - !<!Property> 
           schema: *ref_124
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_92
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the certificate is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_93
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the certificate was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -4452,10 +4452,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: CertificateBundle
-          description: A certificate bundle consists of a certificate (X509) plus its attributes.
+          name: DeletedCertificateBundle
+          description: 'A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
+    - *ref_123
     - *ref_125
     - *ref_126
     - *ref_127
@@ -4465,7 +4466,6 @@ schemas: !<!Schemas>
     - *ref_131
     - *ref_132
     - *ref_133
-    - *ref_101
     - !<!ObjectSchema> &ref_435
       type: object
       apiVersions:
@@ -5607,14 +5607,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_189
+          - !<!ObjectSchema> &ref_194
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_187
               immediate:
@@ -5622,29 +5622,66 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_188
-                serializedName: recoveryId
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+                    name: id
+                    description: The storage account id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_177
+                schema: *ref_189
                 readOnly: true
-                serializedName: scheduledPurgeDate
+                serializedName: resourceId
                 language: !<!Languages> 
                   default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the storage account is scheduled to be purged, in UTC'
+                    name: resourceId
+                    description: The storage account resource id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_178
+                schema: *ref_190
                 readOnly: true
-                serializedName: deletedDate
+                serializedName: activeKeyName
                 language: !<!Languages> 
                   default:
-                    name: deletedDate
-                    description: 'The time when the storage account was deleted, in UTC'
+                    name: activeKeyName
+                    description: The current active storage account key name.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_191
+                readOnly: true
+                serializedName: autoRegenerateKey
+                language: !<!Languages> 
+                  default:
+                    name: autoRegenerateKey
+                    description: whether keyvault should manage the storage account for the user.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_192
+                readOnly: true
+                serializedName: regenerationPeriod
+                language: !<!Languages> 
+                  default:
+                    name: regenerationPeriod
+                    description: The key regeneration time duration specified in ISO-8601 format.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_185
+                readOnly: true
+                serializedName: attributes
+                language: !<!Languages> 
+                  default:
+                    name: attributes
+                    description: The storage account attributes.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_193
+                readOnly: true
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -5652,75 +5689,38 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: DeletedStorageBundle
-                description: 'A deleted storage account bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
+                name: StorageBundle
+                description: A Storage account bundle consists of key vault storage account details plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_189
+          - *ref_194
       properties:
         - !<!Property> 
-          schema: *ref_190
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The storage account id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_191
-          readOnly: true
-          serializedName: resourceId
-          language: !<!Languages> 
-            default:
-              name: resourceId
-              description: The storage account resource id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_192
-          readOnly: true
-          serializedName: activeKeyName
-          language: !<!Languages> 
-            default:
-              name: activeKeyName
-              description: The current active storage account key name.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_193
-          readOnly: true
-          serializedName: autoRegenerateKey
-          language: !<!Languages> 
-            default:
-              name: autoRegenerateKey
-              description: whether keyvault should manage the storage account for the user.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_194
-          readOnly: true
-          serializedName: regenerationPeriod
-          language: !<!Languages> 
-            default:
-              name: regenerationPeriod
-              description: The key regeneration time duration specified in ISO-8601 format.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_185
-          readOnly: true
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The storage account attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_195
-          readOnly: true
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_177
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the storage account is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_178
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the storage account was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -5728,11 +5728,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: StorageBundle
-          description: A Storage account bundle consists of key vault storage account details plus its attributes.
+          name: DeletedStorageBundle
+          description: 'A deleted storage account bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_189
+    - *ref_194
     - !<!ObjectSchema> &ref_574
       type: object
       apiVersions:
@@ -5808,7 +5808,7 @@ schemas: !<!Schemas>
               description: Current active storage account key name.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_588
-          schema: *ref_193
+          schema: *ref_191
           required: true
           serializedName: autoRegenerateKey
           language: !<!Languages> 
@@ -5868,7 +5868,7 @@ schemas: !<!Schemas>
               description: The current active storage account key name.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_603
-          schema: *ref_193
+          schema: *ref_191
           serializedName: autoRegenerateKey
           language: !<!Languages> 
             default:
@@ -6186,14 +6186,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_219
+          - !<!ObjectSchema> &ref_224
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_217
               immediate:
@@ -6201,29 +6201,66 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_218
-                serializedName: recoveryId
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+                    name: id
+                    description: The SAS definition id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_208
+                schema: *ref_219
                 readOnly: true
-                serializedName: scheduledPurgeDate
+                serializedName: sid
                 language: !<!Languages> 
                   default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the SAS definition is scheduled to be purged, in UTC'
+                    name: SecretId
+                    description: Storage account SAS definition secret id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_209
+                schema: *ref_220
                 readOnly: true
-                serializedName: deletedDate
+                serializedName: templateUri
                 language: !<!Languages> 
                   default:
-                    name: deletedDate
-                    description: 'The time when the SAS definition was deleted, in UTC'
+                    name: templateUri
+                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_221
+                readOnly: true
+                serializedName: sasType
+                language: !<!Languages> 
+                  default:
+                    name: sasType
+                    description: The type of SAS token the SAS definition will create.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_222
+                readOnly: true
+                serializedName: validityPeriod
+                language: !<!Languages> 
+                  default:
+                    name: validityPeriod
+                    description: The validity period of SAS tokens created according to the SAS definition.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_215
+                readOnly: true
+                serializedName: attributes
+                language: !<!Languages> 
+                  default:
+                    name: attributes
+                    description: The SAS definition attributes.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_223
+                readOnly: true
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -6231,75 +6268,38 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: DeletedSasDefinitionBundle
-                description: 'A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
+                name: SasDefinitionBundle
+                description: A SAS definition bundle consists of key vault SAS definition details plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_219
+          - *ref_224
       properties:
         - !<!Property> 
-          schema: *ref_220
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The SAS definition id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_221
-          readOnly: true
-          serializedName: sid
-          language: !<!Languages> 
-            default:
-              name: SecretId
-              description: Storage account SAS definition secret id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_222
-          readOnly: true
-          serializedName: templateUri
-          language: !<!Languages> 
-            default:
-              name: templateUri
-              description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_223
-          readOnly: true
-          serializedName: sasType
-          language: !<!Languages> 
-            default:
-              name: sasType
-              description: The type of SAS token the SAS definition will create.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_224
-          readOnly: true
-          serializedName: validityPeriod
-          language: !<!Languages> 
-            default:
-              name: validityPeriod
-              description: The validity period of SAS tokens created according to the SAS definition.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_215
-          readOnly: true
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The SAS definition attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_225
-          readOnly: true
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_208
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the SAS definition is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_209
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the SAS definition was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -6307,11 +6307,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: SasDefinitionBundle
-          description: A SAS definition bundle consists of key vault SAS definition details plus its attributes.
+          name: DeletedSasDefinitionBundle
+          description: 'A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_219
+    - *ref_224
     - !<!ObjectSchema> &ref_640
       type: object
       apiVersions:
@@ -6328,7 +6328,7 @@ schemas: !<!Schemas>
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_643
-          schema: *ref_223
+          schema: *ref_221
           required: true
           serializedName: sasType
           language: !<!Languages> 
@@ -6388,7 +6388,7 @@ schemas: !<!Schemas>
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_658
-          schema: *ref_223
+          schema: *ref_221
           serializedName: sasType
           language: !<!Languages> 
             default:
@@ -10827,7 +10827,7 @@ operationGroups:
           - *ref_434
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -12215,7 +12215,7 @@ operationGroups:
           - *ref_498
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -12836,7 +12836,7 @@ operationGroups:
           - *ref_517
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -12964,7 +12964,7 @@ operationGroups:
           - *ref_520
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13467,7 +13467,7 @@ operationGroups:
           - *ref_540
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13717,7 +13717,7 @@ operationGroups:
           - *ref_548
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13981,7 +13981,7 @@ operationGroups:
           - *ref_554
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -14211,7 +14211,7 @@ operationGroups:
           - *ref_558
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -14589,7 +14589,7 @@ operationGroups:
           - *ref_567
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_189
+            schema: *ref_187
             language: !<!Languages> 
               default:
                 name: ''
@@ -14793,7 +14793,7 @@ operationGroups:
           - *ref_571
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15018,7 +15018,7 @@ operationGroups:
           - *ref_579
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15129,7 +15129,7 @@ operationGroups:
           - *ref_581
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_189
+            schema: *ref_187
             language: !<!Languages> 
               default:
                 name: ''
@@ -15239,7 +15239,7 @@ operationGroups:
           - *ref_583
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15373,7 +15373,7 @@ operationGroups:
                     description: Current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_594
-                schema: *ref_193
+                schema: *ref_191
                 implementation: Method
                 originalParameter: *ref_585
                 pathToProperty: []
@@ -15444,7 +15444,7 @@ operationGroups:
           - *ref_599
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15575,7 +15575,7 @@ operationGroups:
                     description: The current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_608
-                schema: *ref_193
+                schema: *ref_191
                 implementation: Method
                 originalParameter: *ref_601
                 pathToProperty: []
@@ -15641,7 +15641,7 @@ operationGroups:
           - *ref_613
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15784,7 +15784,7 @@ operationGroups:
           - *ref_619
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -16165,7 +16165,7 @@ operationGroups:
           - *ref_630
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_219
+            schema: *ref_217
             language: !<!Languages> 
               default:
                 name: ''
@@ -16287,7 +16287,7 @@ operationGroups:
           - *ref_633
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16406,7 +16406,7 @@ operationGroups:
           - *ref_636
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_219
+            schema: *ref_217
             language: !<!Languages> 
               default:
                 name: ''
@@ -16527,7 +16527,7 @@ operationGroups:
           - *ref_639
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16659,7 +16659,7 @@ operationGroups:
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_648
-                schema: *ref_223
+                schema: *ref_221
                 implementation: Method
                 originalParameter: *ref_641
                 pathToProperty: []
@@ -16730,7 +16730,7 @@ operationGroups:
           - *ref_654
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16867,7 +16867,7 @@ operationGroups:
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_663
-                schema: *ref_223
+                schema: *ref_221
                 implementation: Method
                 originalParameter: *ref_656
                 pathToProperty: []
@@ -16934,7 +16934,7 @@ operationGroups:
           - *ref_669
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/keyvault/modeler.yaml
+++ b/modelerfour/test/scenarios/keyvault/modeler.yaml
@@ -106,7 +106,7 @@ schemas: !<!Schemas>
           description: whether keyvault should manage the storage account for the user.
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_59
+    - !<!NumberSchema> &ref_62
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -440,10 +440,20 @@ schemas: !<!Schemas>
           version: 7.0-preview
       language: !<!Languages> 
         default:
+          name: DeletedCertificateBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_57
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
           name: CertificateBundle-id
           description: The certificate id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_55
+    - !<!StringSchema> &ref_58
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -453,7 +463,7 @@ schemas: !<!Schemas>
           name: CertificateBundle-kid
           description: The key id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_56
+    - !<!StringSchema> &ref_59
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +473,7 @@ schemas: !<!Schemas>
           name: CertificateBundle-sid
           description: The secret id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_58
+    - !<!StringSchema> &ref_61
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -473,7 +483,7 @@ schemas: !<!Schemas>
           name: CertificatePolicy-id
           description: The certificate id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_60
+    - !<!StringSchema> &ref_63
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -483,7 +493,7 @@ schemas: !<!Schemas>
           name: SecretProperties-contentType
           description: The media type (MIME type).
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_61
+    - !<!StringSchema> &ref_64
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -493,7 +503,7 @@ schemas: !<!Schemas>
           name: X509CertificateProperties-subject
           description: The subject name. Should be a valid X509 distinguished Name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_62
+    - !<!StringSchema> &ref_65
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -503,7 +513,7 @@ schemas: !<!Schemas>
           name: X509CertificateProperties-ekusItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_63
+    - !<!StringSchema> &ref_66
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -513,7 +523,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-emailsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_64
+    - !<!StringSchema> &ref_67
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -523,7 +533,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-dns_namesItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_65
+    - !<!StringSchema> &ref_68
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -533,7 +543,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNames-upnsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_66
+    - !<!StringSchema> &ref_69
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -543,7 +553,7 @@ schemas: !<!Schemas>
           name: IssuerParameters-name
           description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_67
+    - !<!StringSchema> &ref_70
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -553,7 +563,7 @@ schemas: !<!Schemas>
           name: CertificateType
           description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_68
+    - !<!StringSchema> &ref_71
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -562,16 +572,6 @@ schemas: !<!Schemas>
         default:
           name: CertificateBundle-contentType
           description: The content type of the secret.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_69
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedCertificateBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_83
       type: string
@@ -901,10 +901,20 @@ schemas: !<!Schemas>
           version: 7.0-preview
       language: !<!Languages> 
         default:
+          name: DeletedStorageBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_128
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
           name: StorageBundle-id
           description: The storage account id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_126
+    - !<!StringSchema> &ref_129
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -914,7 +924,7 @@ schemas: !<!Schemas>
           name: StorageBundle-resourceId
           description: The storage account resource id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_127
+    - !<!StringSchema> &ref_130
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -924,7 +934,7 @@ schemas: !<!Schemas>
           name: StorageBundle-activeKeyName
           description: The current active storage account key name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_128
+    - !<!StringSchema> &ref_131
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -933,16 +943,6 @@ schemas: !<!Schemas>
         default:
           name: StorageBundle-regenerationPeriod
           description: The key regeneration time duration specified in ISO-8601 format.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_129
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedStorageBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_134
       type: string
@@ -1061,10 +1061,20 @@ schemas: !<!Schemas>
           version: 7.0-preview
       language: !<!Languages> 
         default:
+          name: DeletedSasDefinitionBundle-recoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_153
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
           name: SasDefinitionBundle-id
           description: The SAS definition id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_151
+    - !<!StringSchema> &ref_154
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1074,7 +1084,7 @@ schemas: !<!Schemas>
           name: SecretId
           description: Storage account SAS definition secret id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_152
+    - !<!StringSchema> &ref_155
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1084,7 +1094,7 @@ schemas: !<!Schemas>
           name: SasDefinitionBundle-templateUri
           description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_153
+    - !<!StringSchema> &ref_156
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1093,16 +1103,6 @@ schemas: !<!Schemas>
         default:
           name: SasDefinitionBundle-validityPeriod
           description: The validity period of SAS tokens created according to the SAS definition.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_154
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedSasDefinitionBundle-recoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_159
       type: string
@@ -1993,7 +1993,7 @@ schemas: !<!Schemas>
           name: secretBundleBackup
           description: The backup blob associated with a secret bundle.
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_57
+    - !<!ByteArraySchema> &ref_60
       type: byte-array
       format: base64url
       apiVersions:
@@ -2138,42 +2138,42 @@ schemas: !<!Schemas>
           name: unixtime
           description: 'The time when the secret was deleted, in UTC'
       protocol: !<!Protocols> {}
-    - !<!UnixTimeSchema> &ref_70
+    - !<!UnixTimeSchema> &ref_55
       type: unixtime
       language: !<!Languages> 
         default:
           name: unixtime
           description: 'The time when the certificate is scheduled to be purged, in UTC'
       protocol: !<!Protocols> {}
-    - !<!UnixTimeSchema> &ref_71
+    - !<!UnixTimeSchema> &ref_56
       type: unixtime
       language: !<!Languages> 
         default:
           name: unixtime
           description: 'The time when the certificate was deleted, in UTC'
       protocol: !<!Protocols> {}
-    - !<!UnixTimeSchema> &ref_130
+    - !<!UnixTimeSchema> &ref_126
       type: unixtime
       language: !<!Languages> 
         default:
           name: unixtime
           description: 'The time when the storage account is scheduled to be purged, in UTC'
       protocol: !<!Protocols> {}
-    - !<!UnixTimeSchema> &ref_131
+    - !<!UnixTimeSchema> &ref_127
       type: unixtime
       language: !<!Languages> 
         default:
           name: unixtime
           description: 'The time when the storage account was deleted, in UTC'
       protocol: !<!Protocols> {}
-    - !<!UnixTimeSchema> &ref_155
+    - !<!UnixTimeSchema> &ref_151
       type: unixtime
       language: !<!Languages> 
         default:
           name: unixtime
           description: 'The time when the SAS definition is scheduled to be purged, in UTC'
       protocol: !<!Protocols> {}
-    - !<!UnixTimeSchema> &ref_156
+    - !<!UnixTimeSchema> &ref_152
       type: unixtime
       language: !<!Languages> 
         default:
@@ -2197,7 +2197,7 @@ schemas: !<!Schemas>
               description: 'The type of key to create. For valid values, see JsonWebKeyType.'
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_59
+          schema: *ref_62
           required: false
           serializedName: key_size
           language: !<!Languages> 
@@ -2427,8 +2427,8 @@ schemas: !<!Schemas>
           description: The key create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_3
     - *ref_1
+    - *ref_3
     - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
@@ -3770,7 +3770,7 @@ schemas: !<!Schemas>
                             description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_70
+                        schema: *ref_55
                         readOnly: true
                         serializedName: scheduledPurgeDate
                         language: !<!Languages> 
@@ -3779,7 +3779,7 @@ schemas: !<!Schemas>
                             description: 'The time when the certificate is scheduled to be purged, in UTC'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_71
+                        schema: *ref_56
                         readOnly: true
                         serializedName: deletedDate
                         language: !<!Languages> 
@@ -3825,7 +3825,7 @@ schemas: !<!Schemas>
                       description: Application specific metadata in the form of key-value pairs.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_57
+                  schema: *ref_60
                   serializedName: x5t
                   language: !<!Languages> 
                     default:
@@ -3880,103 +3880,21 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_73
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_72
               immediate:
                 - *ref_72
             properties:
               - !<!Property> 
-                schema: *ref_69
-                serializedName: recoveryId
-                language: !<!Languages> 
-                  default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_70
-                readOnly: true
-                serializedName: scheduledPurgeDate
-                language: !<!Languages> 
-                  default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the certificate is scheduled to be purged, in UTC'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_71
-                readOnly: true
-                serializedName: deletedDate
-                language: !<!Languages> 
-                  default:
-                    name: deletedDate
-                    description: 'The time when the certificate was deleted, in UTC'
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-            language: !<!Languages> 
-              default:
-                name: DeletedCertificateBundle
-                description: 'A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
-                namespace: ''
-            protocol: !<!Protocols> {}
-        immediate:
-          - *ref_73
-      properties:
-        - !<!Property> 
-          schema: *ref_54
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The certificate id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_55
-          readOnly: true
-          serializedName: kid
-          language: !<!Languages> 
-            default:
-              name: kid
-              description: The key id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_56
-          readOnly: true
-          serializedName: sid
-          language: !<!Languages> 
-            default:
-              name: sid
-              description: The secret id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_57
-          readOnly: true
-          serializedName: x5t
-          language: !<!Languages> 
-            default:
-              name: X509Thumbprint
-              description: Thumbprint of the certificate.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: !<!ObjectSchema> &ref_74
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 7.0-preview
-            properties:
-              - !<!Property> 
-                schema: *ref_58
+                schema: *ref_57
                 readOnly: true
                 serializedName: id
                 language: !<!Languages> 
@@ -3985,103 +3903,34 @@ schemas: !<!Schemas>
                     description: The certificate id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_75
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_198
-                      serializedName: exportable
-                      language: !<!Languages> 
-                        default:
-                          name: exportable
-                          description: Indicates if the private key can be exported.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_8
-                      serializedName: kty
-                      language: !<!Languages> 
-                        default:
-                          name: keyType
-                          description: The type of key pair to be used for the certificate.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_59
-                      serializedName: key_size
-                      language: !<!Languages> 
-                        default:
-                          name: key_size
-                          description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_199
-                      serializedName: reuse_key
-                      language: !<!Languages> 
-                        default:
-                          name: reuse_key
-                          description: Indicates if the same key pair will be used on certificate renewal.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_10
-                      serializedName: crv
-                      language: !<!Languages> 
-                        default:
-                          name: curve
-                          description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: KeyProperties
-                      description: Properties of the key pair backing a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: key_props
+                schema: *ref_58
+                readOnly: true
+                serializedName: kid
                 language: !<!Languages> 
                   default:
-                    name: KeyProperties
-                    description: Properties of the key backing a certificate.
+                    name: kid
+                    description: The key id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_76
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_60
-                      serializedName: contentType
-                      language: !<!Languages> 
-                        default:
-                          name: contentType
-                          description: The media type (MIME type).
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: SecretProperties
-                      description: Properties of the key backing a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: secret_props
+                schema: *ref_59
+                readOnly: true
+                serializedName: sid
                 language: !<!Languages> 
                   default:
-                    name: SecretProperties
-                    description: Properties of the secret backing a certificate.
+                    name: sid
+                    description: The secret id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_77
+                schema: *ref_60
+                readOnly: true
+                serializedName: x5t
+                language: !<!Languages> 
+                  default:
+                    name: X509Thumbprint
+                    description: Thumbprint of the certificate.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: !<!ObjectSchema> &ref_74
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
@@ -4089,90 +3938,59 @@ schemas: !<!Schemas>
                   properties:
                     - !<!Property> 
                       schema: *ref_61
-                      serializedName: subject
+                      readOnly: true
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: subject
-                          description: The subject name. Should be a valid X509 distinguished Name.
+                          name: id
+                          description: The certificate id.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: !<!ArraySchema> &ref_178
-                        type: array
-                        apiVersions:
-                          - !<!ApiVersion> 
-                            version: 7.0-preview
-                        elementType: *ref_62
-                        language: !<!Languages> 
-                          default:
-                            name: X509CertificateProperties-ekus
-                            description: The enhanced key usage.
-                        protocol: !<!Protocols> {}
-                      serializedName: ekus
-                      language: !<!Languages> 
-                        default:
-                          name: ekus
-                          description: The enhanced key usage.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_78
+                      schema: !<!ObjectSchema> &ref_75
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 7.0-preview
                         properties:
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_179
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_63
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-emails
-                                  description: Email addresses.
-                              protocol: !<!Protocols> {}
-                            serializedName: emails
+                            schema: *ref_198
+                            serializedName: exportable
                             language: !<!Languages> 
                               default:
-                                name: emails
-                                description: Email addresses.
+                                name: exportable
+                                description: Indicates if the private key can be exported.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_180
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_64
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-dns_names
-                                  description: Domain names.
-                              protocol: !<!Protocols> {}
-                            serializedName: dns_names
+                            schema: *ref_8
+                            serializedName: kty
                             language: !<!Languages> 
                               default:
-                                name: dns_names
-                                description: Domain names.
+                                name: keyType
+                                description: The type of key pair to be used for the certificate.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_181
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_65
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNames-upns
-                                  description: User principal names.
-                              protocol: !<!Protocols> {}
-                            serializedName: upns
+                            schema: *ref_62
+                            serializedName: key_size
                             language: !<!Languages> 
                               default:
-                                name: upns
-                                description: User principal names.
+                                name: key_size
+                                description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_199
+                            serializedName: reuse_key
+                            language: !<!Languages> 
+                              default:
+                                name: reuse_key
+                                description: Indicates if the same key pair will be used on certificate renewal.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_10
+                            serializedName: crv
+                            language: !<!Languages> 
+                              default:
+                                name: curve
+                                description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -4181,93 +3999,285 @@ schemas: !<!Schemas>
                           - input
                         language: !<!Languages> 
                           default:
-                            name: SubjectAlternativeNames
-                            description: The subject alternate names of a X509 object.
+                            name: KeyProperties
+                            description: Properties of the key pair backing a certificate.
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: sans
+                      serializedName: key_props
                       language: !<!Languages> 
                         default:
-                          name: SubjectAlternativeNames
-                          description: The subject alternative names.
+                          name: KeyProperties
+                          description: Properties of the key backing a certificate.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: !<!ArraySchema> &ref_182
+                      schema: !<!ObjectSchema> &ref_76
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_63
+                            serializedName: contentType
+                            language: !<!Languages> 
+                              default:
+                                name: contentType
+                                description: The media type (MIME type).
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: SecretProperties
+                            description: Properties of the key backing a certificate.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      serializedName: secret_props
+                      language: !<!Languages> 
+                        default:
+                          name: SecretProperties
+                          description: Properties of the secret backing a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_77
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_64
+                            serializedName: subject
+                            language: !<!Languages> 
+                              default:
+                                name: subject
+                                description: The subject name. Should be a valid X509 distinguished Name.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ArraySchema> &ref_178
+                              type: array
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              elementType: *ref_65
+                              language: !<!Languages> 
+                                default:
+                                  name: X509CertificateProperties-ekus
+                                  description: The enhanced key usage.
+                              protocol: !<!Protocols> {}
+                            serializedName: ekus
+                            language: !<!Languages> 
+                              default:
+                                name: ekus
+                                description: The enhanced key usage.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ObjectSchema> &ref_78
+                              type: object
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              properties:
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_179
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_66
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-emails
+                                        description: Email addresses.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: emails
+                                  language: !<!Languages> 
+                                    default:
+                                      name: emails
+                                      description: Email addresses.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_180
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_67
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-dns_names
+                                        description: Domain names.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: dns_names
+                                  language: !<!Languages> 
+                                    default:
+                                      name: dns_names
+                                      description: Domain names.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_181
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_68
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNames-upns
+                                        description: User principal names.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: upns
+                                  language: !<!Languages> 
+                                    default:
+                                      name: upns
+                                      description: User principal names.
+                                  protocol: !<!Protocols> {}
+                              serializationFormats:
+                                - json
+                              usage:
+                                - output
+                                - input
+                              language: !<!Languages> 
+                                default:
+                                  name: SubjectAlternativeNames
+                                  description: The subject alternate names of a X509 object.
+                                  namespace: ''
+                              protocol: !<!Protocols> {}
+                            serializedName: sans
+                            language: !<!Languages> 
+                              default:
+                                name: SubjectAlternativeNames
+                                description: The subject alternative names.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ArraySchema> &ref_182
+                              type: array
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              elementType: *ref_166
+                              language: !<!Languages> 
+                                default:
+                                  name: X509CertificateProperties-key_usage
+                                  description: List of key usages.
+                              protocol: !<!Protocols> {}
+                            serializedName: key_usage
+                            language: !<!Languages> 
+                              default:
+                                name: key_usage
+                                description: List of key usages.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_167
+                            serializedName: validity_months
+                            language: !<!Languages> 
+                              default:
+                                name: ValidityInMonths
+                                description: The duration that the certificate is valid in months.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: X509CertificateProperties
+                            description: Properties of the X509 component of a certificate.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      serializedName: x509_props
+                      language: !<!Languages> 
+                        default:
+                          name: X509CertificateProperties
+                          description: Properties of the X509 component of a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ArraySchema> &ref_183
                         type: array
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 7.0-preview
-                        elementType: *ref_166
-                        language: !<!Languages> 
-                          default:
-                            name: X509CertificateProperties-key_usage
-                            description: List of key usages.
-                        protocol: !<!Protocols> {}
-                      serializedName: key_usage
-                      language: !<!Languages> 
-                        default:
-                          name: key_usage
-                          description: List of key usages.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_167
-                      serializedName: validity_months
-                      language: !<!Languages> 
-                        default:
-                          name: ValidityInMonths
-                          description: The duration that the certificate is valid in months.
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: X509CertificateProperties
-                      description: Properties of the X509 component of a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: x509_props
-                language: !<!Languages> 
-                  default:
-                    name: X509CertificateProperties
-                    description: Properties of the X509 component of a certificate.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ArraySchema> &ref_183
-                  type: array
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  elementType: !<!ObjectSchema> &ref_79
-                    type: object
-                    apiVersions:
-                      - !<!ApiVersion> 
-                        version: 7.0-preview
-                    properties:
-                      - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_80
+                        elementType: !<!ObjectSchema> &ref_79
                           type: object
                           apiVersions:
                             - !<!ApiVersion> 
                               version: 7.0-preview
                           properties:
                             - !<!Property> 
-                              schema: *ref_168
-                              serializedName: lifetime_percentage
+                              schema: !<!ObjectSchema> &ref_80
+                                type: object
+                                apiVersions:
+                                  - !<!ApiVersion> 
+                                    version: 7.0-preview
+                                properties:
+                                  - !<!Property> 
+                                    schema: *ref_168
+                                    serializedName: lifetime_percentage
+                                    language: !<!Languages> 
+                                      default:
+                                        name: lifetime_percentage
+                                        description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+                                    protocol: !<!Protocols> {}
+                                  - !<!Property> 
+                                    schema: *ref_169
+                                    serializedName: days_before_expiry
+                                    language: !<!Languages> 
+                                      default:
+                                        name: days_before_expiry
+                                        description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
+                                    protocol: !<!Protocols> {}
+                                serializationFormats:
+                                  - json
+                                usage:
+                                  - output
+                                  - input
+                                language: !<!Languages> 
+                                  default:
+                                    name: Trigger
+                                    description: A condition to be satisfied for an action to be executed.
+                                    namespace: ''
+                                protocol: !<!Protocols> {}
+                              serializedName: trigger
                               language: !<!Languages> 
                                 default:
-                                  name: lifetime_percentage
-                                  description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+                                  name: trigger
+                                  description: The condition that will execute the action.
                               protocol: !<!Protocols> {}
                             - !<!Property> 
-                              schema: *ref_169
-                              serializedName: days_before_expiry
+                              schema: !<!ObjectSchema> &ref_81
+                                type: object
+                                apiVersions:
+                                  - !<!ApiVersion> 
+                                    version: 7.0-preview
+                                properties:
+                                  - !<!Property> 
+                                    schema: *ref_255
+                                    serializedName: action_type
+                                    language: !<!Languages> 
+                                      default:
+                                        name: action_type
+                                        description: The type of the action.
+                                    protocol: !<!Protocols> {}
+                                serializationFormats:
+                                  - json
+                                usage:
+                                  - output
+                                  - input
+                                language: !<!Languages> 
+                                  default:
+                                    name: Action
+                                    description: The action that will be executed.
+                                    namespace: ''
+                                protocol: !<!Protocols> {}
+                              serializedName: action
                               language: !<!Languages> 
                                 default:
-                                  name: days_before_expiry
-                                  description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
+                                  name: action
+                                  description: The action that will be executed.
                               protocol: !<!Protocols> {}
                           serializationFormats:
                             - json
@@ -4276,100 +4286,76 @@ schemas: !<!Schemas>
                             - input
                           language: !<!Languages> 
                             default:
-                              name: Trigger
-                              description: A condition to be satisfied for an action to be executed.
+                              name: LifetimeAction
+                              description: Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
                               namespace: ''
                           protocol: !<!Protocols> {}
-                        serializedName: trigger
                         language: !<!Languages> 
                           default:
-                            name: trigger
-                            description: The condition that will execute the action.
+                            name: CertificatePolicy-lifetime_actions
+                            description: Actions that will be performed by Key Vault over the lifetime of a certificate.
                         protocol: !<!Protocols> {}
-                      - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_81
-                          type: object
-                          apiVersions:
-                            - !<!ApiVersion> 
-                              version: 7.0-preview
-                          properties:
-                            - !<!Property> 
-                              schema: *ref_255
-                              serializedName: action_type
-                              language: !<!Languages> 
-                                default:
-                                  name: action_type
-                                  description: The type of the action.
-                              protocol: !<!Protocols> {}
-                          serializationFormats:
-                            - json
-                          usage:
-                            - output
-                            - input
-                          language: !<!Languages> 
-                            default:
-                              name: Action
-                              description: The action that will be executed.
-                              namespace: ''
-                          protocol: !<!Protocols> {}
-                        serializedName: action
+                      serializedName: lifetime_actions
+                      language: !<!Languages> 
+                        default:
+                          name: lifetime_actions
+                          description: Actions that will be performed by Key Vault over the lifetime of a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_82
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_69
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_70
+                            serializedName: cty
+                            language: !<!Languages> 
+                              default:
+                                name: CertificateType
+                                description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_200
+                            serializedName: cert_transparency
+                            language: !<!Languages> 
+                              default:
+                                name: CertificateTransparency
+                                description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
                         language: !<!Languages> 
                           default:
-                            name: action
-                            description: The action that will be executed.
+                            name: IssuerParameters
+                            description: Parameters for the issuer of the X509 component of a certificate.
+                            namespace: ''
                         protocol: !<!Protocols> {}
-                    serializationFormats:
-                      - json
-                    usage:
-                      - output
-                      - input
-                    language: !<!Languages> 
-                      default:
-                        name: LifetimeAction
-                        description: Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
-                        namespace: ''
-                    protocol: !<!Protocols> {}
-                  language: !<!Languages> 
-                    default:
-                      name: CertificatePolicy-lifetime_actions
-                      description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-                  protocol: !<!Protocols> {}
-                serializedName: lifetime_actions
-                language: !<!Languages> 
-                  default:
-                    name: lifetime_actions
-                    description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_82
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_66
-                      serializedName: name
+                      serializedName: issuer
                       language: !<!Languages> 
                         default:
-                          name: name
-                          description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
+                          name: IssuerParameters
+                          description: Parameters for the issuer of the X509 component of a certificate.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_67
-                      serializedName: cty
+                      schema: *ref_5
+                      serializedName: attributes
                       language: !<!Languages> 
                         default:
-                          name: CertificateType
-                          description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_200
-                      serializedName: cert_transparency
-                      language: !<!Languages> 
-                        default:
-                          name: CertificateTransparency
-                          description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
+                          name: attributes
+                          description: The certificate attributes.
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
@@ -4378,15 +4364,32 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: IssuerParameters
-                      description: Parameters for the issuer of the X509 component of a certificate.
+                      name: CertificatePolicy
+                      description: Management policy for a certificate.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                serializedName: issuer
+                readOnly: true
+                serializedName: policy
                 language: !<!Languages> 
                   default:
-                    name: IssuerParameters
-                    description: Parameters for the issuer of the X509 component of a certificate.
+                    name: policy
+                    description: The management policy.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_248
+                serializedName: cer
+                language: !<!Languages> 
+                  default:
+                    name: cer
+                    description: CER contents of x509 certificate.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_71
+                serializedName: contentType
+                language: !<!Languages> 
+                  default:
+                    name: contentType
+                    description: The content type of the secret.
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_5
@@ -4396,55 +4399,52 @@ schemas: !<!Schemas>
                     name: attributes
                     description: The certificate attributes.
                 protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_214
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
+                protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - output
-              - input
             language: !<!Languages> 
               default:
-                name: CertificatePolicy
-                description: Management policy for a certificate.
+                name: CertificateBundle
+                description: A certificate bundle consists of a certificate (X509) plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
+        immediate:
+          - *ref_73
+      properties:
+        - !<!Property> 
+          schema: *ref_54
+          serializedName: recoveryId
+          language: !<!Languages> 
+            default:
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_55
           readOnly: true
-          serializedName: policy
+          serializedName: scheduledPurgeDate
           language: !<!Languages> 
             default:
-              name: policy
-              description: The management policy.
+              name: scheduledPurgeDate
+              description: 'The time when the certificate is scheduled to be purged, in UTC'
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_248
-          serializedName: cer
+          schema: *ref_56
+          readOnly: true
+          serializedName: deletedDate
           language: !<!Languages> 
             default:
-              name: cer
-              description: CER contents of x509 certificate.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_68
-          serializedName: contentType
-          language: !<!Languages> 
-            default:
-              name: contentType
-              description: The content type of the secret.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_5
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The certificate attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_214
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: deletedDate
+              description: 'The time when the certificate was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -4452,10 +4452,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: CertificateBundle
-          description: A certificate bundle consists of a certificate (X509) plus its attributes.
+          name: DeletedCertificateBundle
+          description: 'A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
+    - *ref_73
     - *ref_74
     - *ref_75
     - *ref_76
@@ -4465,7 +4466,6 @@ schemas: !<!Schemas>
     - *ref_80
     - *ref_81
     - *ref_82
-    - *ref_73
     - !<!ObjectSchema> &ref_372
       type: object
       apiVersions:
@@ -5394,7 +5394,7 @@ schemas: !<!Schemas>
                             description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_130
+                        schema: *ref_126
                         readOnly: true
                         serializedName: scheduledPurgeDate
                         language: !<!Languages> 
@@ -5403,7 +5403,7 @@ schemas: !<!Schemas>
                             description: 'The time when the storage account is scheduled to be purged, in UTC'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_131
+                        schema: *ref_127
                         readOnly: true
                         serializedName: deletedDate
                         language: !<!Languages> 
@@ -5607,44 +5607,81 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_133
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_132
               immediate:
                 - *ref_132
             properties:
               - !<!Property> 
-                schema: *ref_129
-                serializedName: recoveryId
+                schema: *ref_128
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+                    name: id
+                    description: The storage account id.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_129
+                readOnly: true
+                serializedName: resourceId
+                language: !<!Languages> 
+                  default:
+                    name: resourceId
+                    description: The storage account resource id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_130
                 readOnly: true
-                serializedName: scheduledPurgeDate
+                serializedName: activeKeyName
                 language: !<!Languages> 
                   default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the storage account is scheduled to be purged, in UTC'
+                    name: activeKeyName
+                    description: The current active storage account key name.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_136
+                readOnly: true
+                serializedName: autoRegenerateKey
+                language: !<!Languages> 
+                  default:
+                    name: autoRegenerateKey
+                    description: whether keyvault should manage the storage account for the user.
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_131
                 readOnly: true
-                serializedName: deletedDate
+                serializedName: regenerationPeriod
                 language: !<!Languages> 
                   default:
-                    name: deletedDate
-                    description: 'The time when the storage account was deleted, in UTC'
+                    name: regenerationPeriod
+                    description: The key regeneration time duration specified in ISO-8601 format.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_123
+                readOnly: true
+                serializedName: attributes
+                language: !<!Languages> 
+                  default:
+                    name: attributes
+                    description: The storage account attributes.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_220
+                readOnly: true
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -5652,8 +5689,8 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: DeletedStorageBundle
-                description: 'A deleted storage account bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
+                name: StorageBundle
+                description: A Storage account bundle consists of key vault storage account details plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
@@ -5661,66 +5698,29 @@ schemas: !<!Schemas>
       properties:
         - !<!Property> 
           schema: *ref_125
-          readOnly: true
-          serializedName: id
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: id
-              description: The storage account id.
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_126
           readOnly: true
-          serializedName: resourceId
+          serializedName: scheduledPurgeDate
           language: !<!Languages> 
             default:
-              name: resourceId
-              description: The storage account resource id.
+              name: scheduledPurgeDate
+              description: 'The time when the storage account is scheduled to be purged, in UTC'
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_127
           readOnly: true
-          serializedName: activeKeyName
+          serializedName: deletedDate
           language: !<!Languages> 
             default:
-              name: activeKeyName
-              description: The current active storage account key name.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_136
-          readOnly: true
-          serializedName: autoRegenerateKey
-          language: !<!Languages> 
-            default:
-              name: autoRegenerateKey
-              description: whether keyvault should manage the storage account for the user.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_128
-          readOnly: true
-          serializedName: regenerationPeriod
-          language: !<!Languages> 
-            default:
-              name: regenerationPeriod
-              description: The key regeneration time duration specified in ISO-8601 format.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_123
-          readOnly: true
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The storage account attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_220
-          readOnly: true
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: deletedDate
+              description: 'The time when the storage account was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -5728,8 +5728,8 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: StorageBundle
-          description: A Storage account bundle consists of key vault storage account details plus its attributes.
+          name: DeletedStorageBundle
+          description: 'A deleted storage account bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_133
@@ -5973,7 +5973,7 @@ schemas: !<!Schemas>
                             description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_155
+                        schema: *ref_151
                         readOnly: true
                         serializedName: scheduledPurgeDate
                         language: !<!Languages> 
@@ -5982,7 +5982,7 @@ schemas: !<!Schemas>
                             description: 'The time when the SAS definition is scheduled to be purged, in UTC'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_156
+                        schema: *ref_152
                         readOnly: true
                         serializedName: deletedDate
                         language: !<!Languages> 
@@ -6186,44 +6186,81 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_158
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_157
               immediate:
                 - *ref_157
             properties:
               - !<!Property> 
-                schema: *ref_154
-                serializedName: recoveryId
+                schema: *ref_153
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+                    name: id
+                    description: The SAS definition id.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_154
+                readOnly: true
+                serializedName: sid
+                language: !<!Languages> 
+                  default:
+                    name: SecretId
+                    description: Storage account SAS definition secret id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_155
                 readOnly: true
-                serializedName: scheduledPurgeDate
+                serializedName: templateUri
                 language: !<!Languages> 
                   default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the SAS definition is scheduled to be purged, in UTC'
+                    name: templateUri
+                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_160
+                readOnly: true
+                serializedName: sasType
+                language: !<!Languages> 
+                  default:
+                    name: sasType
+                    description: The type of SAS token the SAS definition will create.
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_156
                 readOnly: true
-                serializedName: deletedDate
+                serializedName: validityPeriod
                 language: !<!Languages> 
                   default:
-                    name: deletedDate
-                    description: 'The time when the SAS definition was deleted, in UTC'
+                    name: validityPeriod
+                    description: The validity period of SAS tokens created according to the SAS definition.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_148
+                readOnly: true
+                serializedName: attributes
+                language: !<!Languages> 
+                  default:
+                    name: attributes
+                    description: The SAS definition attributes.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_224
+                readOnly: true
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -6231,8 +6268,8 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: DeletedSasDefinitionBundle
-                description: 'A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
+                name: SasDefinitionBundle
+                description: A SAS definition bundle consists of key vault SAS definition details plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
@@ -6240,66 +6277,29 @@ schemas: !<!Schemas>
       properties:
         - !<!Property> 
           schema: *ref_150
-          readOnly: true
-          serializedName: id
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: id
-              description: The SAS definition id.
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_151
           readOnly: true
-          serializedName: sid
+          serializedName: scheduledPurgeDate
           language: !<!Languages> 
             default:
-              name: SecretId
-              description: Storage account SAS definition secret id.
+              name: scheduledPurgeDate
+              description: 'The time when the SAS definition is scheduled to be purged, in UTC'
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_152
           readOnly: true
-          serializedName: templateUri
+          serializedName: deletedDate
           language: !<!Languages> 
             default:
-              name: templateUri
-              description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_160
-          readOnly: true
-          serializedName: sasType
-          language: !<!Languages> 
-            default:
-              name: sasType
-              description: The type of SAS token the SAS definition will create.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_153
-          readOnly: true
-          serializedName: validityPeriod
-          language: !<!Languages> 
-            default:
-              name: validityPeriod
-              description: The validity period of SAS tokens created according to the SAS definition.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_148
-          readOnly: true
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The SAS definition attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_224
-          readOnly: true
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: deletedDate
+              description: 'The time when the SAS definition was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -6307,8 +6307,8 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: SasDefinitionBundle
-          description: A SAS definition bundle consists of key vault SAS definition details plus its attributes.
+          name: DeletedSasDefinitionBundle
+          description: 'A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_158
@@ -10378,7 +10378,7 @@ operationGroups:
           - *ref_370
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_73
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -11553,7 +11553,7 @@ operationGroups:
           - *ref_398
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_72
+            schema: *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -12138,7 +12138,7 @@ operationGroups:
           - *ref_411
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_72
+            schema: *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -12266,7 +12266,7 @@ operationGroups:
           - *ref_416
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_72
+            schema: *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -12717,7 +12717,7 @@ operationGroups:
           - *ref_426
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_72
+            schema: *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -12954,7 +12954,7 @@ operationGroups:
           - *ref_432
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_72
+            schema: *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -13218,7 +13218,7 @@ operationGroups:
           - *ref_440
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_73
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -13448,7 +13448,7 @@ operationGroups:
           - *ref_444
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_72
+            schema: *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -13826,7 +13826,7 @@ operationGroups:
           - *ref_453
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_133
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -14030,7 +14030,7 @@ operationGroups:
           - *ref_457
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -14242,7 +14242,7 @@ operationGroups:
           - *ref_461
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -14353,7 +14353,7 @@ operationGroups:
           - *ref_465
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_133
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -14463,7 +14463,7 @@ operationGroups:
           - *ref_467
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -14590,7 +14590,7 @@ operationGroups:
           - *ref_469
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -14727,7 +14727,7 @@ operationGroups:
           - *ref_473
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -14857,7 +14857,7 @@ operationGroups:
           - *ref_477
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -15238,7 +15238,7 @@ operationGroups:
           - *ref_490
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_158
+            schema: *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -15360,7 +15360,7 @@ operationGroups:
           - *ref_493
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_157
+            schema: *ref_158
             language: !<!Languages> 
               default:
                 name: ''
@@ -15479,7 +15479,7 @@ operationGroups:
           - *ref_496
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_158
+            schema: *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -15600,7 +15600,7 @@ operationGroups:
           - *ref_499
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_157
+            schema: *ref_158
             language: !<!Languages> 
               default:
                 name: ''
@@ -15738,7 +15738,7 @@ operationGroups:
           - *ref_502
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_157
+            schema: *ref_158
             language: !<!Languages> 
               default:
                 name: ''
@@ -15882,7 +15882,7 @@ operationGroups:
           - *ref_507
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_157
+            schema: *ref_158
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -56,21 +56,21 @@ schemas: !<!Schemas>
           name: Boolean
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_106
+    - !<!BooleanSchema> &ref_104
       type: boolean
       language: !<!Languages> 
         default:
           name: Boolean
           description: Indicates if the private key can be exported.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_107
+    - !<!BooleanSchema> &ref_105
       type: boolean
       language: !<!Languages> 
         default:
           name: Boolean
           description: Indicates if the same key pair will be used on certificate renewal.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_121
+    - !<!BooleanSchema> &ref_119
       type: boolean
       language: !<!Languages> 
         default:
@@ -98,7 +98,7 @@ schemas: !<!Schemas>
           name: Boolean
           description: the enabled state of the object.
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_193
+    - !<!BooleanSchema> &ref_191
       type: boolean
       language: !<!Languages> 
         default:
@@ -127,7 +127,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_115
+    - !<!NumberSchema> &ref_113
       type: integer
       minimum: 0
       precision: 32
@@ -136,7 +136,7 @@ schemas: !<!Schemas>
           name: ValidityInMonths
           description: The duration that the certificate is valid in months.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_116
+    - !<!NumberSchema> &ref_114
       type: integer
       maximum: 99
       minimum: 1
@@ -146,7 +146,7 @@ schemas: !<!Schemas>
           name: Integer
           description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_117
+    - !<!NumberSchema> &ref_115
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -433,7 +433,17 @@ schemas: !<!Schemas>
           name: CertificateListResultNextLink
           description: The URL to get the next set of certificates.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_102
+    - !<!StringSchema> &ref_124
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedCertificateBundleRecoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -443,7 +453,7 @@ schemas: !<!Schemas>
           name: CertificateBundleId
           description: The certificate id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_103
+    - !<!StringSchema> &ref_101
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -453,7 +463,7 @@ schemas: !<!Schemas>
           name: CertificateBundleKid
           description: The key id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_104
+    - !<!StringSchema> &ref_102
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +473,7 @@ schemas: !<!Schemas>
           name: CertificateBundleSid
           description: The secret id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_105
+    - !<!StringSchema> &ref_103
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -473,7 +483,7 @@ schemas: !<!Schemas>
           name: CertificatePolicyId
           description: The certificate id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_108
+    - !<!StringSchema> &ref_106
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -483,7 +493,7 @@ schemas: !<!Schemas>
           name: SecretPropertiesContentType
           description: The media type (MIME type).
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_109
+    - !<!StringSchema> &ref_107
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -493,7 +503,7 @@ schemas: !<!Schemas>
           name: X509CertificatePropertiesSubject
           description: The subject name. Should be a valid X509 distinguished Name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_110
+    - !<!StringSchema> &ref_108
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -503,7 +513,7 @@ schemas: !<!Schemas>
           name: X509CertificatePropertiesEkusItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_111
+    - !<!StringSchema> &ref_109
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -513,7 +523,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNamesEmailsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_112
+    - !<!StringSchema> &ref_110
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -523,7 +533,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNamesDnsNamesItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_113
+    - !<!StringSchema> &ref_111
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -533,7 +543,7 @@ schemas: !<!Schemas>
           name: SubjectAlternativeNamesUpnsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_119
+    - !<!StringSchema> &ref_117
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -543,7 +553,7 @@ schemas: !<!Schemas>
           name: IssuerParametersName
           description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_120
+    - !<!StringSchema> &ref_118
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -553,7 +563,7 @@ schemas: !<!Schemas>
           name: CertificateType
           description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_123
+    - !<!StringSchema> &ref_121
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -562,16 +572,6 @@ schemas: !<!Schemas>
         default:
           name: CertificateBundleContentType
           description: The content type of the secret.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_100
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedCertificateBundleRecoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_134
       type: string
@@ -894,7 +894,17 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_190
+    - !<!StringSchema> &ref_195
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedStorageBundleRecoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_188
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -904,7 +914,7 @@ schemas: !<!Schemas>
           name: StorageBundleId
           description: The storage account id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_191
+    - !<!StringSchema> &ref_189
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -914,7 +924,7 @@ schemas: !<!Schemas>
           name: StorageBundleResourceId
           description: The storage account resource id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_192
+    - !<!StringSchema> &ref_190
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -924,7 +934,7 @@ schemas: !<!Schemas>
           name: StorageBundleActiveKeyName
           description: The current active storage account key name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_194
+    - !<!StringSchema> &ref_192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -933,16 +943,6 @@ schemas: !<!Schemas>
         default:
           name: StorageBundleRegenerationPeriod
           description: The key regeneration time duration specified in ISO-8601 format.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_188
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedStorageBundleRecoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_198
       type: string
@@ -1054,7 +1054,17 @@ schemas: !<!Schemas>
           name: DeletedSasDefinitionListResultNextLink
           description: The URL to get the next set of deleted SAS definitions.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_220
+    - !<!StringSchema> &ref_225
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 7.0-preview
+      language: !<!Languages> 
+        default:
+          name: DeletedSasDefinitionBundleRecoveryId
+          description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_218
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1064,7 +1074,7 @@ schemas: !<!Schemas>
           name: SasDefinitionBundleId
           description: The SAS definition id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_221
+    - !<!StringSchema> &ref_219
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1074,7 +1084,7 @@ schemas: !<!Schemas>
           name: SecretId
           description: Storage account SAS definition secret id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_220
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1084,7 +1094,7 @@ schemas: !<!Schemas>
           name: SasDefinitionBundleTemplateUri
           description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_224
+    - !<!StringSchema> &ref_222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1093,16 +1103,6 @@ schemas: !<!Schemas>
         default:
           name: SasDefinitionBundleValidityPeriod
           description: The validity period of SAS tokens created according to the SAS definition.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_218
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 7.0-preview
-      language: !<!Languages> 
-        default:
-          name: DeletedSasDefinitionBundleRecoveryId
-          description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_226
       type: string
@@ -1427,7 +1427,7 @@ schemas: !<!Schemas>
           name: JsonWebKeySignatureAlgorithm
           description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_114
+    - !<!ChoiceSchema> &ref_112
       choices:
         - !<!ChoiceValue> 
           value: digitalSignature
@@ -1493,7 +1493,7 @@ schemas: !<!Schemas>
           name: KeyUsageType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_223
+    - !<!ChoiceSchema> &ref_221
       choices:
         - !<!ChoiceValue> 
           value: account
@@ -1518,7 +1518,7 @@ schemas: !<!Schemas>
           description: The type of SAS token the SAS definition will create.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_118
+    - !<!SealedChoiceSchema> &ref_116
       choices:
         - !<!ChoiceValue> 
           value: EmailContacts
@@ -1644,7 +1644,7 @@ schemas: !<!Schemas>
           name: CertificateItemTags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_124
+    - !<!DictionarySchema> &ref_122
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -1698,7 +1698,7 @@ schemas: !<!Schemas>
           name: StorageAccountItemTags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_195
+    - !<!DictionarySchema> &ref_193
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -1734,7 +1734,7 @@ schemas: !<!Schemas>
           name: SasDefinitionItemTags
           description: Application specific metadata in the form of key-value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_225
+    - !<!DictionarySchema> &ref_223
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -2004,7 +2004,7 @@ schemas: !<!Schemas>
           name: X509Thumbprint
           description: Thumbprint of the certificate.
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_122
+    - !<!ByteArraySchema> &ref_120
       type: byte-array
       format: byte
       apiVersions:
@@ -2427,8 +2427,8 @@ schemas: !<!Schemas>
           description: The key create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
     - *ref_5
+    - *ref_6
     - !<!ObjectSchema> &ref_17
       type: object
       apiVersions:
@@ -3880,14 +3880,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_101
+          - !<!ObjectSchema> &ref_123
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_99
               immediate:
@@ -3895,88 +3895,6 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_100
-                serializedName: recoveryId
-                language: !<!Languages> 
-                  default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_92
-                readOnly: true
-                serializedName: scheduledPurgeDate
-                language: !<!Languages> 
-                  default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the certificate is scheduled to be purged, in UTC'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_93
-                readOnly: true
-                serializedName: deletedDate
-                language: !<!Languages> 
-                  default:
-                    name: deletedDate
-                    description: 'The time when the certificate was deleted, in UTC'
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-            language: !<!Languages> 
-              default:
-                name: DeletedCertificateBundle
-                description: 'A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
-                namespace: ''
-            protocol: !<!Protocols> {}
-        immediate:
-          - *ref_101
-      properties:
-        - !<!Property> 
-          schema: *ref_102
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The certificate id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_103
-          readOnly: true
-          serializedName: kid
-          language: !<!Languages> 
-            default:
-              name: kid
-              description: The key id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_104
-          readOnly: true
-          serializedName: sid
-          language: !<!Languages> 
-            default:
-              name: sid
-              description: The secret id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_97
-          readOnly: true
-          serializedName: x5t
-          language: !<!Languages> 
-            default:
-              name: x509Thumbprint
-              description: Thumbprint of the certificate.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: !<!ObjectSchema> &ref_125
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 7.0-preview
-            properties:
-              - !<!Property> 
-                schema: *ref_105
                 readOnly: true
                 serializedName: id
                 language: !<!Languages> 
@@ -3985,194 +3903,94 @@ schemas: !<!Schemas>
                     description: The certificate id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_126
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_106
-                      serializedName: exportable
-                      language: !<!Languages> 
-                        default:
-                          name: exportable
-                          description: Indicates if the private key can be exported.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_2
-                      serializedName: kty
-                      language: !<!Languages> 
-                        default:
-                          name: keyType
-                          description: The type of key pair to be used for the certificate.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_3
-                      serializedName: key_size
-                      language: !<!Languages> 
-                        default:
-                          name: keySize
-                          description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_107
-                      serializedName: reuse_key
-                      language: !<!Languages> 
-                        default:
-                          name: reuseKey
-                          description: Indicates if the same key pair will be used on certificate renewal.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_16
-                      serializedName: crv
-                      language: !<!Languages> 
-                        default:
-                          name: curve
-                          description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: KeyProperties
-                      description: Properties of the key pair backing a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: key_props
+                schema: *ref_101
+                readOnly: true
+                serializedName: kid
                 language: !<!Languages> 
                   default:
-                    name: keyProperties
-                    description: Properties of the key backing a certificate.
+                    name: kid
+                    description: The key id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_127
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_108
-                      serializedName: contentType
-                      language: !<!Languages> 
-                        default:
-                          name: contentType
-                          description: The media type (MIME type).
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: SecretProperties
-                      description: Properties of the key backing a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: secret_props
+                schema: *ref_102
+                readOnly: true
+                serializedName: sid
                 language: !<!Languages> 
                   default:
-                    name: secretProperties
-                    description: Properties of the secret backing a certificate.
+                    name: sid
+                    description: The secret id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_128
+                schema: *ref_97
+                readOnly: true
+                serializedName: x5t
+                language: !<!Languages> 
+                  default:
+                    name: x509Thumbprint
+                    description: Thumbprint of the certificate.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: !<!ObjectSchema> &ref_125
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 7.0-preview
                   properties:
                     - !<!Property> 
-                      schema: *ref_109
-                      serializedName: subject
+                      schema: *ref_103
+                      readOnly: true
+                      serializedName: id
                       language: !<!Languages> 
                         default:
-                          name: subject
-                          description: The subject name. Should be a valid X509 distinguished Name.
+                          name: id
+                          description: The certificate id.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: !<!ArraySchema> &ref_241
-                        type: array
-                        apiVersions:
-                          - !<!ApiVersion> 
-                            version: 7.0-preview
-                        elementType: *ref_110
-                        language: !<!Languages> 
-                          default:
-                            name: X509CertificatePropertiesEkus
-                            description: The enhanced key usage.
-                        protocol: !<!Protocols> {}
-                      serializedName: ekus
-                      language: !<!Languages> 
-                        default:
-                          name: ekus
-                          description: The enhanced key usage.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_129
+                      schema: !<!ObjectSchema> &ref_126
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 7.0-preview
                         properties:
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_242
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_111
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNamesEmails
-                                  description: Email addresses.
-                              protocol: !<!Protocols> {}
-                            serializedName: emails
+                            schema: *ref_104
+                            serializedName: exportable
                             language: !<!Languages> 
                               default:
-                                name: emails
-                                description: Email addresses.
+                                name: exportable
+                                description: Indicates if the private key can be exported.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_243
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_112
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNamesDnsNames
-                                  description: Domain names.
-                              protocol: !<!Protocols> {}
-                            serializedName: dns_names
+                            schema: *ref_2
+                            serializedName: kty
                             language: !<!Languages> 
                               default:
-                                name: dnsNames
-                                description: Domain names.
+                                name: keyType
+                                description: The type of key pair to be used for the certificate.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: !<!ArraySchema> &ref_244
-                              type: array
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 7.0-preview
-                              elementType: *ref_113
-                              language: !<!Languages> 
-                                default:
-                                  name: SubjectAlternativeNamesUpns
-                                  description: User principal names.
-                              protocol: !<!Protocols> {}
-                            serializedName: upns
+                            schema: *ref_3
+                            serializedName: key_size
                             language: !<!Languages> 
                               default:
-                                name: upns
-                                description: User principal names.
+                                name: keySize
+                                description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_105
+                            serializedName: reuse_key
+                            language: !<!Languages> 
+                              default:
+                                name: reuseKey
+                                description: Indicates if the same key pair will be used on certificate renewal.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_16
+                            serializedName: crv
+                            language: !<!Languages> 
+                              default:
+                                name: curve
+                                description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -4181,93 +3999,285 @@ schemas: !<!Schemas>
                           - input
                         language: !<!Languages> 
                           default:
-                            name: SubjectAlternativeNames
-                            description: The subject alternate names of a X509 object.
+                            name: KeyProperties
+                            description: Properties of the key pair backing a certificate.
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: sans
+                      serializedName: key_props
                       language: !<!Languages> 
                         default:
-                          name: subjectAlternativeNames
-                          description: The subject alternative names.
+                          name: keyProperties
+                          description: Properties of the key backing a certificate.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: !<!ArraySchema> &ref_245
+                      schema: !<!ObjectSchema> &ref_127
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_106
+                            serializedName: contentType
+                            language: !<!Languages> 
+                              default:
+                                name: contentType
+                                description: The media type (MIME type).
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: SecretProperties
+                            description: Properties of the key backing a certificate.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      serializedName: secret_props
+                      language: !<!Languages> 
+                        default:
+                          name: secretProperties
+                          description: Properties of the secret backing a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_128
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_107
+                            serializedName: subject
+                            language: !<!Languages> 
+                              default:
+                                name: subject
+                                description: The subject name. Should be a valid X509 distinguished Name.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ArraySchema> &ref_241
+                              type: array
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              elementType: *ref_108
+                              language: !<!Languages> 
+                                default:
+                                  name: X509CertificatePropertiesEkus
+                                  description: The enhanced key usage.
+                              protocol: !<!Protocols> {}
+                            serializedName: ekus
+                            language: !<!Languages> 
+                              default:
+                                name: ekus
+                                description: The enhanced key usage.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ObjectSchema> &ref_129
+                              type: object
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              properties:
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_242
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_109
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNamesEmails
+                                        description: Email addresses.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: emails
+                                  language: !<!Languages> 
+                                    default:
+                                      name: emails
+                                      description: Email addresses.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_243
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_110
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNamesDnsNames
+                                        description: Domain names.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: dns_names
+                                  language: !<!Languages> 
+                                    default:
+                                      name: dnsNames
+                                      description: Domain names.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ArraySchema> &ref_244
+                                    type: array
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 7.0-preview
+                                    elementType: *ref_111
+                                    language: !<!Languages> 
+                                      default:
+                                        name: SubjectAlternativeNamesUpns
+                                        description: User principal names.
+                                    protocol: !<!Protocols> {}
+                                  serializedName: upns
+                                  language: !<!Languages> 
+                                    default:
+                                      name: upns
+                                      description: User principal names.
+                                  protocol: !<!Protocols> {}
+                              serializationFormats:
+                                - json
+                              usage:
+                                - output
+                                - input
+                              language: !<!Languages> 
+                                default:
+                                  name: SubjectAlternativeNames
+                                  description: The subject alternate names of a X509 object.
+                                  namespace: ''
+                              protocol: !<!Protocols> {}
+                            serializedName: sans
+                            language: !<!Languages> 
+                              default:
+                                name: subjectAlternativeNames
+                                description: The subject alternative names.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ArraySchema> &ref_245
+                              type: array
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 7.0-preview
+                              elementType: *ref_112
+                              language: !<!Languages> 
+                                default:
+                                  name: X509CertificatePropertiesKeyUsage
+                                  description: List of key usages.
+                              protocol: !<!Protocols> {}
+                            serializedName: key_usage
+                            language: !<!Languages> 
+                              default:
+                                name: keyUsage
+                                description: List of key usages.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_113
+                            serializedName: validity_months
+                            language: !<!Languages> 
+                              default:
+                                name: validityInMonths
+                                description: The duration that the certificate is valid in months.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
+                        language: !<!Languages> 
+                          default:
+                            name: X509CertificateProperties
+                            description: Properties of the X509 component of a certificate.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      serializedName: x509_props
+                      language: !<!Languages> 
+                        default:
+                          name: x509CertificateProperties
+                          description: Properties of the X509 component of a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ArraySchema> &ref_246
                         type: array
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 7.0-preview
-                        elementType: *ref_114
-                        language: !<!Languages> 
-                          default:
-                            name: X509CertificatePropertiesKeyUsage
-                            description: List of key usages.
-                        protocol: !<!Protocols> {}
-                      serializedName: key_usage
-                      language: !<!Languages> 
-                        default:
-                          name: keyUsage
-                          description: List of key usages.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_115
-                      serializedName: validity_months
-                      language: !<!Languages> 
-                        default:
-                          name: validityInMonths
-                          description: The duration that the certificate is valid in months.
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - output
-                    - input
-                  language: !<!Languages> 
-                    default:
-                      name: X509CertificateProperties
-                      description: Properties of the X509 component of a certificate.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: x509_props
-                language: !<!Languages> 
-                  default:
-                    name: x509CertificateProperties
-                    description: Properties of the X509 component of a certificate.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ArraySchema> &ref_246
-                  type: array
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  elementType: !<!ObjectSchema> &ref_130
-                    type: object
-                    apiVersions:
-                      - !<!ApiVersion> 
-                        version: 7.0-preview
-                    properties:
-                      - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_131
+                        elementType: !<!ObjectSchema> &ref_130
                           type: object
                           apiVersions:
                             - !<!ApiVersion> 
                               version: 7.0-preview
                           properties:
                             - !<!Property> 
-                              schema: *ref_116
-                              serializedName: lifetime_percentage
+                              schema: !<!ObjectSchema> &ref_131
+                                type: object
+                                apiVersions:
+                                  - !<!ApiVersion> 
+                                    version: 7.0-preview
+                                properties:
+                                  - !<!Property> 
+                                    schema: *ref_114
+                                    serializedName: lifetime_percentage
+                                    language: !<!Languages> 
+                                      default:
+                                        name: lifetimePercentage
+                                        description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+                                    protocol: !<!Protocols> {}
+                                  - !<!Property> 
+                                    schema: *ref_115
+                                    serializedName: days_before_expiry
+                                    language: !<!Languages> 
+                                      default:
+                                        name: daysBeforeExpiry
+                                        description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
+                                    protocol: !<!Protocols> {}
+                                serializationFormats:
+                                  - json
+                                usage:
+                                  - output
+                                  - input
+                                language: !<!Languages> 
+                                  default:
+                                    name: Trigger
+                                    description: A condition to be satisfied for an action to be executed.
+                                    namespace: ''
+                                protocol: !<!Protocols> {}
+                              serializedName: trigger
                               language: !<!Languages> 
                                 default:
-                                  name: lifetimePercentage
-                                  description: Percentage of lifetime at which to trigger. Value should be between 1 and 99.
+                                  name: trigger
+                                  description: The condition that will execute the action.
                               protocol: !<!Protocols> {}
                             - !<!Property> 
-                              schema: *ref_117
-                              serializedName: days_before_expiry
+                              schema: !<!ObjectSchema> &ref_132
+                                type: object
+                                apiVersions:
+                                  - !<!ApiVersion> 
+                                    version: 7.0-preview
+                                properties:
+                                  - !<!Property> 
+                                    schema: *ref_116
+                                    serializedName: action_type
+                                    language: !<!Languages> 
+                                      default:
+                                        name: actionType
+                                        description: The type of the action.
+                                    protocol: !<!Protocols> {}
+                                serializationFormats:
+                                  - json
+                                usage:
+                                  - output
+                                  - input
+                                language: !<!Languages> 
+                                  default:
+                                    name: Action
+                                    description: The action that will be executed.
+                                    namespace: ''
+                                protocol: !<!Protocols> {}
+                              serializedName: action
                               language: !<!Languages> 
                                 default:
-                                  name: daysBeforeExpiry
-                                  description: 'Days before expiry to attempt renewal. Value should be between 1 and validity_in_months multiplied by 27. If validity_in_months is 36, then value should be between 1 and 972 (36 * 27).'
+                                  name: action
+                                  description: The action that will be executed.
                               protocol: !<!Protocols> {}
                           serializationFormats:
                             - json
@@ -4276,100 +4286,76 @@ schemas: !<!Schemas>
                             - input
                           language: !<!Languages> 
                             default:
-                              name: Trigger
-                              description: A condition to be satisfied for an action to be executed.
+                              name: LifetimeAction
+                              description: Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
                               namespace: ''
                           protocol: !<!Protocols> {}
-                        serializedName: trigger
                         language: !<!Languages> 
                           default:
-                            name: trigger
-                            description: The condition that will execute the action.
+                            name: CertificatePolicyLifetimeActions
+                            description: Actions that will be performed by Key Vault over the lifetime of a certificate.
                         protocol: !<!Protocols> {}
-                      - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_132
-                          type: object
-                          apiVersions:
-                            - !<!ApiVersion> 
-                              version: 7.0-preview
-                          properties:
-                            - !<!Property> 
-                              schema: *ref_118
-                              serializedName: action_type
-                              language: !<!Languages> 
-                                default:
-                                  name: actionType
-                                  description: The type of the action.
-                              protocol: !<!Protocols> {}
-                          serializationFormats:
-                            - json
-                          usage:
-                            - output
-                            - input
-                          language: !<!Languages> 
-                            default:
-                              name: Action
-                              description: The action that will be executed.
-                              namespace: ''
-                          protocol: !<!Protocols> {}
-                        serializedName: action
+                      serializedName: lifetime_actions
+                      language: !<!Languages> 
+                        default:
+                          name: lifetimeActions
+                          description: Actions that will be performed by Key Vault over the lifetime of a certificate.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_133
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 7.0-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_117
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_118
+                            serializedName: cty
+                            language: !<!Languages> 
+                              default:
+                                name: certificateType
+                                description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_119
+                            serializedName: cert_transparency
+                            language: !<!Languages> 
+                              default:
+                                name: certificateTransparency
+                                description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - output
+                          - input
                         language: !<!Languages> 
                           default:
-                            name: action
-                            description: The action that will be executed.
+                            name: IssuerParameters
+                            description: Parameters for the issuer of the X509 component of a certificate.
+                            namespace: ''
                         protocol: !<!Protocols> {}
-                    serializationFormats:
-                      - json
-                    usage:
-                      - output
-                      - input
-                    language: !<!Languages> 
-                      default:
-                        name: LifetimeAction
-                        description: Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
-                        namespace: ''
-                    protocol: !<!Protocols> {}
-                  language: !<!Languages> 
-                    default:
-                      name: CertificatePolicyLifetimeActions
-                      description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-                  protocol: !<!Protocols> {}
-                serializedName: lifetime_actions
-                language: !<!Languages> 
-                  default:
-                    name: lifetimeActions
-                    description: Actions that will be performed by Key Vault over the lifetime of a certificate.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_133
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 7.0-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_119
-                      serializedName: name
+                      serializedName: issuer
                       language: !<!Languages> 
                         default:
-                          name: name
-                          description: 'Name of the referenced issuer object or reserved names; for example, ''Self'' or ''Unknown''.'
+                          name: issuerParameters
+                          description: Parameters for the issuer of the X509 component of a certificate.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_120
-                      serializedName: cty
+                      schema: *ref_9
+                      serializedName: attributes
                       language: !<!Languages> 
                         default:
-                          name: certificateType
-                          description: 'Certificate type as supported by the provider (optional); for example ''OV-SSL'', ''EV-SSL'''
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_121
-                      serializedName: cert_transparency
-                      language: !<!Languages> 
-                        default:
-                          name: certificateTransparency
-                          description: Indicates if the certificates generated under this policy should be published to certificate transparency logs.
+                          name: attributes
+                          description: The certificate attributes.
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
@@ -4378,15 +4364,32 @@ schemas: !<!Schemas>
                     - input
                   language: !<!Languages> 
                     default:
-                      name: IssuerParameters
-                      description: Parameters for the issuer of the X509 component of a certificate.
+                      name: CertificatePolicy
+                      description: Management policy for a certificate.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                serializedName: issuer
+                readOnly: true
+                serializedName: policy
                 language: !<!Languages> 
                   default:
-                    name: issuerParameters
-                    description: Parameters for the issuer of the X509 component of a certificate.
+                    name: policy
+                    description: The management policy.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_120
+                serializedName: cer
+                language: !<!Languages> 
+                  default:
+                    name: cer
+                    description: CER contents of x509 certificate.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_121
+                serializedName: contentType
+                language: !<!Languages> 
+                  default:
+                    name: contentType
+                    description: The content type of the secret.
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_9
@@ -4396,55 +4399,52 @@ schemas: !<!Schemas>
                     name: attributes
                     description: The certificate attributes.
                 protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_122
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
+                protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - output
-              - input
             language: !<!Languages> 
               default:
-                name: CertificatePolicy
-                description: Management policy for a certificate.
+                name: CertificateBundle
+                description: A certificate bundle consists of a certificate (X509) plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
-          readOnly: true
-          serializedName: policy
-          language: !<!Languages> 
-            default:
-              name: policy
-              description: The management policy.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_122
-          serializedName: cer
-          language: !<!Languages> 
-            default:
-              name: cer
-              description: CER contents of x509 certificate.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_123
-          serializedName: contentType
-          language: !<!Languages> 
-            default:
-              name: contentType
-              description: The content type of the secret.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_9
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The certificate attributes.
-          protocol: !<!Protocols> {}
+        immediate:
+          - *ref_123
+      properties:
         - !<!Property> 
           schema: *ref_124
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted certificate.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_92
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the certificate is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_93
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the certificate was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -4452,10 +4452,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: CertificateBundle
-          description: A certificate bundle consists of a certificate (X509) plus its attributes.
+          name: DeletedCertificateBundle
+          description: 'A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
+    - *ref_123
     - *ref_125
     - *ref_126
     - *ref_127
@@ -4465,7 +4466,6 @@ schemas: !<!Schemas>
     - *ref_131
     - *ref_132
     - *ref_133
-    - *ref_101
     - !<!ObjectSchema> &ref_435
       type: object
       apiVersions:
@@ -5607,14 +5607,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_189
+          - !<!ObjectSchema> &ref_194
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_187
               immediate:
@@ -5622,29 +5622,66 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_188
-                serializedName: recoveryId
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+                    name: id
+                    description: The storage account id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_177
+                schema: *ref_189
                 readOnly: true
-                serializedName: scheduledPurgeDate
+                serializedName: resourceId
                 language: !<!Languages> 
                   default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the storage account is scheduled to be purged, in UTC'
+                    name: resourceId
+                    description: The storage account resource id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_178
+                schema: *ref_190
                 readOnly: true
-                serializedName: deletedDate
+                serializedName: activeKeyName
                 language: !<!Languages> 
                   default:
-                    name: deletedDate
-                    description: 'The time when the storage account was deleted, in UTC'
+                    name: activeKeyName
+                    description: The current active storage account key name.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_191
+                readOnly: true
+                serializedName: autoRegenerateKey
+                language: !<!Languages> 
+                  default:
+                    name: autoRegenerateKey
+                    description: whether keyvault should manage the storage account for the user.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_192
+                readOnly: true
+                serializedName: regenerationPeriod
+                language: !<!Languages> 
+                  default:
+                    name: regenerationPeriod
+                    description: The key regeneration time duration specified in ISO-8601 format.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_185
+                readOnly: true
+                serializedName: attributes
+                language: !<!Languages> 
+                  default:
+                    name: attributes
+                    description: The storage account attributes.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_193
+                readOnly: true
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -5652,75 +5689,38 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: DeletedStorageBundle
-                description: 'A deleted storage account bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
+                name: StorageBundle
+                description: A Storage account bundle consists of key vault storage account details plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_189
+          - *ref_194
       properties:
         - !<!Property> 
-          schema: *ref_190
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The storage account id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_191
-          readOnly: true
-          serializedName: resourceId
-          language: !<!Languages> 
-            default:
-              name: resourceId
-              description: The storage account resource id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_192
-          readOnly: true
-          serializedName: activeKeyName
-          language: !<!Languages> 
-            default:
-              name: activeKeyName
-              description: The current active storage account key name.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_193
-          readOnly: true
-          serializedName: autoRegenerateKey
-          language: !<!Languages> 
-            default:
-              name: autoRegenerateKey
-              description: whether keyvault should manage the storage account for the user.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_194
-          readOnly: true
-          serializedName: regenerationPeriod
-          language: !<!Languages> 
-            default:
-              name: regenerationPeriod
-              description: The key regeneration time duration specified in ISO-8601 format.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_185
-          readOnly: true
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The storage account attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_195
-          readOnly: true
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted storage account.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_177
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the storage account is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_178
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the storage account was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -5728,11 +5728,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: StorageBundle
-          description: A Storage account bundle consists of key vault storage account details plus its attributes.
+          name: DeletedStorageBundle
+          description: 'A deleted storage account bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_189
+    - *ref_194
     - !<!ObjectSchema> &ref_574
       type: object
       apiVersions:
@@ -5808,7 +5808,7 @@ schemas: !<!Schemas>
               description: Current active storage account key name.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_588
-          schema: *ref_193
+          schema: *ref_191
           required: true
           serializedName: autoRegenerateKey
           language: !<!Languages> 
@@ -5868,7 +5868,7 @@ schemas: !<!Schemas>
               description: The current active storage account key name.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_603
-          schema: *ref_193
+          schema: *ref_191
           serializedName: autoRegenerateKey
           language: !<!Languages> 
             default:
@@ -6186,14 +6186,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_219
+          - !<!ObjectSchema> &ref_224
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 7.0-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_217
               immediate:
@@ -6201,29 +6201,66 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_218
-                serializedName: recoveryId
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: recoveryId
-                    description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+                    name: id
+                    description: The SAS definition id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_208
+                schema: *ref_219
                 readOnly: true
-                serializedName: scheduledPurgeDate
+                serializedName: sid
                 language: !<!Languages> 
                   default:
-                    name: scheduledPurgeDate
-                    description: 'The time when the SAS definition is scheduled to be purged, in UTC'
+                    name: secretId
+                    description: Storage account SAS definition secret id.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_209
+                schema: *ref_220
                 readOnly: true
-                serializedName: deletedDate
+                serializedName: templateUri
                 language: !<!Languages> 
                   default:
-                    name: deletedDate
-                    description: 'The time when the SAS definition was deleted, in UTC'
+                    name: templateUri
+                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_221
+                readOnly: true
+                serializedName: sasType
+                language: !<!Languages> 
+                  default:
+                    name: sasType
+                    description: The type of SAS token the SAS definition will create.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_222
+                readOnly: true
+                serializedName: validityPeriod
+                language: !<!Languages> 
+                  default:
+                    name: validityPeriod
+                    description: The validity period of SAS tokens created according to the SAS definition.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_215
+                readOnly: true
+                serializedName: attributes
+                language: !<!Languages> 
+                  default:
+                    name: attributes
+                    description: The SAS definition attributes.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_223
+                readOnly: true
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -6231,75 +6268,38 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: DeletedSasDefinitionBundle
-                description: 'A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
+                name: SasDefinitionBundle
+                description: A SAS definition bundle consists of key vault SAS definition details plus its attributes.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_219
+          - *ref_224
       properties:
         - !<!Property> 
-          schema: *ref_220
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: The SAS definition id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_221
-          readOnly: true
-          serializedName: sid
-          language: !<!Languages> 
-            default:
-              name: secretId
-              description: Storage account SAS definition secret id.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_222
-          readOnly: true
-          serializedName: templateUri
-          language: !<!Languages> 
-            default:
-              name: templateUri
-              description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_223
-          readOnly: true
-          serializedName: sasType
-          language: !<!Languages> 
-            default:
-              name: sasType
-              description: The type of SAS token the SAS definition will create.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_224
-          readOnly: true
-          serializedName: validityPeriod
-          language: !<!Languages> 
-            default:
-              name: validityPeriod
-              description: The validity period of SAS tokens created according to the SAS definition.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_215
-          readOnly: true
-          serializedName: attributes
-          language: !<!Languages> 
-            default:
-              name: attributes
-              description: The SAS definition attributes.
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_225
-          readOnly: true
-          serializedName: tags
+          serializedName: recoveryId
           language: !<!Languages> 
             default:
-              name: tags
-              description: Application specific metadata in the form of key-value pairs
+              name: recoveryId
+              description: 'The url of the recovery object, used to identify and recover the deleted SAS definition.'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_208
+          readOnly: true
+          serializedName: scheduledPurgeDate
+          language: !<!Languages> 
+            default:
+              name: scheduledPurgeDate
+              description: 'The time when the SAS definition is scheduled to be purged, in UTC'
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_209
+          readOnly: true
+          serializedName: deletedDate
+          language: !<!Languages> 
+            default:
+              name: deletedDate
+              description: 'The time when the SAS definition was deleted, in UTC'
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -6307,11 +6307,11 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: SasDefinitionBundle
-          description: A SAS definition bundle consists of key vault SAS definition details plus its attributes.
+          name: DeletedSasDefinitionBundle
+          description: 'A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as well as information on when it will be purged.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_219
+    - *ref_224
     - !<!ObjectSchema> &ref_640
       type: object
       apiVersions:
@@ -6328,7 +6328,7 @@ schemas: !<!Schemas>
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_643
-          schema: *ref_223
+          schema: *ref_221
           required: true
           serializedName: sasType
           language: !<!Languages> 
@@ -6388,7 +6388,7 @@ schemas: !<!Schemas>
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
         - !<!Property> &ref_658
-          schema: *ref_223
+          schema: *ref_221
           serializedName: sasType
           language: !<!Languages> 
             default:
@@ -10827,7 +10827,7 @@ operationGroups:
           - *ref_434
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -12215,7 +12215,7 @@ operationGroups:
           - *ref_498
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -12836,7 +12836,7 @@ operationGroups:
           - *ref_517
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -12964,7 +12964,7 @@ operationGroups:
           - *ref_520
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13467,7 +13467,7 @@ operationGroups:
           - *ref_540
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13717,7 +13717,7 @@ operationGroups:
           - *ref_548
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -13981,7 +13981,7 @@ operationGroups:
           - *ref_554
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -14211,7 +14211,7 @@ operationGroups:
           - *ref_558
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -14589,7 +14589,7 @@ operationGroups:
           - *ref_567
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_189
+            schema: *ref_187
             language: !<!Languages> 
               default:
                 name: ''
@@ -14793,7 +14793,7 @@ operationGroups:
           - *ref_571
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15018,7 +15018,7 @@ operationGroups:
           - *ref_579
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15129,7 +15129,7 @@ operationGroups:
           - *ref_581
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_189
+            schema: *ref_187
             language: !<!Languages> 
               default:
                 name: ''
@@ -15239,7 +15239,7 @@ operationGroups:
           - *ref_583
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15373,7 +15373,7 @@ operationGroups:
                     description: Current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_594
-                schema: *ref_193
+                schema: *ref_191
                 implementation: Method
                 originalParameter: *ref_585
                 pathToProperty: []
@@ -15444,7 +15444,7 @@ operationGroups:
           - *ref_599
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15575,7 +15575,7 @@ operationGroups:
                     description: The current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_608
-                schema: *ref_193
+                schema: *ref_191
                 implementation: Method
                 originalParameter: *ref_601
                 pathToProperty: []
@@ -15641,7 +15641,7 @@ operationGroups:
           - *ref_613
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -15784,7 +15784,7 @@ operationGroups:
           - *ref_619
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_187
+            schema: *ref_194
             language: !<!Languages> 
               default:
                 name: ''
@@ -16165,7 +16165,7 @@ operationGroups:
           - *ref_630
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_219
+            schema: *ref_217
             language: !<!Languages> 
               default:
                 name: ''
@@ -16287,7 +16287,7 @@ operationGroups:
           - *ref_633
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16406,7 +16406,7 @@ operationGroups:
           - *ref_636
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_219
+            schema: *ref_217
             language: !<!Languages> 
               default:
                 name: ''
@@ -16527,7 +16527,7 @@ operationGroups:
           - *ref_639
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16659,7 +16659,7 @@ operationGroups:
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_648
-                schema: *ref_223
+                schema: *ref_221
                 implementation: Method
                 originalParameter: *ref_641
                 pathToProperty: []
@@ -16730,7 +16730,7 @@ operationGroups:
           - *ref_654
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''
@@ -16867,7 +16867,7 @@ operationGroups:
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_663
-                schema: *ref_223
+                schema: *ref_221
                 implementation: Method
                 originalParameter: *ref_656
                 pathToProperty: []
@@ -16934,7 +16934,7 @@ operationGroups:
           - *ref_669
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_217
+            schema: *ref_224
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/lro/flattened.yaml
+++ b/modelerfour/test/scenarios/lro/flattened.yaml
@@ -40,7 +40,17 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_9
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: Product-properties-provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +60,7 @@ schemas: !<!Schemas>
           name: Resource-id
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +91,7 @@ schemas: !<!Schemas>
           name: Resource-location
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,16 +100,6 @@ schemas: !<!Schemas>
         default:
           name: Resource-name
           description: Resource Name
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: Product-properties-provisioningState
-          description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_12
       type: string
@@ -131,17 +131,7 @@ schemas: !<!Schemas>
           name: Sku-id
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: SubResource-id
-          description: Sub Resource Id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_16
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -150,6 +140,16 @@ schemas: !<!Schemas>
         default:
           name: SubProduct-properties-provisioningState
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_16
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: SubResource-id
+          description: Sub Resource Id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_22
       type: string
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
           description: The detailed arror message
       protocol: !<!Protocols> {}
   choices:
-    - !<!ChoiceSchema> &ref_4
+    - !<!ChoiceSchema> &ref_10
       choices:
         - !<!ChoiceValue> 
           value: Succeeded
@@ -240,7 +240,7 @@ schemas: !<!Schemas>
           name: Product-properties-provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_17
+    - !<!ChoiceSchema> &ref_19
       choices:
         - !<!ChoiceValue> 
           value: Succeeded
@@ -397,7 +397,7 @@ schemas: !<!Schemas>
           description: The status of the request
       protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_8
+    - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -412,14 +412,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_5
+          - !<!ObjectSchema> &ref_8
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_2
               immediate:
@@ -427,98 +427,98 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_3
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: provisioningState
-                    description: ''
+                    name: id
+                    description: Resource Id
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_4
-                flattenedNames:
-                  - properties
-                  - provisioningStateValues
                 readOnly: true
-                serializedName: provisioningStateValues
+                serializedName: type
                 language: !<!Languages> 
                   default:
-                    name: provisioningStateValues
-                    description: ''
+                    name: type
+                    description: Resource Type
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_5
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Dictionary of <string>
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_6
+                serializedName: location
+                language: !<!Languages> 
+                  default:
+                    name: location
+                    description: Resource Location
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_7
+                readOnly: true
+                serializedName: name
+                language: !<!Languages> 
+                  default:
+                    name: name
+                    description: Resource Name
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: Product
+                name: Resource
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_5
+          - *ref_8
       properties:
         - !<!Property> 
-          schema: *ref_6
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: Resource Id
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_7
-          readOnly: true
-          serializedName: type
-          language: !<!Languages> 
-            default:
-              name: type
-              description: Resource Type
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_8
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Dictionary of <string>
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_9
-          serializedName: location
+          flattenedNames:
+            - properties
+            - provisioningState
+          serializedName: provisioningState
           language: !<!Languages> 
             default:
-              name: location
-              description: Resource Location
+              name: provisioningState
+              description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_10
+          flattenedNames:
+            - properties
+            - provisioningStateValues
           readOnly: true
-          serializedName: name
+          serializedName: provisioningStateValues
           language: !<!Languages> 
             default:
-              name: name
-              description: Resource Name
+              name: provisioningStateValues
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: Resource
+          name: Product
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_5
+    - *ref_8
     - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
@@ -591,79 +591,79 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_18
+          - !<!ObjectSchema> &ref_17
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_15
               immediate:
                 - *ref_15
             properties:
-              - !<!Property> &ref_50
-                schema: *ref_16
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
-                language: !<!Languages> 
-                  default:
-                    name: provisioningState
-                    description: ''
-                protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_17
-                flattenedNames:
-                  - properties
-                  - provisioningStateValues
+                schema: *ref_16
                 readOnly: true
-                serializedName: provisioningStateValues
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: provisioningStateValues
-                    description: ''
+                    name: id
+                    description: Sub Resource Id
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: SubProduct
+                name: SubResource
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_18
+          - *ref_17
       properties:
-        - !<!Property> 
-          schema: *ref_19
-          readOnly: true
-          serializedName: id
+        - !<!Property> &ref_50
+          schema: *ref_18
+          flattenedNames:
+            - properties
+            - provisioningState
+          serializedName: provisioningState
           language: !<!Languages> 
             default:
-              name: id
-              description: Sub Resource Id
+              name: provisioningState
+              description: ''
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_19
+          flattenedNames:
+            - properties
+            - provisioningStateValues
+          readOnly: true
+          serializedName: provisioningStateValues
+          language: !<!Languages> 
+            default:
+              name: provisioningStateValues
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: SubResource
+          name: SubProduct
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_18
+    - *ref_17
     - !<!ObjectSchema> 
       type: object
       apiVersions:
@@ -751,7 +751,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_25
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -779,7 +779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -831,7 +831,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_27
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -859,7 +859,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -902,7 +902,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_28
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -930,7 +930,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -973,7 +973,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_29
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1001,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1014,7 +1014,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1057,7 +1057,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_30
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1085,7 +1085,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1128,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_31
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1156,7 +1156,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1169,7 +1169,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1212,7 +1212,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_32
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1240,7 +1240,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1283,7 +1283,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_33
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1311,7 +1311,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1358,7 +1358,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_34
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1386,7 +1386,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1439,7 +1439,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_36
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1467,7 +1467,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1517,7 +1517,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_37
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1545,7 +1545,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1598,7 +1598,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_38
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1626,7 +1626,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1676,7 +1676,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_39
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1704,7 +1704,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1941,7 +1941,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_49
-                schema: *ref_18
+                schema: *ref_15
                 flattened: true
                 implementation: Method
                 required: false
@@ -1954,7 +1954,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_51
-                schema: *ref_16
+                schema: *ref_18
                 implementation: Method
                 originalParameter: *ref_49
                 pathToProperty: []
@@ -1981,7 +1981,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2024,7 +2024,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_52
-                schema: *ref_18
+                schema: *ref_15
                 flattened: true
                 implementation: Method
                 required: false
@@ -2037,7 +2037,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_53
-                schema: *ref_16
+                schema: *ref_18
                 implementation: Method
                 originalParameter: *ref_52
                 pathToProperty: []
@@ -2064,7 +2064,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2117,7 +2117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2130,7 +2130,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2192,7 +2192,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2205,7 +2205,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2265,7 +2265,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2278,7 +2278,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2389,7 +2389,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2458,7 +2458,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2943,7 +2943,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_54
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3017,7 +3017,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_55
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3045,7 +3045,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3105,7 +3105,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3160,7 +3160,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3215,7 +3215,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3260,7 +3260,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_56
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3288,7 +3288,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3350,7 +3350,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_57
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3378,7 +3378,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3440,7 +3440,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_58
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3517,7 +3517,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_59
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3602,7 +3602,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_60
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3630,7 +3630,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3643,7 +3643,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3688,7 +3688,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_61
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3716,7 +3716,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3779,7 +3779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3792,7 +3792,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3959,7 +3959,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_62
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4033,7 +4033,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_63
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4120,7 +4120,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_64
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4148,7 +4148,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4161,7 +4161,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4204,7 +4204,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_65
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4232,7 +4232,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4245,7 +4245,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4288,7 +4288,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_66
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4316,7 +4316,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4329,7 +4329,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4372,7 +4372,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_67
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4400,7 +4400,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4624,7 +4624,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_68
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4698,7 +4698,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_69
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4772,7 +4772,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_70
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4849,7 +4849,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_71
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4877,7 +4877,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4890,7 +4890,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4933,7 +4933,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_72
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4961,7 +4961,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5014,7 +5014,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_73
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5042,7 +5042,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5203,7 +5203,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_74
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5277,7 +5277,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_75
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5354,7 +5354,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_76
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5382,7 +5382,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5434,7 +5434,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_77
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5462,7 +5462,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,7 +5515,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_78
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5543,7 +5543,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5770,7 +5770,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_79
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5844,7 +5844,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_80
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5921,7 +5921,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_81
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6006,7 +6006,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_82
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6034,7 +6034,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6089,7 +6089,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_83
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6117,7 +6117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6130,7 +6130,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6175,7 +6175,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_84
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6251,7 +6251,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_85
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/lro/grouped.yaml
+++ b/modelerfour/test/scenarios/lro/grouped.yaml
@@ -40,7 +40,17 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_9
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: Product-properties-provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +60,7 @@ schemas: !<!Schemas>
           name: Resource-id
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +91,7 @@ schemas: !<!Schemas>
           name: Resource-location
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,16 +100,6 @@ schemas: !<!Schemas>
         default:
           name: Resource-name
           description: Resource Name
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: Product-properties-provisioningState
-          description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_12
       type: string
@@ -131,17 +131,7 @@ schemas: !<!Schemas>
           name: Sku-id
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: SubResource-id
-          description: Sub Resource Id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_16
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -150,6 +140,16 @@ schemas: !<!Schemas>
         default:
           name: SubProduct-properties-provisioningState
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_16
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: SubResource-id
+          description: Sub Resource Id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_22
       type: string
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
           description: The detailed arror message
       protocol: !<!Protocols> {}
   choices:
-    - !<!ChoiceSchema> &ref_4
+    - !<!ChoiceSchema> &ref_10
       choices:
         - !<!ChoiceValue> 
           value: Succeeded
@@ -240,7 +240,7 @@ schemas: !<!Schemas>
           name: Product-properties-provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_17
+    - !<!ChoiceSchema> &ref_19
       choices:
         - !<!ChoiceValue> 
           value: Succeeded
@@ -397,7 +397,7 @@ schemas: !<!Schemas>
           description: The status of the request
       protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_8
+    - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -412,14 +412,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_5
+          - !<!ObjectSchema> &ref_8
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_2
               immediate:
@@ -427,98 +427,98 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_3
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: provisioningState
-                    description: ''
+                    name: id
+                    description: Resource Id
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_4
-                flattenedNames:
-                  - properties
-                  - provisioningStateValues
                 readOnly: true
-                serializedName: provisioningStateValues
+                serializedName: type
                 language: !<!Languages> 
                   default:
-                    name: provisioningStateValues
-                    description: ''
+                    name: type
+                    description: Resource Type
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_5
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Dictionary of <string>
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_6
+                serializedName: location
+                language: !<!Languages> 
+                  default:
+                    name: location
+                    description: Resource Location
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_7
+                readOnly: true
+                serializedName: name
+                language: !<!Languages> 
+                  default:
+                    name: name
+                    description: Resource Name
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: Product
+                name: Resource
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_5
+          - *ref_8
       properties:
         - !<!Property> 
-          schema: *ref_6
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: Resource Id
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_7
-          readOnly: true
-          serializedName: type
-          language: !<!Languages> 
-            default:
-              name: type
-              description: Resource Type
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_8
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Dictionary of <string>
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_9
-          serializedName: location
+          flattenedNames:
+            - properties
+            - provisioningState
+          serializedName: provisioningState
           language: !<!Languages> 
             default:
-              name: location
-              description: Resource Location
+              name: provisioningState
+              description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_10
+          flattenedNames:
+            - properties
+            - provisioningStateValues
           readOnly: true
-          serializedName: name
+          serializedName: provisioningStateValues
           language: !<!Languages> 
             default:
-              name: name
-              description: Resource Name
+              name: provisioningStateValues
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: Resource
+          name: Product
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_5
+    - *ref_8
     - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
@@ -591,79 +591,79 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_18
+          - !<!ObjectSchema> &ref_17
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_15
               immediate:
                 - *ref_15
             properties:
-              - !<!Property> &ref_50
-                schema: *ref_16
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
-                language: !<!Languages> 
-                  default:
-                    name: provisioningState
-                    description: ''
-                protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_17
-                flattenedNames:
-                  - properties
-                  - provisioningStateValues
+                schema: *ref_16
                 readOnly: true
-                serializedName: provisioningStateValues
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: provisioningStateValues
-                    description: ''
+                    name: id
+                    description: Sub Resource Id
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: SubProduct
+                name: SubResource
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_18
+          - *ref_17
       properties:
-        - !<!Property> 
-          schema: *ref_19
-          readOnly: true
-          serializedName: id
+        - !<!Property> &ref_50
+          schema: *ref_18
+          flattenedNames:
+            - properties
+            - provisioningState
+          serializedName: provisioningState
           language: !<!Languages> 
             default:
-              name: id
-              description: Sub Resource Id
+              name: provisioningState
+              description: ''
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_19
+          flattenedNames:
+            - properties
+            - provisioningStateValues
+          readOnly: true
+          serializedName: provisioningStateValues
+          language: !<!Languages> 
+            default:
+              name: provisioningStateValues
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: SubResource
+          name: SubProduct
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_18
+    - *ref_17
     - !<!ObjectSchema> 
       type: object
       apiVersions:
@@ -751,7 +751,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_25
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -779,7 +779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -831,7 +831,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_27
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -859,7 +859,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -902,7 +902,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_28
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -930,7 +930,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -973,7 +973,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_29
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1001,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1014,7 +1014,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1057,7 +1057,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_30
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1085,7 +1085,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1128,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_31
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1156,7 +1156,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1169,7 +1169,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1212,7 +1212,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_32
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1240,7 +1240,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1283,7 +1283,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_33
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1311,7 +1311,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1358,7 +1358,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_34
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1386,7 +1386,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1439,7 +1439,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_36
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1467,7 +1467,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1517,7 +1517,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_37
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1545,7 +1545,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1598,7 +1598,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_38
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1626,7 +1626,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1676,7 +1676,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_39
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1704,7 +1704,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1941,7 +1941,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_49
-                schema: *ref_18
+                schema: *ref_15
                 flattened: true
                 implementation: Method
                 required: false
@@ -1954,7 +1954,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_51
-                schema: *ref_16
+                schema: *ref_18
                 implementation: Method
                 originalParameter: *ref_49
                 pathToProperty: []
@@ -1981,7 +1981,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2024,7 +2024,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_52
-                schema: *ref_18
+                schema: *ref_15
                 flattened: true
                 implementation: Method
                 required: false
@@ -2037,7 +2037,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_53
-                schema: *ref_16
+                schema: *ref_18
                 implementation: Method
                 originalParameter: *ref_52
                 pathToProperty: []
@@ -2064,7 +2064,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2117,7 +2117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2130,7 +2130,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2192,7 +2192,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2205,7 +2205,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2265,7 +2265,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2278,7 +2278,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2389,7 +2389,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2458,7 +2458,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2943,7 +2943,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_54
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3017,7 +3017,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_55
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3045,7 +3045,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3105,7 +3105,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3160,7 +3160,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3215,7 +3215,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3260,7 +3260,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_56
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3288,7 +3288,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3350,7 +3350,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_57
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3378,7 +3378,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3440,7 +3440,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_58
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3517,7 +3517,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_59
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3602,7 +3602,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_60
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3630,7 +3630,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3643,7 +3643,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3688,7 +3688,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_61
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3716,7 +3716,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3779,7 +3779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3792,7 +3792,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3959,7 +3959,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_62
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4033,7 +4033,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_63
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4120,7 +4120,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_64
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4148,7 +4148,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4161,7 +4161,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4204,7 +4204,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_65
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4232,7 +4232,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4245,7 +4245,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4288,7 +4288,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_66
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4316,7 +4316,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4329,7 +4329,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4372,7 +4372,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_67
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4400,7 +4400,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4624,7 +4624,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_68
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4698,7 +4698,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_69
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4772,7 +4772,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_70
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4849,7 +4849,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_71
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4877,7 +4877,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4890,7 +4890,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4933,7 +4933,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_72
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4961,7 +4961,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5014,7 +5014,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_73
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5042,7 +5042,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5203,7 +5203,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_74
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5277,7 +5277,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_75
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5354,7 +5354,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_76
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5382,7 +5382,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5434,7 +5434,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_77
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5462,7 +5462,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,7 +5515,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_78
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5543,7 +5543,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5770,7 +5770,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_79
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5844,7 +5844,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_80
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5921,7 +5921,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_81
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6006,7 +6006,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_82
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6034,7 +6034,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6089,7 +6089,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_83
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6117,7 +6117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6130,7 +6130,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6175,7 +6175,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_84
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6251,7 +6251,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_85
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/lro/modeler.yaml
+++ b/modelerfour/test/scenarios/lro/modeler.yaml
@@ -33,7 +33,7 @@ schemas: !<!Schemas>
           description: The error code for an operation failure
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_1
       type: string
       language: !<!Languages> 
         default:
@@ -47,10 +47,20 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
+          name: Product-properties-provisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_2
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
           name: Resource-id
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +70,7 @@ schemas: !<!Schemas>
           name: Resource-type
           description: Resource Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_5
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +91,7 @@ schemas: !<!Schemas>
           name: Resource-location
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,16 +100,6 @@ schemas: !<!Schemas>
         default:
           name: Resource-name
           description: Resource Name
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: Product-properties-provisioningState
-          description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_10
       type: string
@@ -138,8 +138,8 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: SubResource-id
-          description: Sub Resource Id
+          name: SubProduct-properties-provisioningState
+          description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_14
       type: string
@@ -148,8 +148,8 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: SubProduct-properties-provisioningState
-          description: ''
+          name: SubResource-id
+          description: Sub Resource Id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_18
       type: string
@@ -162,6 +162,84 @@ schemas: !<!Schemas>
           description: The detailed arror message
       protocol: !<!Protocols> {}
   choices:
+    - !<!ChoiceSchema> &ref_20
+      choices:
+        - !<!ChoiceValue> 
+          value: Succeeded
+          language:
+            default:
+              name: Succeeded
+              description: ''
+        - !<!ChoiceValue> 
+          value: Failed
+          language:
+            default:
+              name: Failed
+              description: ''
+        - !<!ChoiceValue> 
+          value: canceled
+          language:
+            default:
+              name: canceled
+              description: ''
+        - !<!ChoiceValue> 
+          value: Accepted
+          language:
+            default:
+              name: Accepted
+              description: ''
+        - !<!ChoiceValue> 
+          value: Creating
+          language:
+            default:
+              name: Creating
+              description: ''
+        - !<!ChoiceValue> 
+          value: Created
+          language:
+            default:
+              name: Created
+              description: ''
+        - !<!ChoiceValue> 
+          value: Updating
+          language:
+            default:
+              name: Updating
+              description: ''
+        - !<!ChoiceValue> 
+          value: Updated
+          language:
+            default:
+              name: Updated
+              description: ''
+        - !<!ChoiceValue> 
+          value: Deleting
+          language:
+            default:
+              name: Deleting
+              description: ''
+        - !<!ChoiceValue> 
+          value: Deleted
+          language:
+            default:
+              name: Deleted
+              description: ''
+        - !<!ChoiceValue> 
+          value: OK
+          language:
+            default:
+              name: OK
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      choiceType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Product-properties-provisioningStateValues
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_21
       choices:
         - !<!ChoiceValue> 
@@ -234,10 +312,10 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      choiceType: *ref_6
+      choiceType: *ref_1
       language: !<!Languages> 
         default:
-          name: Product-properties-provisioningStateValues
+          name: SubProduct-properties-provisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_22
@@ -312,94 +390,16 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      choiceType: *ref_6
-      language: !<!Languages> 
-        default:
-          name: SubProduct-properties-provisioningStateValues
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_23
-      choices:
-        - !<!ChoiceValue> 
-          value: Succeeded
-          language:
-            default:
-              name: Succeeded
-              description: ''
-        - !<!ChoiceValue> 
-          value: Failed
-          language:
-            default:
-              name: Failed
-              description: ''
-        - !<!ChoiceValue> 
-          value: canceled
-          language:
-            default:
-              name: canceled
-              description: ''
-        - !<!ChoiceValue> 
-          value: Accepted
-          language:
-            default:
-              name: Accepted
-              description: ''
-        - !<!ChoiceValue> 
-          value: Creating
-          language:
-            default:
-              name: Creating
-              description: ''
-        - !<!ChoiceValue> 
-          value: Created
-          language:
-            default:
-              name: Created
-              description: ''
-        - !<!ChoiceValue> 
-          value: Updating
-          language:
-            default:
-              name: Updating
-              description: ''
-        - !<!ChoiceValue> 
-          value: Updated
-          language:
-            default:
-              name: Updated
-              description: ''
-        - !<!ChoiceValue> 
-          value: Deleting
-          language:
-            default:
-              name: Deleting
-              description: ''
-        - !<!ChoiceValue> 
-          value: Deleted
-          language:
-            default:
-              name: Deleted
-              description: ''
-        - !<!ChoiceValue> 
-          value: OK
-          language:
-            default:
-              name: OK
-              description: ''
-      type: choice
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      choiceType: *ref_6
+      choiceType: *ref_1
       language: !<!Languages> 
         default:
           name: OperationResult-status
           description: The status of the request
       protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_20
+    - !<!DictionarySchema> &ref_23
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_4
       nullableItems: false
       language: !<!Languages> 
         default:
@@ -412,72 +412,72 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_8
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_7
               immediate:
                 - *ref_7
             properties:
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_9
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 1.0.0
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_5
-                      serializedName: provisioningState
-                      language: !<!Languages> 
-                        default:
-                          name: provisioningState
-                          description: ''
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_21
-                      readOnly: true
-                      serializedName: provisioningStateValues
-                      language: !<!Languages> 
-                        default:
-                          name: provisioningStateValues
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - input
-                    - output
-                  extensions:
-                    x-ms-client-flatten: true
-                  language: !<!Languages> 
-                    default:
-                      name: Product-properties
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: properties
-                extensions:
-                  x-ms-client-flatten: true
+                schema: *ref_2
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: properties
-                    description: ''
+                    name: id
+                    description: Resource Id
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_3
+                readOnly: true
+                serializedName: type
+                language: !<!Languages> 
+                  default:
+                    name: type
+                    description: Resource Type
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_23
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Dictionary of <string>
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_5
+                serializedName: location
+                language: !<!Languages> 
+                  default:
+                    name: location
+                    description: Resource Location
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_6
+                readOnly: true
+                serializedName: name
+                language: !<!Languages> 
+                  default:
+                    name: name
+                    description: Resource Name
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: Product
+                name: Resource
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
@@ -485,63 +485,63 @@ schemas: !<!Schemas>
           - *ref_8
       properties:
         - !<!Property> 
-          schema: *ref_0
-          readOnly: true
-          serializedName: id
+          schema: !<!ObjectSchema> &ref_9
+            type: object
+            apiVersions:
+              - !<!ApiVersion> 
+                version: 1.0.0
+            properties:
+              - !<!Property> 
+                schema: *ref_0
+                serializedName: provisioningState
+                language: !<!Languages> 
+                  default:
+                    name: provisioningState
+                    description: ''
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_20
+                readOnly: true
+                serializedName: provisioningStateValues
+                language: !<!Languages> 
+                  default:
+                    name: provisioningStateValues
+                    description: ''
+                protocol: !<!Protocols> {}
+            serializationFormats:
+              - json
+            usage:
+              - input
+              - output
+            extensions:
+              x-ms-client-flatten: true
+            language: !<!Languages> 
+              default:
+                name: Product-properties
+                description: ''
+                namespace: ''
+            protocol: !<!Protocols> {}
+          serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
-              name: id
-              description: Resource Id
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_1
-          readOnly: true
-          serializedName: type
-          language: !<!Languages> 
-            default:
-              name: type
-              description: Resource Type
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_20
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Dictionary of <string>
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_3
-          serializedName: location
-          language: !<!Languages> 
-            default:
-              name: location
-              description: Resource Location
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_4
-          readOnly: true
-          serializedName: name
-          language: !<!Languages> 
-            default:
-              name: name
-              description: Resource Name
+              name: properties
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: Resource
+          name: Product
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_8
     - *ref_9
+    - *ref_8
     - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
@@ -614,72 +614,38 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_16
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_15
               immediate:
                 - *ref_15
             properties:
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_17
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 1.0.0
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_14
-                      serializedName: provisioningState
-                      language: !<!Languages> 
-                        default:
-                          name: provisioningState
-                          description: ''
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_22
-                      readOnly: true
-                      serializedName: provisioningStateValues
-                      language: !<!Languages> 
-                        default:
-                          name: provisioningStateValues
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - input
-                    - output
-                  extensions:
-                    x-ms-client-flatten: true
-                  language: !<!Languages> 
-                    default:
-                      name: SubProduct-properties
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: properties
-                extensions:
-                  x-ms-client-flatten: true
+                schema: *ref_14
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: properties
-                    description: ''
+                    name: id
+                    description: Sub Resource Id
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: SubProduct
+                name: SubResource
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
@@ -687,29 +653,63 @@ schemas: !<!Schemas>
           - *ref_16
       properties:
         - !<!Property> 
-          schema: *ref_13
-          readOnly: true
-          serializedName: id
+          schema: !<!ObjectSchema> &ref_17
+            type: object
+            apiVersions:
+              - !<!ApiVersion> 
+                version: 1.0.0
+            properties:
+              - !<!Property> 
+                schema: *ref_13
+                serializedName: provisioningState
+                language: !<!Languages> 
+                  default:
+                    name: provisioningState
+                    description: ''
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_21
+                readOnly: true
+                serializedName: provisioningStateValues
+                language: !<!Languages> 
+                  default:
+                    name: provisioningStateValues
+                    description: ''
+                protocol: !<!Protocols> {}
+            serializationFormats:
+              - json
+            usage:
+              - input
+              - output
+            extensions:
+              x-ms-client-flatten: true
+            language: !<!Languages> 
+              default:
+                name: SubProduct-properties
+                description: ''
+                namespace: ''
+            protocol: !<!Protocols> {}
+          serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
-              name: id
-              description: Sub Resource Id
+              name: properties
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: SubResource
+          name: SubProduct
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_16
     - *ref_17
+    - *ref_16
     - !<!ObjectSchema> 
       type: object
       apiVersions:
@@ -717,7 +717,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_23
+          schema: *ref_22
           serializedName: status
           language: !<!Languages> 
             default:
@@ -768,7 +768,7 @@ schemas: !<!Schemas>
     - *ref_19
 globalParameters:
   - !<!Parameter> &ref_28
-    schema: *ref_6
+    schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -797,7 +797,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_26
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -825,7 +825,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -877,7 +877,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_29
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -905,7 +905,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -948,7 +948,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_30
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -976,7 +976,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1019,7 +1019,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_31
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1047,7 +1047,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1060,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1103,7 +1103,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_32
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1131,7 +1131,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1174,7 +1174,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_33
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1202,7 +1202,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1215,7 +1215,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1258,7 +1258,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_34
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1286,7 +1286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1329,7 +1329,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_35
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1357,7 +1357,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1366,7 +1366,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: location
                 knownMediaType: json
                 mediaTypes:
@@ -1404,7 +1404,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_36
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1432,7 +1432,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1441,10 +1441,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -1485,7 +1485,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_38
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1513,7 +1513,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1522,10 +1522,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                 knownMediaType: json
                 mediaTypes:
@@ -1563,7 +1563,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_39
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1591,7 +1591,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1600,10 +1600,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -1644,7 +1644,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_40
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1672,7 +1672,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1681,10 +1681,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                 knownMediaType: json
                 mediaTypes:
@@ -1722,7 +1722,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_41
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1750,7 +1750,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1759,7 +1759,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                 knownMediaType: json
                 mediaTypes:
@@ -1939,7 +1939,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_45
-                schema: *ref_16
+                schema: *ref_15
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1967,7 +1967,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2010,7 +2010,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_46
-                schema: *ref_16
+                schema: *ref_15
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2038,7 +2038,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2091,7 +2091,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2104,7 +2104,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2113,7 +2113,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2166,7 +2166,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2179,7 +2179,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2188,7 +2188,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2239,7 +2239,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2252,7 +2252,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2261,7 +2261,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2363,7 +2363,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2384,7 +2384,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2432,7 +2432,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2453,7 +2453,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2509,7 +2509,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                 statusCodes:
                   - '202'
@@ -2571,7 +2571,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                 statusCodes:
                   - '202'
@@ -2633,10 +2633,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2692,10 +2692,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2751,10 +2751,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2810,10 +2810,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2917,7 +2917,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_47
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2953,7 +2953,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -2991,7 +2991,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_48
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3019,7 +3019,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3028,7 +3028,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3079,7 +3079,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3134,7 +3134,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3189,7 +3189,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3234,7 +3234,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_49
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3262,7 +3262,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3283,10 +3283,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3324,7 +3324,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_50
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3352,7 +3352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3373,10 +3373,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3414,7 +3414,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_51
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3450,10 +3450,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3491,7 +3491,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_52
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3527,10 +3527,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3576,7 +3576,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_53
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3604,7 +3604,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3617,7 +3617,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3662,7 +3662,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_54
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3690,7 +3690,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3699,10 +3699,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3753,7 +3753,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3766,7 +3766,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -3775,7 +3775,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3836,7 +3836,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3892,10 +3892,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -3933,7 +3933,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_55
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3969,7 +3969,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4007,7 +4007,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_56
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4043,10 +4043,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4094,7 +4094,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_57
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4122,7 +4122,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4135,7 +4135,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4178,7 +4178,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_58
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4206,7 +4206,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4219,7 +4219,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4262,7 +4262,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_59
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4290,7 +4290,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4303,7 +4303,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4346,7 +4346,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_60
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4374,7 +4374,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4383,10 +4383,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4445,7 +4445,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4501,7 +4501,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4557,10 +4557,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4598,7 +4598,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_61
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4634,7 +4634,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4672,7 +4672,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_62
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4708,7 +4708,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4746,7 +4746,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_63
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4782,10 +4782,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4823,7 +4823,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_64
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4851,7 +4851,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4864,7 +4864,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4907,7 +4907,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_65
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4935,7 +4935,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -4944,10 +4944,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -4988,7 +4988,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_66
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5016,7 +5016,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -5025,10 +5025,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5136,10 +5136,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5177,7 +5177,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_67
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5213,7 +5213,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5251,7 +5251,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_68
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5287,10 +5287,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5328,7 +5328,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_69
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5356,7 +5356,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -5408,7 +5408,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_70
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5436,7 +5436,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -5445,10 +5445,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5489,7 +5489,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_71
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5517,7 +5517,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -5526,10 +5526,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5588,7 +5588,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5644,10 +5644,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5703,10 +5703,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5744,7 +5744,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_72
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5780,7 +5780,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5818,7 +5818,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_73
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5854,10 +5854,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5895,7 +5895,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_74
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5931,10 +5931,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -5980,7 +5980,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_75
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6008,7 +6008,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -6017,10 +6017,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -6063,7 +6063,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_76
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6091,7 +6091,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -6104,7 +6104,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -6149,7 +6149,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_77
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6185,7 +6185,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37
@@ -6225,7 +6225,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_78
-                schema: *ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6261,10 +6261,10 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Azure-AsyncOperation
                   - !<!HttpHeader> 
-                    schema: *ref_2
+                    schema: *ref_4
                     header: Location
                   - !<!HttpHeader> 
                     schema: *ref_37

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -40,7 +40,17 @@ schemas: !<!Schemas>
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_9
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: ProductPropertiesProvisioningState
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +60,7 @@ schemas: !<!Schemas>
           name: ResourceId
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +91,7 @@ schemas: !<!Schemas>
           name: ResourceLocation
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,16 +100,6 @@ schemas: !<!Schemas>
         default:
           name: ResourceName
           description: Resource Name
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: ProductPropertiesProvisioningState
-          description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_12
       type: string
@@ -131,17 +131,7 @@ schemas: !<!Schemas>
           name: SkuId
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: SubResourceId
-          description: Sub Resource Id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_16
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -150,6 +140,16 @@ schemas: !<!Schemas>
         default:
           name: SubProductPropertiesProvisioningState
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_16
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: SubResourceId
+          description: Sub Resource Id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_22
       type: string
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
           description: The detailed arror message
       protocol: !<!Protocols> {}
   choices:
-    - !<!ChoiceSchema> &ref_4
+    - !<!ChoiceSchema> &ref_10
       choices:
         - !<!ChoiceValue> 
           value: Succeeded
@@ -240,7 +240,7 @@ schemas: !<!Schemas>
           name: ProductPropertiesProvisioningStateValues
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_17
+    - !<!ChoiceSchema> &ref_19
       choices:
         - !<!ChoiceValue> 
           value: Succeeded
@@ -397,7 +397,7 @@ schemas: !<!Schemas>
           description: The status of the request
       protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_8
+    - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
       nullableItems: false
@@ -412,14 +412,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_5
+          - !<!ObjectSchema> &ref_8
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_2
               immediate:
@@ -427,98 +427,98 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_3
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
+                readOnly: true
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: provisioningState
-                    description: ''
+                    name: id
+                    description: Resource Id
                 protocol: !<!Protocols> {}
               - !<!Property> 
                 schema: *ref_4
-                flattenedNames:
-                  - properties
-                  - provisioningStateValues
                 readOnly: true
-                serializedName: provisioningStateValues
+                serializedName: type
                 language: !<!Languages> 
                   default:
-                    name: provisioningStateValues
-                    description: ''
+                    name: type
+                    description: Resource Type
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_5
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Dictionary of <string>
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_6
+                serializedName: location
+                language: !<!Languages> 
+                  default:
+                    name: location
+                    description: Resource Location
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_7
+                readOnly: true
+                serializedName: name
+                language: !<!Languages> 
+                  default:
+                    name: name
+                    description: Resource Name
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: Product
+                name: Resource
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_5
+          - *ref_8
       properties:
         - !<!Property> 
-          schema: *ref_6
-          readOnly: true
-          serializedName: id
-          language: !<!Languages> 
-            default:
-              name: id
-              description: Resource Id
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_7
-          readOnly: true
-          serializedName: type
-          language: !<!Languages> 
-            default:
-              name: type
-              description: Resource Type
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_8
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Dictionary of <string>
-          protocol: !<!Protocols> {}
-        - !<!Property> 
           schema: *ref_9
-          serializedName: location
+          flattenedNames:
+            - properties
+            - provisioningState
+          serializedName: provisioningState
           language: !<!Languages> 
             default:
-              name: location
-              description: Resource Location
+              name: provisioningState
+              description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
           schema: *ref_10
+          flattenedNames:
+            - properties
+            - provisioningStateValues
           readOnly: true
-          serializedName: name
+          serializedName: provisioningStateValues
           language: !<!Languages> 
             default:
-              name: name
-              description: Resource Name
+              name: provisioningStateValues
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: Resource
+          name: Product
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_5
+    - *ref_8
     - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
@@ -591,79 +591,79 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_18
+          - !<!ObjectSchema> &ref_17
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_15
               immediate:
                 - *ref_15
             properties:
-              - !<!Property> &ref_50
-                schema: *ref_16
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
-                language: !<!Languages> 
-                  default:
-                    name: provisioningState
-                    description: ''
-                protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_17
-                flattenedNames:
-                  - properties
-                  - provisioningStateValues
+                schema: *ref_16
                 readOnly: true
-                serializedName: provisioningStateValues
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: provisioningStateValues
-                    description: ''
+                    name: id
+                    description: Sub Resource Id
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: SubProduct
+                name: SubResource
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_18
+          - *ref_17
       properties:
-        - !<!Property> 
-          schema: *ref_19
-          readOnly: true
-          serializedName: id
+        - !<!Property> &ref_50
+          schema: *ref_18
+          flattenedNames:
+            - properties
+            - provisioningState
+          serializedName: provisioningState
           language: !<!Languages> 
             default:
-              name: id
-              description: Sub Resource Id
+              name: provisioningState
+              description: ''
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_19
+          flattenedNames:
+            - properties
+            - provisioningStateValues
+          readOnly: true
+          serializedName: provisioningStateValues
+          language: !<!Languages> 
+            default:
+              name: provisioningStateValues
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: SubResource
+          name: SubProduct
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_18
+    - *ref_17
     - !<!ObjectSchema> 
       type: object
       apiVersions:
@@ -751,7 +751,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_25
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -779,7 +779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -831,7 +831,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_27
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -859,7 +859,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -902,7 +902,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_28
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -930,7 +930,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -973,7 +973,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_29
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1001,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1014,7 +1014,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1057,7 +1057,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_30
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1085,7 +1085,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1128,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_31
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1156,7 +1156,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1169,7 +1169,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1212,7 +1212,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_32
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1240,7 +1240,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1283,7 +1283,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_33
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1311,7 +1311,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1358,7 +1358,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_34
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1386,7 +1386,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1439,7 +1439,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_36
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1467,7 +1467,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1517,7 +1517,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_37
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1545,7 +1545,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1598,7 +1598,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_38
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1626,7 +1626,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1676,7 +1676,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_39
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1704,7 +1704,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1941,7 +1941,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_49
-                schema: *ref_18
+                schema: *ref_15
                 flattened: true
                 implementation: Method
                 required: false
@@ -1954,7 +1954,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_51
-                schema: *ref_16
+                schema: *ref_18
                 implementation: Method
                 originalParameter: *ref_49
                 pathToProperty: []
@@ -1981,7 +1981,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2024,7 +2024,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_52
-                schema: *ref_18
+                schema: *ref_15
                 flattened: true
                 implementation: Method
                 required: false
@@ -2037,7 +2037,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_53
-                schema: *ref_16
+                schema: *ref_18
                 implementation: Method
                 originalParameter: *ref_52
                 pathToProperty: []
@@ -2064,7 +2064,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2117,7 +2117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2130,7 +2130,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2192,7 +2192,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2205,7 +2205,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2265,7 +2265,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2278,7 +2278,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2389,7 +2389,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2458,7 +2458,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -2943,7 +2943,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_54
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3017,7 +3017,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_55
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3045,7 +3045,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3105,7 +3105,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3160,7 +3160,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3215,7 +3215,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3260,7 +3260,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_56
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3288,7 +3288,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3350,7 +3350,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_57
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3378,7 +3378,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3440,7 +3440,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_58
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3517,7 +3517,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_59
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3602,7 +3602,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_60
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3630,7 +3630,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3643,7 +3643,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3688,7 +3688,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_61
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3716,7 +3716,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3779,7 +3779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3792,7 +3792,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -3959,7 +3959,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_62
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4033,7 +4033,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_63
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4120,7 +4120,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_64
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4148,7 +4148,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4161,7 +4161,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4204,7 +4204,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_65
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4232,7 +4232,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4245,7 +4245,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4288,7 +4288,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_66
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4316,7 +4316,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4329,7 +4329,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4372,7 +4372,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_67
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4400,7 +4400,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4624,7 +4624,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_68
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4698,7 +4698,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_69
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4772,7 +4772,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_70
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4849,7 +4849,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_71
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4877,7 +4877,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4890,7 +4890,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -4933,7 +4933,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_72
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4961,7 +4961,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5014,7 +5014,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_73
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5042,7 +5042,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5203,7 +5203,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_74
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5277,7 +5277,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_75
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5354,7 +5354,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_76
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5382,7 +5382,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5434,7 +5434,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_77
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5462,7 +5462,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,7 +5515,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_78
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5543,7 +5543,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -5770,7 +5770,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_79
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5844,7 +5844,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_80
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -5921,7 +5921,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_81
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6006,7 +6006,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_82
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6034,7 +6034,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6089,7 +6089,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_83
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6117,7 +6117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6130,7 +6130,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -6175,7 +6175,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_84
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -6251,7 +6251,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_85
-                schema: *ref_5
+                schema: *ref_2
                 implementation: Method
                 required: false
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/model-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/model-flattening/flattened.yaml
@@ -120,27 +120,7 @@ schemas: !<!Schemas>
           name: WrappedProduct-value
           description: the product value
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_24
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: productId
-          description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_25
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: description
-          description: Description of product.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_22
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -150,7 +130,17 @@ schemas: !<!Schemas>
           name: SimpleProductProperties-max_product_display_name
           description: Display name of product.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_21
+    - !<!StringSchema> &ref_25
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: ProductUrl-@odata.value
+          description: URL value.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_24
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -160,15 +150,25 @@ schemas: !<!Schemas>
           name: GenericUrl-generic_value
           description: Generic URL value.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_19
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: ProductUrl-@odata.value
-          description: URL value.
+          name: productId
+          description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_20
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: description
+          description: Description of product.
       protocol: !<!Protocols> {}
   choices:
     - !<!ChoiceSchema> &ref_11
@@ -250,7 +250,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_23
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -574,64 +574,36 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_23
+          - !<!ObjectSchema> &ref_21
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_18
               immediate:
                 - *ref_18
             properties:
-              - !<!Property> &ref_46
+              - !<!Property> &ref_44
                 schema: *ref_19
-                flattenedNames:
-                  - details
-                  - max_product_display_name
-                serializedName: max_product_display_name
+                required: true
+                serializedName: base_product_id
                 language: !<!Languages> 
                   default:
-                    name: max_product_display_name
-                    description: Display name of product.
+                    name: productId
+                    description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
-              - !<!Property> &ref_47
+              - !<!Property> &ref_45
                 schema: *ref_20
-                flattenedNames:
-                  - details
-                  - max_product_capacity
-                serializedName: max_product_capacity
+                required: false
+                serializedName: base_product_description
                 language: !<!Languages> 
                   default:
-                    name: capacity
-                    description: 'Capacity of product. For example, 4 people.'
-                protocol: !<!Protocols> {}
-              - !<!Property> &ref_48
-                schema: *ref_21
-                flattenedNames:
-                  - details
-                  - max_product_image
-                  - generic_value
-                serializedName: generic_value
-                language: !<!Languages> 
-                  default:
-                    name: generic_value
-                    description: Generic URL value.
-                protocol: !<!Protocols> {}
-              - !<!Property> &ref_49
-                schema: *ref_22
-                flattenedNames:
-                  - details
-                  - max_product_image
-                  - '@odata.value'
-                serializedName: '@odata.value'
-                language: !<!Languages> 
-                  default:
-                    name: '@odata.value'
-                    description: URL value.
+                    name: description
+                    description: Description of product.
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -640,93 +612,59 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: SimpleProduct
+                name: BaseProduct
                 description: The product documentation.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_23
+          - *ref_21
       properties:
-        - !<!Property> &ref_44
+        - !<!Property> &ref_46
+          schema: *ref_22
+          flattenedNames:
+            - details
+            - max_product_display_name
+          serializedName: max_product_display_name
+          language: !<!Languages> 
+            default:
+              name: max_product_display_name
+              description: Display name of product.
+          protocol: !<!Protocols> {}
+        - !<!Property> &ref_47
+          schema: *ref_23
+          flattenedNames:
+            - details
+            - max_product_capacity
+          serializedName: max_product_capacity
+          language: !<!Languages> 
+            default:
+              name: capacity
+              description: 'Capacity of product. For example, 4 people.'
+          protocol: !<!Protocols> {}
+        - !<!Property> &ref_48
           schema: *ref_24
-          required: true
-          serializedName: base_product_id
-          language: !<!Languages> 
-            default:
-              name: productId
-              description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
-          protocol: !<!Protocols> {}
-        - !<!Property> &ref_45
-          schema: *ref_25
-          required: false
-          serializedName: base_product_description
-          language: !<!Languages> 
-            default:
-              name: description
-              description: Description of product.
-          protocol: !<!Protocols> {}
-      serializationFormats:
-        - json
-      usage:
-        - input
-        - output
-      language: !<!Languages> 
-        default:
-          name: BaseProduct
-          description: The product documentation.
-          namespace: ''
-      protocol: !<!Protocols> {}
-    - *ref_23
-    - !<!ObjectSchema> &ref_26
-      type: object
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      children: !<!Relations> 
-        all:
-          - !<!ObjectSchema> &ref_27
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 1.0.0
-            parents: !<!Relations> 
-              all:
-                - *ref_26
-              immediate:
-                - *ref_26
-            properties:
-              - !<!Property> 
-                schema: *ref_22
-                serializedName: '@odata.value'
-                language: !<!Languages> 
-                  default:
-                    name: '@odata.value'
-                    description: URL value.
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - input
-              - output
-            extensions:
-              x-ms-flattened: true
-            language: !<!Languages> 
-              default:
-                name: ProductUrl
-                description: The product URL.
-                namespace: ''
-            protocol: !<!Protocols> {}
-        immediate:
-          - *ref_27
-      properties:
-        - !<!Property> 
-          schema: *ref_21
+          flattenedNames:
+            - details
+            - max_product_image
+            - generic_value
           serializedName: generic_value
           language: !<!Languages> 
             default:
               name: generic_value
               description: Generic URL value.
           protocol: !<!Protocols> {}
+        - !<!Property> &ref_49
+          schema: *ref_25
+          flattenedNames:
+            - details
+            - max_product_image
+            - '@odata.value'
+          serializedName: '@odata.value'
+          language: !<!Languages> 
+            default:
+              name: '@odata.value'
+              description: URL value.
+          protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
@@ -734,11 +672,73 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: GenericUrl
-          description: The Generic URL.
+          name: SimpleProduct
+          description: The product documentation.
+          namespace: ''
+      protocol: !<!Protocols> {}
+    - !<!ObjectSchema> &ref_26
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      parents: !<!Relations> 
+        all:
+          - !<!ObjectSchema> &ref_27
+            type: object
+            apiVersions:
+              - !<!ApiVersion> 
+                version: 1.0.0
+            children: !<!Relations> 
+              all:
+                - *ref_26
+              immediate:
+                - *ref_26
+            properties:
+              - !<!Property> 
+                schema: *ref_24
+                serializedName: generic_value
+                language: !<!Languages> 
+                  default:
+                    name: generic_value
+                    description: Generic URL value.
+                protocol: !<!Protocols> {}
+            serializationFormats:
+              - json
+            usage:
+              - input
+              - output
+            language: !<!Languages> 
+              default:
+                name: GenericUrl
+                description: The Generic URL.
+                namespace: ''
+            protocol: !<!Protocols> {}
+        immediate:
+          - *ref_27
+      properties:
+        - !<!Property> 
+          schema: *ref_25
+          serializedName: '@odata.value'
+          language: !<!Languages> 
+            default:
+              name: '@odata.value'
+              description: URL value.
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - json
+      usage:
+        - input
+        - output
+      extensions:
+        x-ms-flattened: true
+      language: !<!Languages> 
+        default:
+          name: ProductUrl
+          description: The product URL.
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_27
+    - *ref_21
   arrays:
     - !<!ArraySchema> &ref_32
       type: array
@@ -1280,7 +1280,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_42
-                schema: *ref_23
+                schema: *ref_18
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1308,7 +1308,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1349,7 +1349,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_43
-                schema: *ref_23
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: false
@@ -1364,7 +1364,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_50
-                schema: *ref_24
+                schema: *ref_19
                 implementation: Method
                 originalParameter: *ref_43
                 pathToProperty: []
@@ -1376,7 +1376,7 @@ operationGroups:
                     description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_51
-                schema: *ref_25
+                schema: *ref_20
                 implementation: Method
                 originalParameter: *ref_43
                 pathToProperty: []
@@ -1388,7 +1388,7 @@ operationGroups:
                     description: Description of product.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_52
-                schema: *ref_19
+                schema: *ref_22
                 implementation: Method
                 originalParameter: *ref_43
                 pathToProperty: []
@@ -1399,7 +1399,7 @@ operationGroups:
                     description: Display name of product.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> 
-                schema: *ref_20
+                schema: *ref_23
                 implementation: Method
                 originalParameter: *ref_43
                 pathToProperty: []
@@ -1410,7 +1410,7 @@ operationGroups:
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_53
-                schema: *ref_21
+                schema: *ref_24
                 implementation: Method
                 originalParameter: *ref_43
                 pathToProperty: []
@@ -1421,7 +1421,7 @@ operationGroups:
                     description: Generic URL value.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_54
-                schema: *ref_22
+                schema: *ref_25
                 implementation: Method
                 originalParameter: *ref_43
                 pathToProperty: []
@@ -1452,7 +1452,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1508,7 +1508,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_55
-                schema: *ref_23
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: false
@@ -1525,7 +1525,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_57
-                schema: *ref_24
+                schema: *ref_19
                 implementation: Method
                 originalParameter: *ref_55
                 pathToProperty: []
@@ -1539,7 +1539,7 @@ operationGroups:
                     description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_58
-                schema: *ref_25
+                schema: *ref_20
                 implementation: Method
                 originalParameter: *ref_55
                 pathToProperty: []
@@ -1553,7 +1553,7 @@ operationGroups:
                     description: Description of product.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_59
-                schema: *ref_19
+                schema: *ref_22
                 implementation: Method
                 originalParameter: *ref_55
                 pathToProperty: []
@@ -1566,7 +1566,7 @@ operationGroups:
                     description: Display name of product.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> 
-                schema: *ref_20
+                schema: *ref_23
                 implementation: Method
                 originalParameter: *ref_55
                 pathToProperty: []
@@ -1579,7 +1579,7 @@ operationGroups:
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_60
-                schema: *ref_21
+                schema: *ref_24
                 implementation: Method
                 originalParameter: *ref_55
                 pathToProperty: []
@@ -1592,7 +1592,7 @@ operationGroups:
                     description: Generic URL value.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_61
-                schema: *ref_22
+                schema: *ref_25
                 implementation: Method
                 originalParameter: *ref_55
                 pathToProperty: []
@@ -1626,7 +1626,7 @@ operationGroups:
           - *ref_62
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -120,27 +120,7 @@ schemas: !<!Schemas>
           name: WrappedProduct-value
           description: the product value
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_24
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: productId
-          description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_25
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: description
-          description: Description of product.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_22
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -150,7 +130,17 @@ schemas: !<!Schemas>
           name: SimpleProductProperties-max_product_display_name
           description: Display name of product.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_21
+    - !<!StringSchema> &ref_25
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: ProductUrl-@odata.value
+          description: URL value.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_24
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -160,15 +150,25 @@ schemas: !<!Schemas>
           name: GenericUrl-generic_value
           description: Generic URL value.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_19
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: ProductUrl-@odata.value
-          description: URL value.
+          name: productId
+          description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_20
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: description
+          description: Description of product.
       protocol: !<!Protocols> {}
   choices:
     - !<!ChoiceSchema> &ref_11
@@ -250,7 +250,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_23
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -457,26 +457,26 @@ schemas: !<!Schemas>
               description: Product name with value 'groupproduct'
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: !<!ObjectSchema> &ref_23
+          schema: !<!ObjectSchema> &ref_18
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
             parents: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_18
+                - !<!ObjectSchema> &ref_21
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 1.0.0
                   children: !<!Relations> 
                     all:
-                      - *ref_23
+                      - *ref_18
                     immediate:
-                      - *ref_23
+                      - *ref_18
                   properties:
                     - !<!Property> &ref_34
-                      schema: *ref_24
+                      schema: *ref_19
                       required: true
                       serializedName: base_product_id
                       language: !<!Languages> 
@@ -485,7 +485,7 @@ schemas: !<!Schemas>
                           description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                       protocol: !<!Protocols> {}
                     - !<!Property> &ref_35
-                      schema: *ref_25
+                      schema: *ref_20
                       required: false
                       serializedName: base_product_description
                       language: !<!Languages> 
@@ -505,10 +505,10 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_18
+                - *ref_21
             properties:
               - !<!Property> &ref_36
-                schema: *ref_19
+                schema: *ref_22
                 flattenedNames:
                   - details
                   - max_product_display_name
@@ -519,7 +519,7 @@ schemas: !<!Schemas>
                     description: Display name of product.
                 protocol: !<!Protocols> {}
               - !<!Property> &ref_52
-                schema: *ref_20
+                schema: *ref_23
                 flattenedNames:
                   - details
                   - max_product_capacity
@@ -530,7 +530,7 @@ schemas: !<!Schemas>
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
               - !<!Property> &ref_37
-                schema: *ref_21
+                schema: *ref_24
                 flattenedNames:
                   - details
                   - max_product_image
@@ -542,7 +542,7 @@ schemas: !<!Schemas>
                     description: Generic URL value.
                 protocol: !<!Protocols> {}
               - !<!Property> &ref_38
-                schema: *ref_22
+                schema: *ref_25
                 flattenedNames:
                   - details
                   - max_product_image
@@ -566,7 +566,7 @@ schemas: !<!Schemas>
             protocol: !<!Protocols> {}
           originalParameter:
             - !<!Parameter> &ref_33
-              schema: *ref_23
+              schema: *ref_18
               flattened: true
               groupedBy: *ref_32
               implementation: Method
@@ -589,10 +589,10 @@ schemas: !<!Schemas>
               description: Simple body product to put
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_24
+          schema: *ref_19
           originalParameter:
             - !<!VirtualParameter> &ref_59
-              schema: *ref_24
+              schema: *ref_19
               groupedBy: *ref_32
               implementation: Method
               originalParameter: *ref_33
@@ -612,10 +612,10 @@ schemas: !<!Schemas>
               description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_25
+          schema: *ref_20
           originalParameter:
             - !<!VirtualParameter> &ref_60
-              schema: *ref_25
+              schema: *ref_20
               groupedBy: *ref_32
               implementation: Method
               originalParameter: *ref_33
@@ -635,10 +635,10 @@ schemas: !<!Schemas>
               description: Description of product.
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_19
+          schema: *ref_22
           originalParameter:
             - !<!VirtualParameter> &ref_61
-              schema: *ref_19
+              schema: *ref_22
               groupedBy: *ref_32
               implementation: Method
               originalParameter: *ref_33
@@ -656,10 +656,10 @@ schemas: !<!Schemas>
               description: Display name of product.
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_21
+          schema: *ref_24
           originalParameter:
             - !<!VirtualParameter> &ref_62
-              schema: *ref_21
+              schema: *ref_24
               groupedBy: *ref_32
               implementation: Method
               originalParameter: *ref_33
@@ -677,10 +677,10 @@ schemas: !<!Schemas>
               description: Generic URL value.
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_22
+          schema: *ref_25
           originalParameter:
             - !<!VirtualParameter> &ref_63
-              schema: *ref_22
+              schema: *ref_25
               groupedBy: *ref_32
               implementation: Method
               originalParameter: *ref_33
@@ -853,69 +853,69 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_18
-    - *ref_23
     - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_27
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_26
               immediate:
                 - *ref_26
             properties:
               - !<!Property> 
-                schema: *ref_22
-                serializedName: '@odata.value'
+                schema: *ref_24
+                serializedName: generic_value
                 language: !<!Languages> 
                   default:
-                    name: '@odata.value'
-                    description: URL value.
+                    name: generic_value
+                    description: Generic URL value.
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
-            extensions:
-              x-ms-flattened: true
             language: !<!Languages> 
               default:
-                name: ProductUrl
-                description: The product URL.
+                name: GenericUrl
+                description: The Generic URL.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
           - *ref_27
       properties:
         - !<!Property> 
-          schema: *ref_21
-          serializedName: generic_value
+          schema: *ref_25
+          serializedName: '@odata.value'
           language: !<!Languages> 
             default:
-              name: generic_value
-              description: Generic URL value.
+              name: '@odata.value'
+              description: URL value.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
+      extensions:
+        x-ms-flattened: true
       language: !<!Languages> 
         default:
-          name: GenericUrl
-          description: The Generic URL.
+          name: ProductUrl
+          description: The product URL.
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_27
+    - *ref_21
   arrays:
     - !<!ArraySchema> &ref_40
       type: array
@@ -1457,7 +1457,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_50
-                schema: *ref_23
+                schema: *ref_18
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1485,7 +1485,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1526,7 +1526,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_51
-                schema: *ref_23
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: false
@@ -1541,7 +1541,7 @@ operationGroups:
                     in: body
                     style: json
               - !<!VirtualParameter> &ref_53
-                schema: *ref_24
+                schema: *ref_19
                 implementation: Method
                 originalParameter: *ref_51
                 pathToProperty: []
@@ -1553,7 +1553,7 @@ operationGroups:
                     description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_54
-                schema: *ref_25
+                schema: *ref_20
                 implementation: Method
                 originalParameter: *ref_51
                 pathToProperty: []
@@ -1565,7 +1565,7 @@ operationGroups:
                     description: Description of product.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_55
-                schema: *ref_19
+                schema: *ref_22
                 implementation: Method
                 originalParameter: *ref_51
                 pathToProperty: []
@@ -1576,7 +1576,7 @@ operationGroups:
                     description: Display name of product.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> 
-                schema: *ref_20
+                schema: *ref_23
                 implementation: Method
                 originalParameter: *ref_51
                 pathToProperty: []
@@ -1587,7 +1587,7 @@ operationGroups:
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_56
-                schema: *ref_21
+                schema: *ref_24
                 implementation: Method
                 originalParameter: *ref_51
                 pathToProperty: []
@@ -1598,7 +1598,7 @@ operationGroups:
                     description: Generic URL value.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_57
-                schema: *ref_22
+                schema: *ref_25
                 implementation: Method
                 originalParameter: *ref_51
                 pathToProperty: []
@@ -1629,7 +1629,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1675,7 +1675,7 @@ operationGroups:
               - *ref_60
               - *ref_61
               - !<!VirtualParameter> 
-                schema: *ref_20
+                schema: *ref_23
                 implementation: Method
                 originalParameter: *ref_33
                 pathToProperty: []
@@ -1708,7 +1708,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/model-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/model-flattening/modeler.yaml
@@ -127,8 +127,8 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: productId
-          description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
+          name: SimpleProductProperties-max_product_display_name
+          description: Display name of product.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_17
       type: string
@@ -137,20 +137,10 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: description
-          description: Description of product.
+          name: ProductUrl-@odata.value
+          description: URL value.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_18
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: SimpleProductProperties-max_product_display_name
-          description: Display name of product.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_20
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -160,15 +150,25 @@ schemas: !<!Schemas>
           name: GenericUrl-generic_value
           description: Generic URL value.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_21
       type: string
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: ProductUrl-@odata.value
-          description: URL value.
+          name: productId
+          description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_22
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: description
+          description: Description of product.
       protocol: !<!Protocols> {}
   choices:
     - !<!ChoiceSchema> &ref_31
@@ -588,131 +588,36 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_24
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_23
               immediate:
                 - *ref_23
             properties:
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_25
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 1.0.0
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_18
-                      required: true
-                      serializedName: max_product_display_name
-                      language: !<!Languages> 
-                        default:
-                          name: max_product_display_name
-                          description: Display name of product.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_32
-                      required: true
-                      serializedName: max_product_capacity
-                      language: !<!Languages> 
-                        default:
-                          name: capacity
-                          description: 'Capacity of product. For example, 4 people.'
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_21
-                        type: object
-                        apiVersions:
-                          - !<!ApiVersion> 
-                            version: 1.0.0
-                        parents: !<!Relations> 
-                          all:
-                            - !<!ObjectSchema> &ref_22
-                              type: object
-                              apiVersions:
-                                - !<!ApiVersion> 
-                                  version: 1.0.0
-                              children: !<!Relations> 
-                                all:
-                                  - *ref_21
-                                immediate:
-                                  - *ref_21
-                              properties:
-                                - !<!Property> 
-                                  schema: *ref_20
-                                  serializedName: generic_value
-                                  language: !<!Languages> 
-                                    default:
-                                      name: generic_value
-                                      description: Generic URL value.
-                                  protocol: !<!Protocols> {}
-                              serializationFormats:
-                                - json
-                              usage:
-                                - input
-                                - output
-                              language: !<!Languages> 
-                                default:
-                                  name: GenericUrl
-                                  description: The Generic URL.
-                                  namespace: ''
-                              protocol: !<!Protocols> {}
-                          immediate:
-                            - *ref_22
-                        properties:
-                          - !<!Property> 
-                            schema: *ref_19
-                            serializedName: '@odata.value'
-                            language: !<!Languages> 
-                              default:
-                                name: '@odata.value'
-                                description: URL value.
-                            protocol: !<!Protocols> {}
-                        serializationFormats:
-                          - json
-                        usage:
-                          - input
-                          - output
-                        language: !<!Languages> 
-                          default:
-                            name: ProductUrl
-                            description: The product URL.
-                            namespace: ''
-                        protocol: !<!Protocols> {}
-                      required: false
-                      serializedName: max_product_image
-                      extensions:
-                        x-ms-client-flatten: true
-                      language: !<!Languages> 
-                        default:
-                          name: max_product_image
-                          description: The product URL.
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - input
-                    - output
-                  language: !<!Languages> 
-                    default:
-                      name: SimpleProductProperties
-                      description: The product documentation.
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: details
-                extensions:
-                  x-ms-client-flatten: true
+                schema: *ref_21
+                required: true
+                serializedName: base_product_id
                 language: !<!Languages> 
                   default:
-                    name: details
-                    description: The product documentation.
+                    name: productId
+                    description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_22
+                required: false
+                serializedName: base_product_description
+                language: !<!Languages> 
+                  default:
+                    name: description
+                    description: Description of product.
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -721,7 +626,7 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: SimpleProduct
+                name: BaseProduct
                 description: The product documentation.
                 namespace: ''
             protocol: !<!Protocols> {}
@@ -729,22 +634,117 @@ schemas: !<!Schemas>
           - *ref_24
       properties:
         - !<!Property> 
-          schema: *ref_16
-          required: true
-          serializedName: base_product_id
+          schema: !<!ObjectSchema> &ref_25
+            type: object
+            apiVersions:
+              - !<!ApiVersion> 
+                version: 1.0.0
+            properties:
+              - !<!Property> 
+                schema: *ref_16
+                required: true
+                serializedName: max_product_display_name
+                language: !<!Languages> 
+                  default:
+                    name: max_product_display_name
+                    description: Display name of product.
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_32
+                required: true
+                serializedName: max_product_capacity
+                language: !<!Languages> 
+                  default:
+                    name: capacity
+                    description: 'Capacity of product. For example, 4 people.'
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: !<!ObjectSchema> &ref_19
+                  type: object
+                  apiVersions:
+                    - !<!ApiVersion> 
+                      version: 1.0.0
+                  parents: !<!Relations> 
+                    all:
+                      - !<!ObjectSchema> &ref_20
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 1.0.0
+                        children: !<!Relations> 
+                          all:
+                            - *ref_19
+                          immediate:
+                            - *ref_19
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_18
+                            serializedName: generic_value
+                            language: !<!Languages> 
+                              default:
+                                name: generic_value
+                                description: Generic URL value.
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - input
+                          - output
+                        language: !<!Languages> 
+                          default:
+                            name: GenericUrl
+                            description: The Generic URL.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                    immediate:
+                      - *ref_20
+                  properties:
+                    - !<!Property> 
+                      schema: *ref_17
+                      serializedName: '@odata.value'
+                      language: !<!Languages> 
+                        default:
+                          name: '@odata.value'
+                          description: URL value.
+                      protocol: !<!Protocols> {}
+                  serializationFormats:
+                    - json
+                  usage:
+                    - input
+                    - output
+                  language: !<!Languages> 
+                    default:
+                      name: ProductUrl
+                      description: The product URL.
+                      namespace: ''
+                  protocol: !<!Protocols> {}
+                required: false
+                serializedName: max_product_image
+                extensions:
+                  x-ms-client-flatten: true
+                language: !<!Languages> 
+                  default:
+                    name: max_product_image
+                    description: The product URL.
+                protocol: !<!Protocols> {}
+            serializationFormats:
+              - json
+            usage:
+              - input
+              - output
+            language: !<!Languages> 
+              default:
+                name: SimpleProductProperties
+                description: The product documentation.
+                namespace: ''
+            protocol: !<!Protocols> {}
+          serializedName: details
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
-              name: productId
-              description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_17
-          required: false
-          serializedName: base_product_description
-          language: !<!Languages> 
-            default:
-              name: description
-              description: Description of product.
+              name: details
+              description: The product documentation.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -753,14 +753,14 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: BaseProduct
+          name: SimpleProduct
           description: The product documentation.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_24
     - *ref_25
-    - *ref_22
-    - *ref_21
+    - *ref_19
+    - *ref_20
+    - *ref_24
   arrays:
     - !<!ArraySchema> &ref_33
       type: array
@@ -1302,7 +1302,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_44
-                schema: *ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1330,7 +1330,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -1371,7 +1371,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_45
-                schema: *ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 extensions:
@@ -1401,7 +1401,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -1457,7 +1457,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_47
-                schema: *ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 extensions:
@@ -1490,7 +1490,7 @@ operationGroups:
           - *ref_46
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -120,6 +120,36 @@ schemas: !<!Schemas>
           name: WrappedProductValue
           description: the product value
       protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_18
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: SimpleProductPropertiesMaxProductDisplayName
+          description: Display name of product.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_21
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: ProductUrlOdataValue
+          description: URL value.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_20
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: GenericUrlGenericValue
+          description: Generic URL value.
+      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_15
       type: string
       apiVersions:
@@ -139,36 +169,6 @@ schemas: !<!Schemas>
         default:
           name: Description
           description: Description of product.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_18
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: SimpleProductPropertiesMaxProductDisplayName
-          description: Display name of product.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_20
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: GenericUrlGenericValue
-          description: Generic URL value.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_21
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: ProductUrlOdataValue
-          description: URL value.
       protocol: !<!Protocols> {}
   choices:
     - !<!ChoiceSchema> &ref_11
@@ -852,70 +852,70 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_17
     - *ref_14
     - !<!ObjectSchema> &ref_34
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_35
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_34
               immediate:
                 - *ref_34
             properties:
               - !<!Property> 
-                schema: *ref_21
-                serializedName: '@odata.value'
+                schema: *ref_20
+                serializedName: generic_value
                 language: !<!Languages> 
                   default:
-                    name: odataValue
-                    description: URL value.
+                    name: genericValue
+                    description: Generic URL value.
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
-            extensions:
-              x-ms-flattened: true
             language: !<!Languages> 
               default:
-                name: ProductUrl
-                description: The product URL.
+                name: GenericUrl
+                description: The Generic URL.
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
           - *ref_35
       properties:
         - !<!Property> 
-          schema: *ref_20
-          serializedName: generic_value
+          schema: *ref_21
+          serializedName: '@odata.value'
           language: !<!Languages> 
             default:
-              name: genericValue
-              description: Generic URL value.
+              name: odataValue
+              description: URL value.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
+      extensions:
+        x-ms-flattened: true
       language: !<!Languages> 
         default:
-          name: GenericUrl
-          description: The Generic URL.
+          name: ProductUrl
+          description: The product URL.
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_35
+    - *ref_17
   arrays:
     - !<!ArraySchema> &ref_40
       type: array

--- a/modelerfour/test/scenarios/storage/flattened.yaml
+++ b/modelerfour/test/scenarios/storage/flattened.yaml
@@ -10,7 +10,7 @@ schemas: !<!Schemas>
           name: boolean
           description: 'Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or invalid and cannot be used.'
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_20
+    - !<!BooleanSchema> &ref_21
       type: boolean
       language: !<!Languages> 
         default:
@@ -123,7 +123,7 @@ schemas: !<!Schemas>
           name: Resource-location
           description: Resource location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -133,7 +133,7 @@ schemas: !<!Schemas>
           name: Endpoints-blob
           description: Gets the blob endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -143,7 +143,7 @@ schemas: !<!Schemas>
           name: Endpoints-queue
           description: Gets the queue endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -153,7 +153,7 @@ schemas: !<!Schemas>
           name: Endpoints-table
           description: Gets the table endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -163,7 +163,7 @@ schemas: !<!Schemas>
           name: StorageAccountProperties-primaryLocation
           description: Gets the location of the primary for the storage account.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -173,7 +173,7 @@ schemas: !<!Schemas>
           name: StorageAccountProperties-secondaryLocation
           description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_20
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -258,7 +258,7 @@ schemas: !<!Schemas>
           name: Reason
           description: Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_8
+    - !<!SealedChoiceSchema> &ref_10
       choices:
         - !<!ChoiceValue> 
           value: Standard_LRS
@@ -330,7 +330,7 @@ schemas: !<!Schemas>
           name: ProvisioningState
           description: Gets the status of the storage account at the time the operation was called.
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_15
+    - !<!SealedChoiceSchema> &ref_16
       choices:
         - !<!ChoiceValue> 
           value: Available
@@ -448,7 +448,7 @@ schemas: !<!Schemas>
           description: Resource tags
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_16
+    - !<!DateTimeSchema> &ref_17
       type: date-time
       format: date-time
       apiVersions:
@@ -461,7 +461,7 @@ schemas: !<!Schemas>
             Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the
             accountType is StandardGRS or StandardRAGRS.
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_18
+    - !<!DateTimeSchema> &ref_19
       type: date-time
       format: date-time
       apiVersions:
@@ -552,134 +552,126 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_22
+          - !<!ObjectSchema> &ref_8
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_7
-              immediate:
-                - *ref_7
-            properties:
-              - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
-                language: !<!Languages> 
-                  default:
-                    name: accountType
-                    description: Gets or sets the account type.
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - input
-              - output
-            language: !<!Languages> 
-              default:
-                name: StorageAccountCreateParameters
-                description: The parameters to provide for the account.
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_23
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 2015-05-01-preview
-            parents: !<!Relations> 
-              all:
-                - *ref_7
-              immediate:
-                - *ref_7
-            properties:
-              - !<!Property> 
-                schema: *ref_9
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
-                language: !<!Languages> 
-                  default:
-                    name: provisioningState
-                    description: Gets the status of the storage account at the time the operation was called.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
-                language: !<!Languages> 
-                  default:
-                    name: accountType
-                    description: Gets the type of the storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_13
+                - !<!ObjectSchema> &ref_23
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                  parents: !<!Relations> 
+                    all:
+                      - *ref_8
+                    immediate:
+                      - *ref_8
                   properties:
                     - !<!Property> 
+                      schema: *ref_9
+                      flattenedNames:
+                        - properties
+                        - provisioningState
+                      serializedName: provisioningState
+                      language: !<!Languages> 
+                        default:
+                          name: provisioningState
+                          description: Gets the status of the storage account at the time the operation was called.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
                       schema: *ref_10
-                      serializedName: blob
+                      flattenedNames:
+                        - properties
+                        - accountType
+                      serializedName: accountType
                       language: !<!Languages> 
                         default:
-                          name: blob
-                          description: Gets the blob endpoint.
+                          name: accountType
+                          description: Gets the type of the storage account.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_11
-                      serializedName: queue
-                      language: !<!Languages> 
-                        default:
-                          name: queue
-                          description: Gets the queue endpoint.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_12
-                      serializedName: table
-                      language: !<!Languages> 
-                        default:
-                          name: table
-                          description: Gets the table endpoint.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_13
-                      serializedName: dummyEndPoint
-                      language: !<!Languages> 
-                        default:
-                          name: dummyEndPoint
-                          description: Dummy EndPoint
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_30
+                      schema: !<!ObjectSchema> &ref_14
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 2015-05-01-preview
                         properties:
                           - !<!Property> 
-                            schema: !<!ObjectSchema> &ref_31
+                            schema: *ref_11
+                            serializedName: blob
+                            language: !<!Languages> 
+                              default:
+                                name: blob
+                                description: Gets the blob endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_12
+                            serializedName: queue
+                            language: !<!Languages> 
+                              default:
+                                name: queue
+                                description: Gets the queue endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_13
+                            serializedName: table
+                            language: !<!Languages> 
+                              default:
+                                name: table
+                                description: Gets the table endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_14
+                            serializedName: dummyEndPoint
+                            language: !<!Languages> 
+                              default:
+                                name: dummyEndPoint
+                                description: Dummy EndPoint
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ObjectSchema> &ref_30
                               type: object
                               apiVersions:
                                 - !<!ApiVersion> 
                                   version: 2015-05-01-preview
                               properties:
                                 - !<!Property> 
-                                  schema: *ref_13
-                                  serializedName: RecursivePoint
+                                  schema: !<!ObjectSchema> &ref_31
+                                    type: object
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 2015-05-01-preview
+                                    properties:
+                                      - !<!Property> 
+                                        schema: *ref_14
+                                        serializedName: RecursivePoint
+                                        language: !<!Languages> 
+                                          default:
+                                            name: RecursivePoint
+                                            description: Recursive Endpoints
+                                        protocol: !<!Protocols> {}
+                                    serializationFormats:
+                                      - json
+                                    usage:
+                                      - input
+                                      - output
+                                    language: !<!Languages> 
+                                      default:
+                                        name: Bar
+                                        description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
+                                        namespace: ''
+                                    protocol: !<!Protocols> {}
+                                  serializedName: Bar.Point
                                   language: !<!Languages> 
                                     default:
-                                      name: RecursivePoint
-                                      description: Recursive Endpoints
+                                      name: Bar.Point
+                                      description: Bar point
                                   protocol: !<!Protocols> {}
                               serializationFormats:
                                 - json
@@ -688,15 +680,15 @@ schemas: !<!Schemas>
                                 - output
                               language: !<!Languages> 
                                 default:
-                                  name: Bar
+                                  name: Foo
                                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                                   namespace: ''
                               protocol: !<!Protocols> {}
-                            serializedName: Bar.Point
+                            serializedName: FooPoint
                             language: !<!Languages> 
                               default:
-                                name: Bar.Point
-                                description: Bar point
+                                name: FooPoint
+                                description: Foo point
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -705,126 +697,186 @@ schemas: !<!Schemas>
                           - output
                         language: !<!Languages> 
                           default:
-                            name: Foo
+                            name: Endpoints
                             description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: FooPoint
+                      flattenedNames:
+                        - properties
+                        - primaryEndpoints
+                      serializedName: primaryEndpoints
                       language: !<!Languages> 
                         default:
-                          name: FooPoint
-                          description: Foo point
+                          name: primaryEndpoints
+                          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_15
+                      flattenedNames:
+                        - properties
+                        - primaryLocation
+                      serializedName: primaryLocation
+                      language: !<!Languages> 
+                        default:
+                          name: primaryLocation
+                          description: Gets the location of the primary for the storage account.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_16
+                      flattenedNames:
+                        - properties
+                        - statusOfPrimary
+                      serializedName: statusOfPrimary
+                      language: !<!Languages> 
+                        default:
+                          name: statusOfPrimary
+                          description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_17
+                      flattenedNames:
+                        - properties
+                        - lastGeoFailoverTime
+                      serializedName: lastGeoFailoverTime
+                      language: !<!Languages> 
+                        default:
+                          name: lastGeoFailoverTime
+                          description: >-
+                            Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only
+                            available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_18
+                      flattenedNames:
+                        - properties
+                        - secondaryLocation
+                      serializedName: secondaryLocation
+                      language: !<!Languages> 
+                        default:
+                          name: secondaryLocation
+                          description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_16
+                      flattenedNames:
+                        - properties
+                        - statusOfSecondary
+                      serializedName: statusOfSecondary
+                      language: !<!Languages> 
+                        default:
+                          name: statusOfSecondary
+                          description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_19
+                      flattenedNames:
+                        - properties
+                        - creationTime
+                      serializedName: creationTime
+                      language: !<!Languages> 
+                        default:
+                          name: creationTime
+                          description: Gets the creation date and time of the storage account in UTC.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_22
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 2015-05-01-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_20
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: Gets or sets the custom domain name. Name is the CNAME source.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_21
+                            serializedName: useSubDomain
+                            language: !<!Languages> 
+                              default:
+                                name: useSubDomain
+                                description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - input
+                          - output
+                        language: !<!Languages> 
+                          default:
+                            name: CustomDomain
+                            description: The custom domain assigned to this storage account. This can be set via Update.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      flattenedNames:
+                        - properties
+                        - customDomain
+                      serializedName: customDomain
+                      language: !<!Languages> 
+                        default:
+                          name: customDomain
+                          description: Gets the user assigned custom domain assigned to this storage account.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_14
+                      flattenedNames:
+                        - properties
+                        - secondaryEndpoints
+                      serializedName: secondaryEndpoints
+                      language: !<!Languages> 
+                        default:
+                          name: secondaryEndpoints
+                          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
                   usage:
-                    - input
                     - output
+                    - input
                   language: !<!Languages> 
                     default:
-                      name: Endpoints
-                      description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
+                      name: StorageAccount
+                      description: The storage account.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                flattenedNames:
-                  - properties
-                  - primaryEndpoints
-                serializedName: primaryEndpoints
-                language: !<!Languages> 
-                  default:
-                    name: primaryEndpoints
-                    description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_14
-                flattenedNames:
-                  - properties
-                  - primaryLocation
-                serializedName: primaryLocation
-                language: !<!Languages> 
-                  default:
-                    name: primaryLocation
-                    description: Gets the location of the primary for the storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_15
-                flattenedNames:
-                  - properties
-                  - statusOfPrimary
-                serializedName: statusOfPrimary
-                language: !<!Languages> 
-                  default:
-                    name: statusOfPrimary
-                    description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_16
-                flattenedNames:
-                  - properties
-                  - lastGeoFailoverTime
-                serializedName: lastGeoFailoverTime
-                language: !<!Languages> 
-                  default:
-                    name: lastGeoFailoverTime
-                    description: >-
-                      Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only
-                      available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_17
-                flattenedNames:
-                  - properties
-                  - secondaryLocation
-                serializedName: secondaryLocation
-                language: !<!Languages> 
-                  default:
-                    name: secondaryLocation
-                    description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_15
-                flattenedNames:
-                  - properties
-                  - statusOfSecondary
-                serializedName: statusOfSecondary
-                language: !<!Languages> 
-                  default:
-                    name: statusOfSecondary
-                    description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_18
-                flattenedNames:
-                  - properties
-                  - creationTime
-                serializedName: creationTime
-                language: !<!Languages> 
-                  default:
-                    name: creationTime
-                    description: Gets the creation date and time of the storage account in UTC.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_21
+                - !<!ObjectSchema> &ref_24
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                  parents: !<!Relations> 
+                    all:
+                      - *ref_8
+                    immediate:
+                      - *ref_8
                   properties:
                     - !<!Property> 
-                      schema: *ref_19
-                      serializedName: name
+                      schema: *ref_10
+                      flattenedNames:
+                        - properties
+                        - accountType
+                      serializedName: accountType
                       language: !<!Languages> 
                         default:
-                          name: name
-                          description: Gets or sets the custom domain name. Name is the CNAME source.
+                          name: accountType
+                          description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_20
-                      serializedName: useSubDomain
+                      schema: *ref_22
+                      flattenedNames:
+                        - properties
+                        - customDomain
+                      serializedName: customDomain
                       language: !<!Languages> 
                         default:
-                          name: useSubDomain
-                          description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+                          name: customDomain
+                          description: >-
+                            User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom
+                            domain name property.
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
@@ -833,159 +885,107 @@ schemas: !<!Schemas>
                     - output
                   language: !<!Languages> 
                     default:
-                      name: CustomDomain
-                      description: The custom domain assigned to this storage account. This can be set via Update.
+                      name: StorageAccountUpdateParameters
+                      description: The parameters to update on the account.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                flattenedNames:
-                  - properties
-                  - customDomain
-                serializedName: customDomain
-                language: !<!Languages> 
-                  default:
-                    name: customDomain
-                    description: Gets the user assigned custom domain assigned to this storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_13
-                flattenedNames:
-                  - properties
-                  - secondaryEndpoints
-                serializedName: secondaryEndpoints
-                language: !<!Languages> 
-                  default:
-                    name: secondaryEndpoints
-                    description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: StorageAccount
-                description: The storage account.
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_24
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 2015-05-01-preview
-            parents: !<!Relations> 
-              all:
-                - *ref_7
               immediate:
                 - *ref_7
+                - *ref_23
+                - *ref_24
             properties:
               - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
+                schema: *ref_25
+                readOnly: true
+                required: false
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: accountType
-                    description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
+                    name: id
+                    description: Resource Id
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_21
-                flattenedNames:
-                  - properties
-                  - customDomain
-                serializedName: customDomain
+                schema: *ref_26
+                readOnly: true
+                required: false
+                serializedName: name
                 language: !<!Languages> 
                   default:
-                    name: customDomain
-                    description: >-
-                      User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom
-                      domain name property.
+                    name: name
+                    description: Resource name
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_27
+                readOnly: true
+                required: false
+                serializedName: type
+                language: !<!Languages> 
+                  default:
+                    name: type
+                    description: Resource type
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_28
+                required: true
+                serializedName: location
+                language: !<!Languages> 
+                  default:
+                    name: location
+                    description: Resource location
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_29
+                required: false
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Resource tags
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: StorageAccountUpdateParameters
-                description: The parameters to update on the account.
+                name: Resource
+                description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_22
-          - *ref_23
-          - *ref_24
+          - *ref_8
       properties:
         - !<!Property> 
-          schema: *ref_25
-          readOnly: true
-          required: false
-          serializedName: id
+          schema: *ref_10
+          flattenedNames:
+            - properties
+            - accountType
+          serializedName: accountType
           language: !<!Languages> 
             default:
-              name: id
-              description: Resource Id
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_26
-          readOnly: true
-          required: false
-          serializedName: name
-          language: !<!Languages> 
-            default:
-              name: name
-              description: Resource name
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_27
-          readOnly: true
-          required: false
-          serializedName: type
-          language: !<!Languages> 
-            default:
-              name: type
-              description: Resource type
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_28
-          required: true
-          serializedName: location
-          language: !<!Languages> 
-            default:
-              name: location
-              description: Resource location
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_29
-          required: false
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Resource tags
+              name: accountType
+              description: Gets or sets the account type.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: Resource
-          description: ''
+          name: StorageAccountCreateParameters
+          description: The parameters to provide for the account.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_22
+    - *ref_8
     - *ref_23
-    - *ref_13
+    - *ref_14
     - *ref_30
     - *ref_31
-    - *ref_21
+    - *ref_22
     - *ref_24
     - !<!ObjectSchema> &ref_68
       type: object
@@ -1393,7 +1393,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_56
-                schema: *ref_22
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/storage/grouped.yaml
+++ b/modelerfour/test/scenarios/storage/grouped.yaml
@@ -10,7 +10,7 @@ schemas: !<!Schemas>
           name: boolean
           description: 'Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or invalid and cannot be used.'
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_20
+    - !<!BooleanSchema> &ref_21
       type: boolean
       language: !<!Languages> 
         default:
@@ -123,7 +123,7 @@ schemas: !<!Schemas>
           name: Resource-location
           description: Resource location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -133,7 +133,7 @@ schemas: !<!Schemas>
           name: Endpoints-blob
           description: Gets the blob endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -143,7 +143,7 @@ schemas: !<!Schemas>
           name: Endpoints-queue
           description: Gets the queue endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -153,7 +153,7 @@ schemas: !<!Schemas>
           name: Endpoints-table
           description: Gets the table endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -163,7 +163,7 @@ schemas: !<!Schemas>
           name: StorageAccountProperties-primaryLocation
           description: Gets the location of the primary for the storage account.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -173,7 +173,7 @@ schemas: !<!Schemas>
           name: StorageAccountProperties-secondaryLocation
           description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_20
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -258,7 +258,7 @@ schemas: !<!Schemas>
           name: Reason
           description: Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_8
+    - !<!SealedChoiceSchema> &ref_10
       choices:
         - !<!ChoiceValue> 
           value: Standard_LRS
@@ -330,7 +330,7 @@ schemas: !<!Schemas>
           name: ProvisioningState
           description: Gets the status of the storage account at the time the operation was called.
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_15
+    - !<!SealedChoiceSchema> &ref_16
       choices:
         - !<!ChoiceValue> 
           value: Available
@@ -448,7 +448,7 @@ schemas: !<!Schemas>
           description: Resource tags
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_16
+    - !<!DateTimeSchema> &ref_17
       type: date-time
       format: date-time
       apiVersions:
@@ -461,7 +461,7 @@ schemas: !<!Schemas>
             Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the
             accountType is StandardGRS or StandardRAGRS.
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_18
+    - !<!DateTimeSchema> &ref_19
       type: date-time
       format: date-time
       apiVersions:
@@ -552,134 +552,126 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_22
+          - !<!ObjectSchema> &ref_8
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_7
-              immediate:
-                - *ref_7
-            properties:
-              - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
-                language: !<!Languages> 
-                  default:
-                    name: accountType
-                    description: Gets or sets the account type.
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - input
-              - output
-            language: !<!Languages> 
-              default:
-                name: StorageAccountCreateParameters
-                description: The parameters to provide for the account.
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_23
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 2015-05-01-preview
-            parents: !<!Relations> 
-              all:
-                - *ref_7
-              immediate:
-                - *ref_7
-            properties:
-              - !<!Property> 
-                schema: *ref_9
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
-                language: !<!Languages> 
-                  default:
-                    name: provisioningState
-                    description: Gets the status of the storage account at the time the operation was called.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
-                language: !<!Languages> 
-                  default:
-                    name: accountType
-                    description: Gets the type of the storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_13
+                - !<!ObjectSchema> &ref_23
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                  parents: !<!Relations> 
+                    all:
+                      - *ref_8
+                    immediate:
+                      - *ref_8
                   properties:
                     - !<!Property> 
+                      schema: *ref_9
+                      flattenedNames:
+                        - properties
+                        - provisioningState
+                      serializedName: provisioningState
+                      language: !<!Languages> 
+                        default:
+                          name: provisioningState
+                          description: Gets the status of the storage account at the time the operation was called.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
                       schema: *ref_10
-                      serializedName: blob
+                      flattenedNames:
+                        - properties
+                        - accountType
+                      serializedName: accountType
                       language: !<!Languages> 
                         default:
-                          name: blob
-                          description: Gets the blob endpoint.
+                          name: accountType
+                          description: Gets the type of the storage account.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_11
-                      serializedName: queue
-                      language: !<!Languages> 
-                        default:
-                          name: queue
-                          description: Gets the queue endpoint.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_12
-                      serializedName: table
-                      language: !<!Languages> 
-                        default:
-                          name: table
-                          description: Gets the table endpoint.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_13
-                      serializedName: dummyEndPoint
-                      language: !<!Languages> 
-                        default:
-                          name: dummyEndPoint
-                          description: Dummy EndPoint
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_30
+                      schema: !<!ObjectSchema> &ref_14
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 2015-05-01-preview
                         properties:
                           - !<!Property> 
-                            schema: !<!ObjectSchema> &ref_31
+                            schema: *ref_11
+                            serializedName: blob
+                            language: !<!Languages> 
+                              default:
+                                name: blob
+                                description: Gets the blob endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_12
+                            serializedName: queue
+                            language: !<!Languages> 
+                              default:
+                                name: queue
+                                description: Gets the queue endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_13
+                            serializedName: table
+                            language: !<!Languages> 
+                              default:
+                                name: table
+                                description: Gets the table endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_14
+                            serializedName: dummyEndPoint
+                            language: !<!Languages> 
+                              default:
+                                name: dummyEndPoint
+                                description: Dummy EndPoint
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ObjectSchema> &ref_30
                               type: object
                               apiVersions:
                                 - !<!ApiVersion> 
                                   version: 2015-05-01-preview
                               properties:
                                 - !<!Property> 
-                                  schema: *ref_13
-                                  serializedName: RecursivePoint
+                                  schema: !<!ObjectSchema> &ref_31
+                                    type: object
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 2015-05-01-preview
+                                    properties:
+                                      - !<!Property> 
+                                        schema: *ref_14
+                                        serializedName: RecursivePoint
+                                        language: !<!Languages> 
+                                          default:
+                                            name: RecursivePoint
+                                            description: Recursive Endpoints
+                                        protocol: !<!Protocols> {}
+                                    serializationFormats:
+                                      - json
+                                    usage:
+                                      - input
+                                      - output
+                                    language: !<!Languages> 
+                                      default:
+                                        name: Bar
+                                        description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
+                                        namespace: ''
+                                    protocol: !<!Protocols> {}
+                                  serializedName: Bar.Point
                                   language: !<!Languages> 
                                     default:
-                                      name: RecursivePoint
-                                      description: Recursive Endpoints
+                                      name: Bar.Point
+                                      description: Bar point
                                   protocol: !<!Protocols> {}
                               serializationFormats:
                                 - json
@@ -688,15 +680,15 @@ schemas: !<!Schemas>
                                 - output
                               language: !<!Languages> 
                                 default:
-                                  name: Bar
+                                  name: Foo
                                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                                   namespace: ''
                               protocol: !<!Protocols> {}
-                            serializedName: Bar.Point
+                            serializedName: FooPoint
                             language: !<!Languages> 
                               default:
-                                name: Bar.Point
-                                description: Bar point
+                                name: FooPoint
+                                description: Foo point
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -705,126 +697,186 @@ schemas: !<!Schemas>
                           - output
                         language: !<!Languages> 
                           default:
-                            name: Foo
+                            name: Endpoints
                             description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: FooPoint
+                      flattenedNames:
+                        - properties
+                        - primaryEndpoints
+                      serializedName: primaryEndpoints
                       language: !<!Languages> 
                         default:
-                          name: FooPoint
-                          description: Foo point
+                          name: primaryEndpoints
+                          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_15
+                      flattenedNames:
+                        - properties
+                        - primaryLocation
+                      serializedName: primaryLocation
+                      language: !<!Languages> 
+                        default:
+                          name: primaryLocation
+                          description: Gets the location of the primary for the storage account.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_16
+                      flattenedNames:
+                        - properties
+                        - statusOfPrimary
+                      serializedName: statusOfPrimary
+                      language: !<!Languages> 
+                        default:
+                          name: statusOfPrimary
+                          description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_17
+                      flattenedNames:
+                        - properties
+                        - lastGeoFailoverTime
+                      serializedName: lastGeoFailoverTime
+                      language: !<!Languages> 
+                        default:
+                          name: lastGeoFailoverTime
+                          description: >-
+                            Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only
+                            available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_18
+                      flattenedNames:
+                        - properties
+                        - secondaryLocation
+                      serializedName: secondaryLocation
+                      language: !<!Languages> 
+                        default:
+                          name: secondaryLocation
+                          description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_16
+                      flattenedNames:
+                        - properties
+                        - statusOfSecondary
+                      serializedName: statusOfSecondary
+                      language: !<!Languages> 
+                        default:
+                          name: statusOfSecondary
+                          description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_19
+                      flattenedNames:
+                        - properties
+                        - creationTime
+                      serializedName: creationTime
+                      language: !<!Languages> 
+                        default:
+                          name: creationTime
+                          description: Gets the creation date and time of the storage account in UTC.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_22
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 2015-05-01-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_20
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: Gets or sets the custom domain name. Name is the CNAME source.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_21
+                            serializedName: useSubDomain
+                            language: !<!Languages> 
+                              default:
+                                name: useSubDomain
+                                description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - input
+                          - output
+                        language: !<!Languages> 
+                          default:
+                            name: CustomDomain
+                            description: The custom domain assigned to this storage account. This can be set via Update.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      flattenedNames:
+                        - properties
+                        - customDomain
+                      serializedName: customDomain
+                      language: !<!Languages> 
+                        default:
+                          name: customDomain
+                          description: Gets the user assigned custom domain assigned to this storage account.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_14
+                      flattenedNames:
+                        - properties
+                        - secondaryEndpoints
+                      serializedName: secondaryEndpoints
+                      language: !<!Languages> 
+                        default:
+                          name: secondaryEndpoints
+                          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
                   usage:
-                    - input
                     - output
+                    - input
                   language: !<!Languages> 
                     default:
-                      name: Endpoints
-                      description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
+                      name: StorageAccount
+                      description: The storage account.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                flattenedNames:
-                  - properties
-                  - primaryEndpoints
-                serializedName: primaryEndpoints
-                language: !<!Languages> 
-                  default:
-                    name: primaryEndpoints
-                    description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_14
-                flattenedNames:
-                  - properties
-                  - primaryLocation
-                serializedName: primaryLocation
-                language: !<!Languages> 
-                  default:
-                    name: primaryLocation
-                    description: Gets the location of the primary for the storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_15
-                flattenedNames:
-                  - properties
-                  - statusOfPrimary
-                serializedName: statusOfPrimary
-                language: !<!Languages> 
-                  default:
-                    name: statusOfPrimary
-                    description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_16
-                flattenedNames:
-                  - properties
-                  - lastGeoFailoverTime
-                serializedName: lastGeoFailoverTime
-                language: !<!Languages> 
-                  default:
-                    name: lastGeoFailoverTime
-                    description: >-
-                      Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only
-                      available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_17
-                flattenedNames:
-                  - properties
-                  - secondaryLocation
-                serializedName: secondaryLocation
-                language: !<!Languages> 
-                  default:
-                    name: secondaryLocation
-                    description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_15
-                flattenedNames:
-                  - properties
-                  - statusOfSecondary
-                serializedName: statusOfSecondary
-                language: !<!Languages> 
-                  default:
-                    name: statusOfSecondary
-                    description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_18
-                flattenedNames:
-                  - properties
-                  - creationTime
-                serializedName: creationTime
-                language: !<!Languages> 
-                  default:
-                    name: creationTime
-                    description: Gets the creation date and time of the storage account in UTC.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_21
+                - !<!ObjectSchema> &ref_24
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                  parents: !<!Relations> 
+                    all:
+                      - *ref_8
+                    immediate:
+                      - *ref_8
                   properties:
                     - !<!Property> 
-                      schema: *ref_19
-                      serializedName: name
+                      schema: *ref_10
+                      flattenedNames:
+                        - properties
+                        - accountType
+                      serializedName: accountType
                       language: !<!Languages> 
                         default:
-                          name: name
-                          description: Gets or sets the custom domain name. Name is the CNAME source.
+                          name: accountType
+                          description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_20
-                      serializedName: useSubDomain
+                      schema: *ref_22
+                      flattenedNames:
+                        - properties
+                        - customDomain
+                      serializedName: customDomain
                       language: !<!Languages> 
                         default:
-                          name: useSubDomain
-                          description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+                          name: customDomain
+                          description: >-
+                            User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom
+                            domain name property.
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
@@ -833,159 +885,107 @@ schemas: !<!Schemas>
                     - output
                   language: !<!Languages> 
                     default:
-                      name: CustomDomain
-                      description: The custom domain assigned to this storage account. This can be set via Update.
+                      name: StorageAccountUpdateParameters
+                      description: The parameters to update on the account.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                flattenedNames:
-                  - properties
-                  - customDomain
-                serializedName: customDomain
-                language: !<!Languages> 
-                  default:
-                    name: customDomain
-                    description: Gets the user assigned custom domain assigned to this storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_13
-                flattenedNames:
-                  - properties
-                  - secondaryEndpoints
-                serializedName: secondaryEndpoints
-                language: !<!Languages> 
-                  default:
-                    name: secondaryEndpoints
-                    description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: StorageAccount
-                description: The storage account.
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_24
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 2015-05-01-preview
-            parents: !<!Relations> 
-              all:
-                - *ref_7
               immediate:
                 - *ref_7
+                - *ref_23
+                - *ref_24
             properties:
               - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
+                schema: *ref_25
+                readOnly: true
+                required: false
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: accountType
-                    description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
+                    name: id
+                    description: Resource Id
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_21
-                flattenedNames:
-                  - properties
-                  - customDomain
-                serializedName: customDomain
+                schema: *ref_26
+                readOnly: true
+                required: false
+                serializedName: name
                 language: !<!Languages> 
                   default:
-                    name: customDomain
-                    description: >-
-                      User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom
-                      domain name property.
+                    name: name
+                    description: Resource name
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_27
+                readOnly: true
+                required: false
+                serializedName: type
+                language: !<!Languages> 
+                  default:
+                    name: type
+                    description: Resource type
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_28
+                required: true
+                serializedName: location
+                language: !<!Languages> 
+                  default:
+                    name: location
+                    description: Resource location
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_29
+                required: false
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Resource tags
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: StorageAccountUpdateParameters
-                description: The parameters to update on the account.
+                name: Resource
+                description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_22
-          - *ref_23
-          - *ref_24
+          - *ref_8
       properties:
         - !<!Property> 
-          schema: *ref_25
-          readOnly: true
-          required: false
-          serializedName: id
+          schema: *ref_10
+          flattenedNames:
+            - properties
+            - accountType
+          serializedName: accountType
           language: !<!Languages> 
             default:
-              name: id
-              description: Resource Id
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_26
-          readOnly: true
-          required: false
-          serializedName: name
-          language: !<!Languages> 
-            default:
-              name: name
-              description: Resource name
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_27
-          readOnly: true
-          required: false
-          serializedName: type
-          language: !<!Languages> 
-            default:
-              name: type
-              description: Resource type
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_28
-          required: true
-          serializedName: location
-          language: !<!Languages> 
-            default:
-              name: location
-              description: Resource location
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_29
-          required: false
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Resource tags
+              name: accountType
+              description: Gets or sets the account type.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: Resource
-          description: ''
+          name: StorageAccountCreateParameters
+          description: The parameters to provide for the account.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_22
+    - *ref_8
     - *ref_23
-    - *ref_13
+    - *ref_14
     - *ref_30
     - *ref_31
-    - *ref_21
+    - *ref_22
     - *ref_24
     - !<!ObjectSchema> &ref_68
       type: object
@@ -1393,7 +1393,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_56
-                schema: *ref_22
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/storage/modeler.yaml
+++ b/modelerfour/test/scenarios/storage/modeler.yaml
@@ -552,158 +552,127 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_20
+          - !<!ObjectSchema> &ref_19
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_9
-              immediate:
-                - *ref_9
-            properties:
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_23
+                - !<!ObjectSchema> &ref_21
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                  parents: !<!Relations> 
+                    all:
+                      - *ref_19
+                    immediate:
+                      - *ref_19
                   properties:
                     - !<!Property> 
-                      schema: *ref_10
-                      serializedName: accountType
-                      language: !<!Languages> 
-                        default:
-                          name: accountType
-                          description: Gets or sets the account type.
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - input
-                    - output
-                  language: !<!Languages> 
-                    default:
-                      name: StorageAccountPropertiesCreateParameters
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: properties
-                extensions:
-                  x-ms-client-flatten: true
-                language: !<!Languages> 
-                  default:
-                    name: properties
-                    description: ''
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - input
-              - output
-            language: !<!Languages> 
-              default:
-                name: StorageAccountCreateParameters
-                description: The parameters to provide for the account.
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_21
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 2015-05-01-preview
-            parents: !<!Relations> 
-              all:
-                - *ref_9
-              immediate:
-                - *ref_9
-            properties:
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_24
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 2015-05-01-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_38
-                      serializedName: provisioningState
-                      language: !<!Languages> 
-                        default:
-                          name: provisioningState
-                          description: Gets the status of the storage account at the time the operation was called.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_10
-                      serializedName: accountType
-                      language: !<!Languages> 
-                        default:
-                          name: accountType
-                          description: Gets the type of the storage account.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_14
+                      schema: !<!ObjectSchema> &ref_24
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 2015-05-01-preview
                         properties:
                           - !<!Property> 
-                            schema: *ref_11
-                            serializedName: blob
+                            schema: *ref_38
+                            serializedName: provisioningState
                             language: !<!Languages> 
                               default:
-                                name: blob
-                                description: Gets the blob endpoint.
+                                name: provisioningState
+                                description: Gets the status of the storage account at the time the operation was called.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: *ref_12
-                            serializedName: queue
+                            schema: *ref_10
+                            serializedName: accountType
                             language: !<!Languages> 
                               default:
-                                name: queue
-                                description: Gets the queue endpoint.
+                                name: accountType
+                                description: Gets the type of the storage account.
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: *ref_13
-                            serializedName: table
-                            language: !<!Languages> 
-                              default:
-                                name: table
-                                description: Gets the table endpoint.
-                            protocol: !<!Protocols> {}
-                          - !<!Property> 
-                            schema: *ref_14
-                            serializedName: dummyEndPoint
-                            language: !<!Languages> 
-                              default:
-                                name: dummyEndPoint
-                                description: Dummy EndPoint
-                            protocol: !<!Protocols> {}
-                          - !<!Property> 
-                            schema: !<!ObjectSchema> &ref_25
+                            schema: !<!ObjectSchema> &ref_14
                               type: object
                               apiVersions:
                                 - !<!ApiVersion> 
                                   version: 2015-05-01-preview
                               properties:
                                 - !<!Property> 
-                                  schema: !<!ObjectSchema> &ref_26
+                                  schema: *ref_11
+                                  serializedName: blob
+                                  language: !<!Languages> 
+                                    default:
+                                      name: blob
+                                      description: Gets the blob endpoint.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: *ref_12
+                                  serializedName: queue
+                                  language: !<!Languages> 
+                                    default:
+                                      name: queue
+                                      description: Gets the queue endpoint.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: *ref_13
+                                  serializedName: table
+                                  language: !<!Languages> 
+                                    default:
+                                      name: table
+                                      description: Gets the table endpoint.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: *ref_14
+                                  serializedName: dummyEndPoint
+                                  language: !<!Languages> 
+                                    default:
+                                      name: dummyEndPoint
+                                      description: Dummy EndPoint
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: !<!ObjectSchema> &ref_25
                                     type: object
                                     apiVersions:
                                       - !<!ApiVersion> 
                                         version: 2015-05-01-preview
                                     properties:
                                       - !<!Property> 
-                                        schema: *ref_14
-                                        serializedName: RecursivePoint
+                                        schema: !<!ObjectSchema> &ref_26
+                                          type: object
+                                          apiVersions:
+                                            - !<!ApiVersion> 
+                                              version: 2015-05-01-preview
+                                          properties:
+                                            - !<!Property> 
+                                              schema: *ref_14
+                                              serializedName: RecursivePoint
+                                              language: !<!Languages> 
+                                                default:
+                                                  name: RecursivePoint
+                                                  description: Recursive Endpoints
+                                              protocol: !<!Protocols> {}
+                                          serializationFormats:
+                                            - json
+                                          usage:
+                                            - input
+                                            - output
+                                          language: !<!Languages> 
+                                            default:
+                                              name: Bar
+                                              description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
+                                              namespace: ''
+                                          protocol: !<!Protocols> {}
+                                        serializedName: Bar.Point
                                         language: !<!Languages> 
                                           default:
-                                            name: RecursivePoint
-                                            description: Recursive Endpoints
+                                            name: Bar.Point
+                                            description: Bar point
                                         protocol: !<!Protocols> {}
                                     serializationFormats:
                                       - json
@@ -712,15 +681,15 @@ schemas: !<!Schemas>
                                       - output
                                     language: !<!Languages> 
                                       default:
-                                        name: Bar
+                                        name: Foo
                                         description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                                         namespace: ''
                                     protocol: !<!Protocols> {}
-                                  serializedName: Bar.Point
+                                  serializedName: FooPoint
                                   language: !<!Languages> 
                                     default:
-                                      name: Bar.Point
-                                      description: Bar point
+                                      name: FooPoint
+                                      description: Foo point
                                   protocol: !<!Protocols> {}
                               serializationFormats:
                                 - json
@@ -729,15 +698,113 @@ schemas: !<!Schemas>
                                 - output
                               language: !<!Languages> 
                                 default:
-                                  name: Foo
+                                  name: Endpoints
                                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                                   namespace: ''
                               protocol: !<!Protocols> {}
-                            serializedName: FooPoint
+                            serializedName: primaryEndpoints
                             language: !<!Languages> 
                               default:
-                                name: FooPoint
-                                description: Foo point
+                                name: primaryEndpoints
+                                description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_15
+                            serializedName: primaryLocation
+                            language: !<!Languages> 
+                              default:
+                                name: primaryLocation
+                                description: Gets the location of the primary for the storage account.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_17
+                            serializedName: statusOfPrimary
+                            language: !<!Languages> 
+                              default:
+                                name: statusOfPrimary
+                                description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_42
+                            serializedName: lastGeoFailoverTime
+                            language: !<!Languages> 
+                              default:
+                                name: lastGeoFailoverTime
+                                description: >-
+                                  Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance.
+                                  Only available if the accountType is StandardGRS or StandardRAGRS.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_16
+                            serializedName: secondaryLocation
+                            language: !<!Languages> 
+                              default:
+                                name: secondaryLocation
+                                description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_17
+                            serializedName: statusOfSecondary
+                            language: !<!Languages> 
+                              default:
+                                name: statusOfSecondary
+                                description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_43
+                            serializedName: creationTime
+                            language: !<!Languages> 
+                              default:
+                                name: creationTime
+                                description: Gets the creation date and time of the storage account in UTC.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ObjectSchema> &ref_20
+                              type: object
+                              apiVersions:
+                                - !<!ApiVersion> 
+                                  version: 2015-05-01-preview
+                              properties:
+                                - !<!Property> 
+                                  schema: *ref_18
+                                  serializedName: name
+                                  language: !<!Languages> 
+                                    default:
+                                      name: name
+                                      description: Gets or sets the custom domain name. Name is the CNAME source.
+                                  protocol: !<!Protocols> {}
+                                - !<!Property> 
+                                  schema: *ref_36
+                                  serializedName: useSubDomain
+                                  language: !<!Languages> 
+                                    default:
+                                      name: useSubDomain
+                                      description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+                                  protocol: !<!Protocols> {}
+                              serializationFormats:
+                                - json
+                              usage:
+                                - input
+                                - output
+                              language: !<!Languages> 
+                                default:
+                                  name: CustomDomain
+                                  description: The custom domain assigned to this storage account. This can be set via Update.
+                                  namespace: ''
+                              protocol: !<!Protocols> {}
+                            serializedName: customDomain
+                            language: !<!Languages> 
+                              default:
+                                name: customDomain
+                                description: Gets the user assigned custom domain assigned to this storage account.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_14
+                            serializedName: secondaryEndpoints
+                            language: !<!Languages> 
+                              default:
+                                name: secondaryEndpoints
+                                description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -746,88 +813,64 @@ schemas: !<!Schemas>
                           - output
                         language: !<!Languages> 
                           default:
-                            name: Endpoints
-                            description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
+                            name: StorageAccountProperties
+                            description: ''
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: primaryEndpoints
+                      serializedName: properties
+                      extensions:
+                        x-ms-client-flatten: true
                       language: !<!Languages> 
                         default:
-                          name: primaryEndpoints
-                          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
+                          name: properties
+                          description: ''
                       protocol: !<!Protocols> {}
+                  serializationFormats:
+                    - json
+                  usage:
+                    - output
+                    - input
+                  language: !<!Languages> 
+                    default:
+                      name: StorageAccount
+                      description: The storage account.
+                      namespace: ''
+                  protocol: !<!Protocols> {}
+                - !<!ObjectSchema> &ref_22
+                  type: object
+                  apiVersions:
+                    - !<!ApiVersion> 
+                      version: 2015-05-01-preview
+                  parents: !<!Relations> 
+                    all:
+                      - *ref_19
+                    immediate:
+                      - *ref_19
+                  properties:
                     - !<!Property> 
-                      schema: *ref_15
-                      serializedName: primaryLocation
-                      language: !<!Languages> 
-                        default:
-                          name: primaryLocation
-                          description: Gets the location of the primary for the storage account.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_17
-                      serializedName: statusOfPrimary
-                      language: !<!Languages> 
-                        default:
-                          name: statusOfPrimary
-                          description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_42
-                      serializedName: lastGeoFailoverTime
-                      language: !<!Languages> 
-                        default:
-                          name: lastGeoFailoverTime
-                          description: >-
-                            Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only
-                            available if the accountType is StandardGRS or StandardRAGRS.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_16
-                      serializedName: secondaryLocation
-                      language: !<!Languages> 
-                        default:
-                          name: secondaryLocation
-                          description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_17
-                      serializedName: statusOfSecondary
-                      language: !<!Languages> 
-                        default:
-                          name: statusOfSecondary
-                          description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_43
-                      serializedName: creationTime
-                      language: !<!Languages> 
-                        default:
-                          name: creationTime
-                          description: Gets the creation date and time of the storage account in UTC.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_19
+                      schema: !<!ObjectSchema> &ref_27
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 2015-05-01-preview
                         properties:
                           - !<!Property> 
-                            schema: *ref_18
-                            serializedName: name
+                            schema: *ref_10
+                            serializedName: accountType
                             language: !<!Languages> 
                               default:
-                                name: name
-                                description: Gets or sets the custom domain name. Name is the CNAME source.
+                                name: accountType
+                                description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
                             protocol: !<!Protocols> {}
                           - !<!Property> 
-                            schema: *ref_36
-                            serializedName: useSubDomain
+                            schema: *ref_20
+                            serializedName: customDomain
                             language: !<!Languages> 
                               default:
-                                name: useSubDomain
-                                description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+                                name: customDomain
+                                description: >-
+                                  User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the
+                                  custom domain name property.
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -836,23 +879,17 @@ schemas: !<!Schemas>
                           - output
                         language: !<!Languages> 
                           default:
-                            name: CustomDomain
-                            description: The custom domain assigned to this storage account. This can be set via Update.
+                            name: StorageAccountPropertiesUpdateParameters
+                            description: ''
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: customDomain
+                      serializedName: properties
+                      extensions:
+                        x-ms-client-flatten: true
                       language: !<!Languages> 
                         default:
-                          name: customDomain
-                          description: Gets the user assigned custom domain assigned to this storage account.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_14
-                      serializedName: secondaryEndpoints
-                      language: !<!Languages> 
-                        default:
-                          name: secondaryEndpoints
-                          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
+                          name: properties
+                          description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
@@ -861,83 +898,93 @@ schemas: !<!Schemas>
                     - output
                   language: !<!Languages> 
                     default:
-                      name: StorageAccountProperties
-                      description: ''
+                      name: StorageAccountUpdateParameters
+                      description: The parameters to update on the account.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                serializedName: properties
-                extensions:
-                  x-ms-client-flatten: true
+              immediate:
+                - *ref_9
+                - *ref_21
+                - *ref_22
+            properties:
+              - !<!Property> 
+                schema: *ref_4
+                readOnly: true
+                required: false
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: properties
-                    description: ''
+                    name: id
+                    description: Resource Id
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_5
+                readOnly: true
+                required: false
+                serializedName: name
+                language: !<!Languages> 
+                  default:
+                    name: name
+                    description: Resource name
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_6
+                readOnly: true
+                required: false
+                serializedName: type
+                language: !<!Languages> 
+                  default:
+                    name: type
+                    description: Resource type
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_7
+                required: true
+                serializedName: location
+                language: !<!Languages> 
+                  default:
+                    name: location
+                    description: Resource location
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_41
+                required: false
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Resource tags
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
-              - output
               - input
+              - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: StorageAccount
-                description: The storage account.
+                name: Resource
+                description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_22
+        immediate:
+          - *ref_19
+      properties:
+        - !<!Property> 
+          schema: !<!ObjectSchema> &ref_23
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-            parents: !<!Relations> 
-              all:
-                - *ref_9
-              immediate:
-                - *ref_9
             properties:
               - !<!Property> 
-                schema: !<!ObjectSchema> &ref_27
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 2015-05-01-preview
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_10
-                      serializedName: accountType
-                      language: !<!Languages> 
-                        default:
-                          name: accountType
-                          description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_19
-                      serializedName: customDomain
-                      language: !<!Languages> 
-                        default:
-                          name: customDomain
-                          description: >-
-                            User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom
-                            domain name property.
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - input
-                    - output
-                  language: !<!Languages> 
-                    default:
-                      name: StorageAccountPropertiesUpdateParameters
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                serializedName: properties
-                extensions:
-                  x-ms-client-flatten: true
+                schema: *ref_10
+                serializedName: accountType
                 language: !<!Languages> 
                   default:
-                    name: properties
-                    description: ''
+                    name: accountType
+                    description: Gets or sets the account type.
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -946,84 +993,37 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: StorageAccountUpdateParameters
-                description: The parameters to update on the account.
+                name: StorageAccountPropertiesCreateParameters
+                description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-        immediate:
-          - *ref_20
-          - *ref_21
-          - *ref_22
-      properties:
-        - !<!Property> 
-          schema: *ref_4
-          readOnly: true
-          required: false
-          serializedName: id
+          serializedName: properties
+          extensions:
+            x-ms-client-flatten: true
           language: !<!Languages> 
             default:
-              name: id
-              description: Resource Id
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_5
-          readOnly: true
-          required: false
-          serializedName: name
-          language: !<!Languages> 
-            default:
-              name: name
-              description: Resource name
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_6
-          readOnly: true
-          required: false
-          serializedName: type
-          language: !<!Languages> 
-            default:
-              name: type
-              description: Resource type
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_7
-          required: true
-          serializedName: location
-          language: !<!Languages> 
-            default:
-              name: location
-              description: Resource location
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_41
-          required: false
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Resource tags
+              name: properties
+              description: ''
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: Resource
-          description: ''
+          name: StorageAccountCreateParameters
+          description: The parameters to provide for the account.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_20
     - *ref_23
+    - *ref_19
     - *ref_21
     - *ref_24
     - *ref_14
     - *ref_25
     - *ref_26
-    - *ref_19
+    - *ref_20
     - *ref_22
     - *ref_27
     - !<!ObjectSchema> &ref_67
@@ -1406,7 +1406,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_57
-                schema: *ref_20
+                schema: *ref_9
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -10,7 +10,7 @@ schemas: !<!Schemas>
           name: Boolean
           description: 'Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or invalid and cannot be used.'
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_20
+    - !<!BooleanSchema> &ref_21
       type: boolean
       language: !<!Languages> 
         default:
@@ -123,7 +123,7 @@ schemas: !<!Schemas>
           name: ResourceLocation
           description: Resource location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -133,7 +133,7 @@ schemas: !<!Schemas>
           name: EndpointsBlob
           description: Gets the blob endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -143,7 +143,7 @@ schemas: !<!Schemas>
           name: EndpointsQueue
           description: Gets the queue endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -153,7 +153,7 @@ schemas: !<!Schemas>
           name: EndpointsTable
           description: Gets the table endpoint.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -163,7 +163,7 @@ schemas: !<!Schemas>
           name: StorageAccountPropertiesPrimaryLocation
           description: Gets the location of the primary for the storage account.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -173,7 +173,7 @@ schemas: !<!Schemas>
           name: StorageAccountPropertiesSecondaryLocation
           description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_20
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -258,7 +258,7 @@ schemas: !<!Schemas>
           name: Reason
           description: Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_8
+    - !<!SealedChoiceSchema> &ref_10
       choices:
         - !<!ChoiceValue> 
           value: Standard_LRS
@@ -330,7 +330,7 @@ schemas: !<!Schemas>
           name: ProvisioningState
           description: Gets the status of the storage account at the time the operation was called.
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_15
+    - !<!SealedChoiceSchema> &ref_16
       choices:
         - !<!ChoiceValue> 
           value: Available
@@ -448,7 +448,7 @@ schemas: !<!Schemas>
           description: Resource tags
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_16
+    - !<!DateTimeSchema> &ref_17
       type: date-time
       format: date-time
       apiVersions:
@@ -461,7 +461,7 @@ schemas: !<!Schemas>
             Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the
             accountType is StandardGRS or StandardRAGRS.
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_18
+    - !<!DateTimeSchema> &ref_19
       type: date-time
       format: date-time
       apiVersions:
@@ -552,134 +552,126 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_22
+          - !<!ObjectSchema> &ref_8
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 2015-05-01-preview
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_7
-              immediate:
-                - *ref_7
-            properties:
-              - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
-                language: !<!Languages> 
-                  default:
-                    name: accountType
-                    description: Gets or sets the account type.
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - input
-              - output
-            language: !<!Languages> 
-              default:
-                name: StorageAccountCreateParameters
-                description: The parameters to provide for the account.
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_23
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 2015-05-01-preview
-            parents: !<!Relations> 
-              all:
-                - *ref_7
-              immediate:
-                - *ref_7
-            properties:
-              - !<!Property> 
-                schema: *ref_9
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
-                language: !<!Languages> 
-                  default:
-                    name: provisioningState
-                    description: Gets the status of the storage account at the time the operation was called.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
-                language: !<!Languages> 
-                  default:
-                    name: accountType
-                    description: Gets the type of the storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_13
+                - !<!ObjectSchema> &ref_23
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                  parents: !<!Relations> 
+                    all:
+                      - *ref_8
+                    immediate:
+                      - *ref_8
                   properties:
                     - !<!Property> 
+                      schema: *ref_9
+                      flattenedNames:
+                        - properties
+                        - provisioningState
+                      serializedName: provisioningState
+                      language: !<!Languages> 
+                        default:
+                          name: provisioningState
+                          description: Gets the status of the storage account at the time the operation was called.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
                       schema: *ref_10
-                      serializedName: blob
+                      flattenedNames:
+                        - properties
+                        - accountType
+                      serializedName: accountType
                       language: !<!Languages> 
                         default:
-                          name: blob
-                          description: Gets the blob endpoint.
+                          name: accountType
+                          description: Gets the type of the storage account.
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_11
-                      serializedName: queue
-                      language: !<!Languages> 
-                        default:
-                          name: queue
-                          description: Gets the queue endpoint.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_12
-                      serializedName: table
-                      language: !<!Languages> 
-                        default:
-                          name: table
-                          description: Gets the table endpoint.
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: *ref_13
-                      serializedName: dummyEndPoint
-                      language: !<!Languages> 
-                        default:
-                          name: dummyEndPoint
-                          description: Dummy EndPoint
-                      protocol: !<!Protocols> {}
-                    - !<!Property> 
-                      schema: !<!ObjectSchema> &ref_30
+                      schema: !<!ObjectSchema> &ref_14
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
                             version: 2015-05-01-preview
                         properties:
                           - !<!Property> 
-                            schema: !<!ObjectSchema> &ref_31
+                            schema: *ref_11
+                            serializedName: blob
+                            language: !<!Languages> 
+                              default:
+                                name: blob
+                                description: Gets the blob endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_12
+                            serializedName: queue
+                            language: !<!Languages> 
+                              default:
+                                name: queue
+                                description: Gets the queue endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_13
+                            serializedName: table
+                            language: !<!Languages> 
+                              default:
+                                name: table
+                                description: Gets the table endpoint.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_14
+                            serializedName: dummyEndPoint
+                            language: !<!Languages> 
+                              default:
+                                name: dummyEndPoint
+                                description: Dummy EndPoint
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: !<!ObjectSchema> &ref_30
                               type: object
                               apiVersions:
                                 - !<!ApiVersion> 
                                   version: 2015-05-01-preview
                               properties:
                                 - !<!Property> 
-                                  schema: *ref_13
-                                  serializedName: RecursivePoint
+                                  schema: !<!ObjectSchema> &ref_31
+                                    type: object
+                                    apiVersions:
+                                      - !<!ApiVersion> 
+                                        version: 2015-05-01-preview
+                                    properties:
+                                      - !<!Property> 
+                                        schema: *ref_14
+                                        serializedName: RecursivePoint
+                                        language: !<!Languages> 
+                                          default:
+                                            name: recursivePoint
+                                            description: Recursive Endpoints
+                                        protocol: !<!Protocols> {}
+                                    serializationFormats:
+                                      - json
+                                    usage:
+                                      - input
+                                      - output
+                                    language: !<!Languages> 
+                                      default:
+                                        name: Bar
+                                        description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
+                                        namespace: ''
+                                    protocol: !<!Protocols> {}
+                                  serializedName: Bar.Point
                                   language: !<!Languages> 
                                     default:
-                                      name: recursivePoint
-                                      description: Recursive Endpoints
+                                      name: barPoint
+                                      description: Bar point
                                   protocol: !<!Protocols> {}
                               serializationFormats:
                                 - json
@@ -688,15 +680,15 @@ schemas: !<!Schemas>
                                 - output
                               language: !<!Languages> 
                                 default:
-                                  name: Bar
+                                  name: Foo
                                   description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                                   namespace: ''
                               protocol: !<!Protocols> {}
-                            serializedName: Bar.Point
+                            serializedName: FooPoint
                             language: !<!Languages> 
                               default:
-                                name: barPoint
-                                description: Bar point
+                                name: fooPoint
+                                description: Foo point
                             protocol: !<!Protocols> {}
                         serializationFormats:
                           - json
@@ -705,126 +697,186 @@ schemas: !<!Schemas>
                           - output
                         language: !<!Languages> 
                           default:
-                            name: Foo
+                            name: Endpoints
                             description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
                             namespace: ''
                         protocol: !<!Protocols> {}
-                      serializedName: FooPoint
+                      flattenedNames:
+                        - properties
+                        - primaryEndpoints
+                      serializedName: primaryEndpoints
                       language: !<!Languages> 
                         default:
-                          name: fooPoint
-                          description: Foo point
+                          name: primaryEndpoints
+                          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_15
+                      flattenedNames:
+                        - properties
+                        - primaryLocation
+                      serializedName: primaryLocation
+                      language: !<!Languages> 
+                        default:
+                          name: primaryLocation
+                          description: Gets the location of the primary for the storage account.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_16
+                      flattenedNames:
+                        - properties
+                        - statusOfPrimary
+                      serializedName: statusOfPrimary
+                      language: !<!Languages> 
+                        default:
+                          name: statusOfPrimary
+                          description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_17
+                      flattenedNames:
+                        - properties
+                        - lastGeoFailoverTime
+                      serializedName: lastGeoFailoverTime
+                      language: !<!Languages> 
+                        default:
+                          name: lastGeoFailoverTime
+                          description: >-
+                            Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only
+                            available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_18
+                      flattenedNames:
+                        - properties
+                        - secondaryLocation
+                      serializedName: secondaryLocation
+                      language: !<!Languages> 
+                        default:
+                          name: secondaryLocation
+                          description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_16
+                      flattenedNames:
+                        - properties
+                        - statusOfSecondary
+                      serializedName: statusOfSecondary
+                      language: !<!Languages> 
+                        default:
+                          name: statusOfSecondary
+                          description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_19
+                      flattenedNames:
+                        - properties
+                        - creationTime
+                      serializedName: creationTime
+                      language: !<!Languages> 
+                        default:
+                          name: creationTime
+                          description: Gets the creation date and time of the storage account in UTC.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: !<!ObjectSchema> &ref_22
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 2015-05-01-preview
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_20
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: Gets or sets the custom domain name. Name is the CNAME source.
+                            protocol: !<!Protocols> {}
+                          - !<!Property> 
+                            schema: *ref_21
+                            serializedName: useSubDomain
+                            language: !<!Languages> 
+                              default:
+                                name: useSubDomain
+                                description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - input
+                          - output
+                        language: !<!Languages> 
+                          default:
+                            name: CustomDomain
+                            description: The custom domain assigned to this storage account. This can be set via Update.
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                      flattenedNames:
+                        - properties
+                        - customDomain
+                      serializedName: customDomain
+                      language: !<!Languages> 
+                        default:
+                          name: customDomain
+                          description: Gets the user assigned custom domain assigned to this storage account.
+                      protocol: !<!Protocols> {}
+                    - !<!Property> 
+                      schema: *ref_14
+                      flattenedNames:
+                        - properties
+                        - secondaryEndpoints
+                      serializedName: secondaryEndpoints
+                      language: !<!Languages> 
+                        default:
+                          name: secondaryEndpoints
+                          description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
                   usage:
-                    - input
                     - output
+                    - input
                   language: !<!Languages> 
                     default:
-                      name: Endpoints
-                      description: 'The URIs that are used to perform a retrieval of a public blob, queue or table object.'
+                      name: StorageAccount
+                      description: The storage account.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                flattenedNames:
-                  - properties
-                  - primaryEndpoints
-                serializedName: primaryEndpoints
-                language: !<!Languages> 
-                  default:
-                    name: primaryEndpoints
-                    description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.'
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_14
-                flattenedNames:
-                  - properties
-                  - primaryLocation
-                serializedName: primaryLocation
-                language: !<!Languages> 
-                  default:
-                    name: primaryLocation
-                    description: Gets the location of the primary for the storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_15
-                flattenedNames:
-                  - properties
-                  - statusOfPrimary
-                serializedName: statusOfPrimary
-                language: !<!Languages> 
-                  default:
-                    name: statusOfPrimary
-                    description: Gets the status indicating whether the primary location of the storage account is available or unavailable.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_16
-                flattenedNames:
-                  - properties
-                  - lastGeoFailoverTime
-                serializedName: lastGeoFailoverTime
-                language: !<!Languages> 
-                  default:
-                    name: lastGeoFailoverTime
-                    description: >-
-                      Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only
-                      available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_17
-                flattenedNames:
-                  - properties
-                  - secondaryLocation
-                serializedName: secondaryLocation
-                language: !<!Languages> 
-                  default:
-                    name: secondaryLocation
-                    description: Gets the location of the geo replicated secondary for the storage account. Only available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_15
-                flattenedNames:
-                  - properties
-                  - statusOfSecondary
-                serializedName: statusOfSecondary
-                language: !<!Languages> 
-                  default:
-                    name: statusOfSecondary
-                    description: Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_18
-                flattenedNames:
-                  - properties
-                  - creationTime
-                serializedName: creationTime
-                language: !<!Languages> 
-                  default:
-                    name: creationTime
-                    description: Gets the creation date and time of the storage account in UTC.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: !<!ObjectSchema> &ref_21
+                - !<!ObjectSchema> &ref_24
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 2015-05-01-preview
+                  parents: !<!Relations> 
+                    all:
+                      - *ref_8
+                    immediate:
+                      - *ref_8
                   properties:
                     - !<!Property> 
-                      schema: *ref_19
-                      serializedName: name
+                      schema: *ref_10
+                      flattenedNames:
+                        - properties
+                        - accountType
+                      serializedName: accountType
                       language: !<!Languages> 
                         default:
-                          name: name
-                          description: Gets or sets the custom domain name. Name is the CNAME source.
+                          name: accountType
+                          description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_20
-                      serializedName: useSubDomain
+                      schema: *ref_22
+                      flattenedNames:
+                        - properties
+                        - customDomain
+                      serializedName: customDomain
                       language: !<!Languages> 
                         default:
-                          name: useSubDomain
-                          description: Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+                          name: customDomain
+                          description: >-
+                            User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom
+                            domain name property.
                       protocol: !<!Protocols> {}
                   serializationFormats:
                     - json
@@ -833,159 +885,107 @@ schemas: !<!Schemas>
                     - output
                   language: !<!Languages> 
                     default:
-                      name: CustomDomain
-                      description: The custom domain assigned to this storage account. This can be set via Update.
+                      name: StorageAccountUpdateParameters
+                      description: The parameters to update on the account.
                       namespace: ''
                   protocol: !<!Protocols> {}
-                flattenedNames:
-                  - properties
-                  - customDomain
-                serializedName: customDomain
-                language: !<!Languages> 
-                  default:
-                    name: customDomain
-                    description: Gets the user assigned custom domain assigned to this storage account.
-                protocol: !<!Protocols> {}
-              - !<!Property> 
-                schema: *ref_13
-                flattenedNames:
-                  - properties
-                  - secondaryEndpoints
-                serializedName: secondaryEndpoints
-                language: !<!Languages> 
-                  default:
-                    name: secondaryEndpoints
-                    description: 'Gets the URLs that are used to perform a retrieval of a public blob, queue or table object from the secondary location of the storage account. Only available if the accountType is StandardRAGRS.'
-                protocol: !<!Protocols> {}
-            serializationFormats:
-              - json
-            usage:
-              - output
-              - input
-            language: !<!Languages> 
-              default:
-                name: StorageAccount
-                description: The storage account.
-                namespace: ''
-            protocol: !<!Protocols> {}
-          - !<!ObjectSchema> &ref_24
-            type: object
-            apiVersions:
-              - !<!ApiVersion> 
-                version: 2015-05-01-preview
-            parents: !<!Relations> 
-              all:
-                - *ref_7
               immediate:
                 - *ref_7
+                - *ref_23
+                - *ref_24
             properties:
               - !<!Property> 
-                schema: *ref_8
-                flattenedNames:
-                  - properties
-                  - accountType
-                serializedName: accountType
+                schema: *ref_25
+                readOnly: true
+                required: false
+                serializedName: id
                 language: !<!Languages> 
                   default:
-                    name: accountType
-                    description: 'Gets or sets the account type. Note that StandardZRS and PremiumLRS accounts cannot be changed to other account types, and other account types cannot be changed to StandardZRS or PremiumLRS.'
+                    name: id
+                    description: Resource Id
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_21
-                flattenedNames:
-                  - properties
-                  - customDomain
-                serializedName: customDomain
+                schema: *ref_26
+                readOnly: true
+                required: false
+                serializedName: name
                 language: !<!Languages> 
                   default:
-                    name: customDomain
-                    description: >-
-                      User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom
-                      domain name property.
+                    name: name
+                    description: Resource name
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_27
+                readOnly: true
+                required: false
+                serializedName: type
+                language: !<!Languages> 
+                  default:
+                    name: type
+                    description: Resource type
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_28
+                required: true
+                serializedName: location
+                language: !<!Languages> 
+                  default:
+                    name: location
+                    description: Resource location
+                protocol: !<!Protocols> {}
+              - !<!Property> 
+                schema: *ref_29
+                required: false
+                serializedName: tags
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Resource tags
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
             usage:
               - input
               - output
+            extensions:
+              x-ms-azure-resource: true
             language: !<!Languages> 
               default:
-                name: StorageAccountUpdateParameters
-                description: The parameters to update on the account.
+                name: Resource
+                description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_22
-          - *ref_23
-          - *ref_24
+          - *ref_8
       properties:
         - !<!Property> 
-          schema: *ref_25
-          readOnly: true
-          required: false
-          serializedName: id
+          schema: *ref_10
+          flattenedNames:
+            - properties
+            - accountType
+          serializedName: accountType
           language: !<!Languages> 
             default:
-              name: id
-              description: Resource Id
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_26
-          readOnly: true
-          required: false
-          serializedName: name
-          language: !<!Languages> 
-            default:
-              name: name
-              description: Resource name
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_27
-          readOnly: true
-          required: false
-          serializedName: type
-          language: !<!Languages> 
-            default:
-              name: type
-              description: Resource type
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_28
-          required: true
-          serializedName: location
-          language: !<!Languages> 
-            default:
-              name: location
-              description: Resource location
-          protocol: !<!Protocols> {}
-        - !<!Property> 
-          schema: *ref_29
-          required: false
-          serializedName: tags
-          language: !<!Languages> 
-            default:
-              name: tags
-              description: Resource tags
+              name: accountType
+              description: Gets or sets the account type.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
       usage:
         - input
         - output
-      extensions:
-        x-ms-azure-resource: true
       language: !<!Languages> 
         default:
-          name: Resource
-          description: ''
+          name: StorageAccountCreateParameters
+          description: The parameters to provide for the account.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_22
+    - *ref_8
     - *ref_23
-    - *ref_13
+    - *ref_14
     - *ref_30
     - *ref_31
-    - *ref_21
+    - *ref_22
     - *ref_24
     - !<!ObjectSchema> &ref_68
       type: object
@@ -1393,7 +1393,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_56
-                schema: *ref_22
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 

--- a/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
@@ -40,8 +40,8 @@ schemas: !<!Schemas>
           version: 0.0.0
       language: !<!Languages> 
         default:
-          name: Animal-aniType
-          description: ''
+          name: Pet-name
+          description: Gets the Pet by id.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1
       type: string
@@ -50,20 +50,10 @@ schemas: !<!Schemas>
           version: 0.0.0
       language: !<!Languages> 
         default:
-          name: Pet-name
-          description: Gets the Pet by id.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_13
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 0.0.0
-      language: !<!Languages> 
-        default:
-          name: BaseError-someBaseProp
+          name: Animal-aniType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +63,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBase-reason
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,6 +71,16 @@ schemas: !<!Schemas>
       language: !<!Languages> 
         default:
           name: NotFoundErrorBase-whatNotFound
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_8
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 0.0.0
+      language: !<!Languages> 
+        default:
+          name: BaseError-someBaseProp
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_14
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
           name: PetActionError-errorMessage
           description: the error message
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -159,14 +159,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_2
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_0
               immediate:
@@ -174,12 +174,11 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_1
-                readOnly: true
-                serializedName: name
+                serializedName: aniType
                 language: !<!Languages> 
                   default:
-                    name: name
-                    description: Gets the Pet by id.
+                    name: aniType
+                    description: ''
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -187,7 +186,7 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: Pet
+                name: Animal
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
@@ -196,11 +195,12 @@ schemas: !<!Schemas>
       properties:
         - !<!Property> 
           schema: *ref_3
-          serializedName: aniType
+          readOnly: true
+          serializedName: name
           language: !<!Languages> 
             default:
-              name: aniType
-              description: ''
+              name: name
+              description: Gets the Pet by id.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -208,160 +208,160 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: Animal
+          name: Pet
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_2
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_4
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_4
+          - !<!ObjectSchema> &ref_5
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
-            children: !<!Relations> 
-              all:
-                - !<!ObjectSchema> &ref_8
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 0.0.0
-                  discriminatorValue: InvalidResourceLink
-                  parents: !<!Relations> 
-                    all:
-                      - *ref_4
-                      - *ref_5
-                    immediate:
-                      - *ref_4
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_6
-                      serializedName: whatSubAddress
-                      language: !<!Languages> 
-                        default:
-                          name: whatSubAddress
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - exception
-                  extensions:
-                    x-ms-discriminator-value: InvalidResourceLink
-                  language: !<!Languages> 
-                    default:
-                      name: LinkNotFound
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                - !<!ObjectSchema> &ref_9
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 0.0.0
-                  discriminatorValue: AnimalNotFound
-                  parents: !<!Relations> 
-                    all:
-                      - *ref_4
-                      - *ref_5
-                    immediate:
-                      - *ref_4
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_7
-                      serializedName: name
-                      language: !<!Languages> 
-                        default:
-                          name: name
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - exception
-                  language: !<!Languages> 
-                    default:
-                      name: AnimalNotFound
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-              immediate:
-                - *ref_8
-                - *ref_9
-            discriminator: !<!Discriminator> 
-              all:
-                AnimalNotFound: *ref_9
-                InvalidResourceLink: *ref_8
-              immediate:
-                AnimalNotFound: *ref_9
-                InvalidResourceLink: *ref_8
-              property: !<!Property> &ref_12
-                schema: *ref_10
-                isDiscriminator: true
-                required: true
-                serializedName: whatNotFound
-                language: !<!Languages> 
-                  default:
-                    name: whatNotFound
-                    description: ''
-                protocol: !<!Protocols> {}
-            discriminatorValue: NotFoundErrorBase
+            discriminatorValue: InvalidResourceLink
             parents: !<!Relations> 
               all:
-                - *ref_5
+                - *ref_4
+                - !<!ObjectSchema> &ref_6
+                  type: object
+                  apiVersions:
+                    - !<!ApiVersion> 
+                      version: 0.0.0
+                  children: !<!Relations> 
+                    all:
+                      - *ref_4
+                      - *ref_5
+                      - !<!ObjectSchema> &ref_10
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 0.0.0
+                        discriminatorValue: AnimalNotFound
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_4
+                            - *ref_6
+                          immediate:
+                            - *ref_4
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_7
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - exception
+                        language: !<!Languages> 
+                          default:
+                            name: AnimalNotFound
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                    immediate:
+                      - *ref_4
+                  properties:
+                    - !<!Property> 
+                      schema: *ref_8
+                      serializedName: someBaseProp
+                      language: !<!Languages> 
+                        default:
+                          name: someBaseProp
+                          description: ''
+                      protocol: !<!Protocols> {}
+                  serializationFormats:
+                    - json
+                  usage:
+                    - exception
+                  language: !<!Languages> 
+                    default:
+                      name: BaseError
+                      description: ''
+                      namespace: ''
+                  protocol: !<!Protocols> {}
               immediate:
-                - *ref_5
+                - *ref_4
             properties:
               - !<!Property> 
-                schema: *ref_11
-                required: false
-                serializedName: reason
+                schema: *ref_9
+                serializedName: whatSubAddress
                 language: !<!Languages> 
                   default:
-                    name: reason
+                    name: whatSubAddress
                     description: ''
                 protocol: !<!Protocols> {}
-              - *ref_12
             serializationFormats:
               - json
             usage:
               - exception
+            extensions:
+              x-ms-discriminator-value: InvalidResourceLink
             language: !<!Languages> 
               default:
-                name: NotFoundErrorBase
+                name: LinkNotFound
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_8
-          - *ref_9
+          - *ref_10
         immediate:
-          - *ref_4
-      properties:
-        - !<!Property> 
-          schema: *ref_13
-          serializedName: someBaseProp
+          - *ref_5
+          - *ref_10
+      discriminator: !<!Discriminator> 
+        all:
+          AnimalNotFound: *ref_10
+          InvalidResourceLink: *ref_5
+        immediate:
+          AnimalNotFound: *ref_10
+          InvalidResourceLink: *ref_5
+        property: !<!Property> &ref_13
+          schema: *ref_11
+          isDiscriminator: true
+          required: true
+          serializedName: whatNotFound
           language: !<!Languages> 
             default:
-              name: someBaseProp
+              name: whatNotFound
               description: ''
           protocol: !<!Protocols> {}
+      discriminatorValue: NotFoundErrorBase
+      parents: !<!Relations> 
+        all:
+          - *ref_6
+        immediate:
+          - *ref_6
+      properties:
+        - !<!Property> 
+          schema: *ref_12
+          required: false
+          serializedName: reason
+          language: !<!Languages> 
+            default:
+              name: reason
+              description: ''
+          protocol: !<!Protocols> {}
+        - *ref_13
       serializationFormats:
         - json
       usage:
         - exception
       language: !<!Languages> 
         default:
-          name: BaseError
+          name: NotFoundErrorBase
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_4
+    - *ref_6
     - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
@@ -504,8 +504,8 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_8
-    - *ref_9
+    - *ref_5
+    - *ref_10
     - *ref_15
     - *ref_18
 globalParameters:
@@ -562,7 +562,7 @@ operationGroups:
           - *ref_26
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_0
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
@@ -40,8 +40,8 @@ schemas: !<!Schemas>
           version: 0.0.0
       language: !<!Languages> 
         default:
-          name: Animal-aniType
-          description: ''
+          name: Pet-name
+          description: Gets the Pet by id.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1
       type: string
@@ -50,20 +50,10 @@ schemas: !<!Schemas>
           version: 0.0.0
       language: !<!Languages> 
         default:
-          name: Pet-name
-          description: Gets the Pet by id.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_13
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 0.0.0
-      language: !<!Languages> 
-        default:
-          name: BaseError-someBaseProp
+          name: Animal-aniType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +63,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBase-reason
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,6 +71,16 @@ schemas: !<!Schemas>
       language: !<!Languages> 
         default:
           name: NotFoundErrorBase-whatNotFound
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_8
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 0.0.0
+      language: !<!Languages> 
+        default:
+          name: BaseError-someBaseProp
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_14
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
           name: PetActionError-errorMessage
           description: the error message
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -159,14 +159,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_2
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_0
               immediate:
@@ -174,12 +174,11 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_1
-                readOnly: true
-                serializedName: name
+                serializedName: aniType
                 language: !<!Languages> 
                   default:
-                    name: name
-                    description: Gets the Pet by id.
+                    name: aniType
+                    description: ''
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -187,7 +186,7 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: Pet
+                name: Animal
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
@@ -196,11 +195,12 @@ schemas: !<!Schemas>
       properties:
         - !<!Property> 
           schema: *ref_3
-          serializedName: aniType
+          readOnly: true
+          serializedName: name
           language: !<!Languages> 
             default:
-              name: aniType
-              description: ''
+              name: name
+              description: Gets the Pet by id.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -208,160 +208,160 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: Animal
+          name: Pet
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_2
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_4
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_4
+          - !<!ObjectSchema> &ref_5
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
-            children: !<!Relations> 
-              all:
-                - !<!ObjectSchema> &ref_8
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 0.0.0
-                  discriminatorValue: InvalidResourceLink
-                  parents: !<!Relations> 
-                    all:
-                      - *ref_4
-                      - *ref_5
-                    immediate:
-                      - *ref_4
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_6
-                      serializedName: whatSubAddress
-                      language: !<!Languages> 
-                        default:
-                          name: whatSubAddress
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - exception
-                  extensions:
-                    x-ms-discriminator-value: InvalidResourceLink
-                  language: !<!Languages> 
-                    default:
-                      name: LinkNotFound
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                - !<!ObjectSchema> &ref_9
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 0.0.0
-                  discriminatorValue: AnimalNotFound
-                  parents: !<!Relations> 
-                    all:
-                      - *ref_4
-                      - *ref_5
-                    immediate:
-                      - *ref_4
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_7
-                      serializedName: name
-                      language: !<!Languages> 
-                        default:
-                          name: name
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - exception
-                  language: !<!Languages> 
-                    default:
-                      name: AnimalNotFound
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-              immediate:
-                - *ref_8
-                - *ref_9
-            discriminator: !<!Discriminator> 
-              all:
-                AnimalNotFound: *ref_9
-                InvalidResourceLink: *ref_8
-              immediate:
-                AnimalNotFound: *ref_9
-                InvalidResourceLink: *ref_8
-              property: !<!Property> &ref_12
-                schema: *ref_10
-                isDiscriminator: true
-                required: true
-                serializedName: whatNotFound
-                language: !<!Languages> 
-                  default:
-                    name: whatNotFound
-                    description: ''
-                protocol: !<!Protocols> {}
-            discriminatorValue: NotFoundErrorBase
+            discriminatorValue: InvalidResourceLink
             parents: !<!Relations> 
               all:
-                - *ref_5
+                - *ref_4
+                - !<!ObjectSchema> &ref_6
+                  type: object
+                  apiVersions:
+                    - !<!ApiVersion> 
+                      version: 0.0.0
+                  children: !<!Relations> 
+                    all:
+                      - *ref_4
+                      - *ref_5
+                      - !<!ObjectSchema> &ref_10
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 0.0.0
+                        discriminatorValue: AnimalNotFound
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_4
+                            - *ref_6
+                          immediate:
+                            - *ref_4
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_7
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - exception
+                        language: !<!Languages> 
+                          default:
+                            name: AnimalNotFound
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                    immediate:
+                      - *ref_4
+                  properties:
+                    - !<!Property> 
+                      schema: *ref_8
+                      serializedName: someBaseProp
+                      language: !<!Languages> 
+                        default:
+                          name: someBaseProp
+                          description: ''
+                      protocol: !<!Protocols> {}
+                  serializationFormats:
+                    - json
+                  usage:
+                    - exception
+                  language: !<!Languages> 
+                    default:
+                      name: BaseError
+                      description: ''
+                      namespace: ''
+                  protocol: !<!Protocols> {}
               immediate:
-                - *ref_5
+                - *ref_4
             properties:
               - !<!Property> 
-                schema: *ref_11
-                required: false
-                serializedName: reason
+                schema: *ref_9
+                serializedName: whatSubAddress
                 language: !<!Languages> 
                   default:
-                    name: reason
+                    name: whatSubAddress
                     description: ''
                 protocol: !<!Protocols> {}
-              - *ref_12
             serializationFormats:
               - json
             usage:
               - exception
+            extensions:
+              x-ms-discriminator-value: InvalidResourceLink
             language: !<!Languages> 
               default:
-                name: NotFoundErrorBase
+                name: LinkNotFound
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_8
-          - *ref_9
+          - *ref_10
         immediate:
-          - *ref_4
-      properties:
-        - !<!Property> 
-          schema: *ref_13
-          serializedName: someBaseProp
+          - *ref_5
+          - *ref_10
+      discriminator: !<!Discriminator> 
+        all:
+          AnimalNotFound: *ref_10
+          InvalidResourceLink: *ref_5
+        immediate:
+          AnimalNotFound: *ref_10
+          InvalidResourceLink: *ref_5
+        property: !<!Property> &ref_13
+          schema: *ref_11
+          isDiscriminator: true
+          required: true
+          serializedName: whatNotFound
           language: !<!Languages> 
             default:
-              name: someBaseProp
+              name: whatNotFound
               description: ''
           protocol: !<!Protocols> {}
+      discriminatorValue: NotFoundErrorBase
+      parents: !<!Relations> 
+        all:
+          - *ref_6
+        immediate:
+          - *ref_6
+      properties:
+        - !<!Property> 
+          schema: *ref_12
+          required: false
+          serializedName: reason
+          language: !<!Languages> 
+            default:
+              name: reason
+              description: ''
+          protocol: !<!Protocols> {}
+        - *ref_13
       serializationFormats:
         - json
       usage:
         - exception
       language: !<!Languages> 
         default:
-          name: BaseError
+          name: NotFoundErrorBase
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_4
+    - *ref_6
     - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
@@ -504,8 +504,8 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_8
-    - *ref_9
+    - *ref_5
+    - *ref_10
     - *ref_15
     - *ref_18
 globalParameters:
@@ -562,7 +562,7 @@ operationGroups:
           - *ref_26
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_0
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
@@ -40,8 +40,8 @@ schemas: !<!Schemas>
           version: 0.0.0
       language: !<!Languages> 
         default:
-          name: Animal-aniType
-          description: ''
+          name: Pet-name
+          description: Gets the Pet by id.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1
       type: string
@@ -50,20 +50,10 @@ schemas: !<!Schemas>
           version: 0.0.0
       language: !<!Languages> 
         default:
-          name: Pet-name
-          description: Gets the Pet by id.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_4
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 0.0.0
-      language: !<!Languages> 
-        default:
-          name: BaseError-someBaseProp
+          name: Animal-aniType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +63,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBase-reason
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_5
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,6 +71,16 @@ schemas: !<!Schemas>
       language: !<!Languages> 
         default:
           name: NotFoundErrorBase-whatNotFound
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_9
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 0.0.0
+      language: !<!Languages> 
+        default:
+          name: BaseError-someBaseProp
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_14
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
           name: PetActionError-errorMessage
           description: the error message
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -159,14 +159,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_3
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_2
               immediate:
@@ -174,12 +174,11 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_1
-                readOnly: true
-                serializedName: name
+                serializedName: aniType
                 language: !<!Languages> 
                   default:
-                    name: name
-                    description: Gets the Pet by id.
+                    name: aniType
+                    description: ''
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -187,7 +186,7 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: Pet
+                name: Animal
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
@@ -196,11 +195,12 @@ schemas: !<!Schemas>
       properties:
         - !<!Property> 
           schema: *ref_0
-          serializedName: aniType
+          readOnly: true
+          serializedName: name
           language: !<!Languages> 
             default:
-              name: aniType
-              description: ''
+              name: name
+              description: Gets the Pet by id.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -208,77 +208,76 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: Animal
+          name: Pet
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_3
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_9
+          - !<!ObjectSchema> &ref_10
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
-            children: !<!Relations> 
+            discriminatorValue: InvalidResourceLink
+            parents: !<!Relations> 
               all:
+                - *ref_8
                 - !<!ObjectSchema> &ref_12
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 0.0.0
-                  discriminatorValue: InvalidResourceLink
-                  parents: !<!Relations> 
+                  children: !<!Relations> 
                     all:
-                      - *ref_9
+                      - *ref_8
                       - *ref_10
+                      - !<!ObjectSchema> &ref_13
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 0.0.0
+                        discriminatorValue: AnimalNotFound
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_8
+                            - *ref_12
+                          immediate:
+                            - *ref_8
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_11
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - exception
+                        language: !<!Languages> 
+                          default:
+                            name: AnimalNotFound
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
                     immediate:
-                      - *ref_9
+                      - *ref_8
                   properties:
                     - !<!Property> 
-                      schema: *ref_8
-                      serializedName: whatSubAddress
+                      schema: *ref_9
+                      serializedName: someBaseProp
                       language: !<!Languages> 
                         default:
-                          name: whatSubAddress
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - exception
-                  extensions:
-                    x-ms-discriminator-value: InvalidResourceLink
-                  language: !<!Languages> 
-                    default:
-                      name: LinkNotFound
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                - !<!ObjectSchema> &ref_13
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 0.0.0
-                  discriminatorValue: AnimalNotFound
-                  parents: !<!Relations> 
-                    all:
-                      - *ref_9
-                      - *ref_10
-                    immediate:
-                      - *ref_9
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_11
-                      serializedName: name
-                      language: !<!Languages> 
-                        default:
-                          name: name
+                          name: someBaseProp
                           description: ''
                       protocol: !<!Protocols> {}
                   serializationFormats:
@@ -287,81 +286,82 @@ schemas: !<!Schemas>
                     - exception
                   language: !<!Languages> 
                     default:
-                      name: AnimalNotFound
+                      name: BaseError
                       description: ''
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_12
-                - *ref_13
-            discriminator: !<!Discriminator> 
-              all:
-                AnimalNotFound: *ref_13
-                InvalidResourceLink: *ref_12
-              immediate:
-                AnimalNotFound: *ref_13
-                InvalidResourceLink: *ref_12
-              property: !<!Property> &ref_7
-                schema: *ref_6
-                isDiscriminator: true
-                required: true
-                serializedName: whatNotFound
-                language: !<!Languages> 
-                  default:
-                    name: whatNotFound
-                    description: ''
-                protocol: !<!Protocols> {}
-            discriminatorValue: NotFoundErrorBase
-            parents: !<!Relations> 
-              all:
-                - *ref_10
-              immediate:
-                - *ref_10
+                - *ref_8
             properties:
               - !<!Property> 
-                schema: *ref_5
-                required: false
-                serializedName: reason
+                schema: *ref_7
+                serializedName: whatSubAddress
                 language: !<!Languages> 
                   default:
-                    name: reason
+                    name: whatSubAddress
                     description: ''
                 protocol: !<!Protocols> {}
-              - *ref_7
             serializationFormats:
               - json
             usage:
               - exception
+            extensions:
+              x-ms-discriminator-value: InvalidResourceLink
             language: !<!Languages> 
               default:
-                name: NotFoundErrorBase
+                name: LinkNotFound
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_12
           - *ref_13
         immediate:
-          - *ref_9
+          - *ref_10
+          - *ref_13
+      discriminator: !<!Discriminator> 
+        all:
+          AnimalNotFound: *ref_13
+          InvalidResourceLink: *ref_10
+        immediate:
+          AnimalNotFound: *ref_13
+          InvalidResourceLink: *ref_10
+        property: !<!Property> &ref_6
+          schema: *ref_5
+          isDiscriminator: true
+          required: true
+          serializedName: whatNotFound
+          language: !<!Languages> 
+            default:
+              name: whatNotFound
+              description: ''
+          protocol: !<!Protocols> {}
+      discriminatorValue: NotFoundErrorBase
+      parents: !<!Relations> 
+        all:
+          - *ref_12
+        immediate:
+          - *ref_12
       properties:
         - !<!Property> 
           schema: *ref_4
-          serializedName: someBaseProp
+          required: false
+          serializedName: reason
           language: !<!Languages> 
             default:
-              name: someBaseProp
+              name: reason
               description: ''
           protocol: !<!Protocols> {}
+        - *ref_6
       serializationFormats:
         - json
       usage:
         - exception
       language: !<!Languages> 
         default:
-          name: BaseError
+          name: NotFoundErrorBase
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_9
+    - *ref_12
     - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
@@ -504,7 +504,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_12
+    - *ref_10
     - *ref_13
     - *ref_21
     - *ref_22
@@ -562,7 +562,7 @@ operationGroups:
           - *ref_25
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -600,7 +600,7 @@ operationGroups:
                 statusCodes:
                   - '400'
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_8
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 

--- a/modelerfour/test/scenarios/xms-error-responses/namer.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/namer.yaml
@@ -40,8 +40,8 @@ schemas: !<!Schemas>
           version: 0.0.0
       language: !<!Languages> 
         default:
-          name: AnimalAniType
-          description: ''
+          name: PetName
+          description: Gets the Pet by id.
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1
       type: string
@@ -50,20 +50,10 @@ schemas: !<!Schemas>
           version: 0.0.0
       language: !<!Languages> 
         default:
-          name: PetName
-          description: Gets the Pet by id.
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_13
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 0.0.0
-      language: !<!Languages> 
-        default:
-          name: BaseErrorSomeBaseProp
+          name: AnimalAniType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +63,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBaseReason
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,6 +71,16 @@ schemas: !<!Schemas>
       language: !<!Languages> 
         default:
           name: NotFoundErrorBaseWhatNotFound
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_8
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 0.0.0
+      language: !<!Languages> 
+        default:
+          name: BaseErrorSomeBaseProp
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_14
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
           name: PetActionErrorMessage
           description: the error message
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -159,14 +159,14 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
-      children: !<!Relations> 
+      parents: !<!Relations> 
         all:
           - !<!ObjectSchema> &ref_2
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
-            parents: !<!Relations> 
+            children: !<!Relations> 
               all:
                 - *ref_0
               immediate:
@@ -174,12 +174,11 @@ schemas: !<!Schemas>
             properties:
               - !<!Property> 
                 schema: *ref_1
-                readOnly: true
-                serializedName: name
+                serializedName: aniType
                 language: !<!Languages> 
                   default:
-                    name: name
-                    description: Gets the Pet by id.
+                    name: aniType
+                    description: ''
                 protocol: !<!Protocols> {}
             serializationFormats:
               - json
@@ -187,7 +186,7 @@ schemas: !<!Schemas>
               - output
             language: !<!Languages> 
               default:
-                name: Pet
+                name: Animal
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
@@ -196,11 +195,12 @@ schemas: !<!Schemas>
       properties:
         - !<!Property> 
           schema: *ref_3
-          serializedName: aniType
+          readOnly: true
+          serializedName: name
           language: !<!Languages> 
             default:
-              name: aniType
-              description: ''
+              name: name
+              description: Gets the Pet by id.
           protocol: !<!Protocols> {}
       serializationFormats:
         - json
@@ -208,160 +208,160 @@ schemas: !<!Schemas>
         - output
       language: !<!Languages> 
         default:
-          name: Animal
+          name: Pet
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_2
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_4
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_4
+          - !<!ObjectSchema> &ref_5
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
-            children: !<!Relations> 
-              all:
-                - !<!ObjectSchema> &ref_8
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 0.0.0
-                  discriminatorValue: InvalidResourceLink
-                  parents: !<!Relations> 
-                    all:
-                      - *ref_4
-                      - *ref_5
-                    immediate:
-                      - *ref_4
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_6
-                      serializedName: whatSubAddress
-                      language: !<!Languages> 
-                        default:
-                          name: whatSubAddress
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - exception
-                  extensions:
-                    x-ms-discriminator-value: InvalidResourceLink
-                  language: !<!Languages> 
-                    default:
-                      name: LinkNotFound
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-                - !<!ObjectSchema> &ref_9
-                  type: object
-                  apiVersions:
-                    - !<!ApiVersion> 
-                      version: 0.0.0
-                  discriminatorValue: AnimalNotFound
-                  parents: !<!Relations> 
-                    all:
-                      - *ref_4
-                      - *ref_5
-                    immediate:
-                      - *ref_4
-                  properties:
-                    - !<!Property> 
-                      schema: *ref_7
-                      serializedName: name
-                      language: !<!Languages> 
-                        default:
-                          name: name
-                          description: ''
-                      protocol: !<!Protocols> {}
-                  serializationFormats:
-                    - json
-                  usage:
-                    - exception
-                  language: !<!Languages> 
-                    default:
-                      name: AnimalNotFound
-                      description: ''
-                      namespace: ''
-                  protocol: !<!Protocols> {}
-              immediate:
-                - *ref_8
-                - *ref_9
-            discriminator: !<!Discriminator> 
-              all:
-                AnimalNotFound: *ref_9
-                InvalidResourceLink: *ref_8
-              immediate:
-                AnimalNotFound: *ref_9
-                InvalidResourceLink: *ref_8
-              property: !<!Property> &ref_12
-                schema: *ref_10
-                isDiscriminator: true
-                required: true
-                serializedName: whatNotFound
-                language: !<!Languages> 
-                  default:
-                    name: whatNotFound
-                    description: ''
-                protocol: !<!Protocols> {}
-            discriminatorValue: NotFoundErrorBase
+            discriminatorValue: InvalidResourceLink
             parents: !<!Relations> 
               all:
-                - *ref_5
+                - *ref_4
+                - !<!ObjectSchema> &ref_6
+                  type: object
+                  apiVersions:
+                    - !<!ApiVersion> 
+                      version: 0.0.0
+                  children: !<!Relations> 
+                    all:
+                      - *ref_4
+                      - *ref_5
+                      - !<!ObjectSchema> &ref_10
+                        type: object
+                        apiVersions:
+                          - !<!ApiVersion> 
+                            version: 0.0.0
+                        discriminatorValue: AnimalNotFound
+                        parents: !<!Relations> 
+                          all:
+                            - *ref_4
+                            - *ref_6
+                          immediate:
+                            - *ref_4
+                        properties:
+                          - !<!Property> 
+                            schema: *ref_7
+                            serializedName: name
+                            language: !<!Languages> 
+                              default:
+                                name: name
+                                description: ''
+                            protocol: !<!Protocols> {}
+                        serializationFormats:
+                          - json
+                        usage:
+                          - exception
+                        language: !<!Languages> 
+                          default:
+                            name: AnimalNotFound
+                            description: ''
+                            namespace: ''
+                        protocol: !<!Protocols> {}
+                    immediate:
+                      - *ref_4
+                  properties:
+                    - !<!Property> 
+                      schema: *ref_8
+                      serializedName: someBaseProp
+                      language: !<!Languages> 
+                        default:
+                          name: someBaseProp
+                          description: ''
+                      protocol: !<!Protocols> {}
+                  serializationFormats:
+                    - json
+                  usage:
+                    - exception
+                  language: !<!Languages> 
+                    default:
+                      name: BaseError
+                      description: ''
+                      namespace: ''
+                  protocol: !<!Protocols> {}
               immediate:
-                - *ref_5
+                - *ref_4
             properties:
               - !<!Property> 
-                schema: *ref_11
-                required: false
-                serializedName: reason
+                schema: *ref_9
+                serializedName: whatSubAddress
                 language: !<!Languages> 
                   default:
-                    name: reason
+                    name: whatSubAddress
                     description: ''
                 protocol: !<!Protocols> {}
-              - *ref_12
             serializationFormats:
               - json
             usage:
               - exception
+            extensions:
+              x-ms-discriminator-value: InvalidResourceLink
             language: !<!Languages> 
               default:
-                name: NotFoundErrorBase
+                name: LinkNotFound
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_8
-          - *ref_9
+          - *ref_10
         immediate:
-          - *ref_4
-      properties:
-        - !<!Property> 
-          schema: *ref_13
-          serializedName: someBaseProp
+          - *ref_5
+          - *ref_10
+      discriminator: !<!Discriminator> 
+        all:
+          AnimalNotFound: *ref_10
+          InvalidResourceLink: *ref_5
+        immediate:
+          AnimalNotFound: *ref_10
+          InvalidResourceLink: *ref_5
+        property: !<!Property> &ref_13
+          schema: *ref_11
+          isDiscriminator: true
+          required: true
+          serializedName: whatNotFound
           language: !<!Languages> 
             default:
-              name: someBaseProp
+              name: whatNotFound
               description: ''
           protocol: !<!Protocols> {}
+      discriminatorValue: NotFoundErrorBase
+      parents: !<!Relations> 
+        all:
+          - *ref_6
+        immediate:
+          - *ref_6
+      properties:
+        - !<!Property> 
+          schema: *ref_12
+          required: false
+          serializedName: reason
+          language: !<!Languages> 
+            default:
+              name: reason
+              description: ''
+          protocol: !<!Protocols> {}
+        - *ref_13
       serializationFormats:
         - json
       usage:
         - exception
       language: !<!Languages> 
         default:
-          name: BaseError
+          name: NotFoundErrorBase
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_4
+    - *ref_6
     - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
@@ -504,8 +504,8 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_8
-    - *ref_9
+    - *ref_5
+    - *ref_10
     - *ref_15
     - *ref_18
 globalParameters:
@@ -562,7 +562,7 @@ operationGroups:
           - *ref_26
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_0
             language: !<!Languages> 
               default:
                 name: ''

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepare": "(pwsh -v || npm --silent run show-error) && pwsh -noprofile ./.scripts/verify-install.ps1",
     "show-error": "echo ====== &echo ====== & echo ====== & echo REQUIRED: Install PowerShell-core 6.1 or greater (see readme.md) & echo ====== & echo ====== & echo ====== & exit 1",
     "pack": "rush publish --publish --pack --include-all --tag preview",
-    "test": "cd ./modelerfour && npm run test "
+    "build": "cd ./modelerfour && npm run build",
+    "test": "cd ./modelerfour && npm run test"
   }
 }


### PR DESCRIPTION
This change addresses issue #282 which reports that a "Recursing!" error message is returned for the `drive` schema when running the MSGraph spec through modelerfour.  It turns out that `processObjectSchema` was traversing schemas referenced in `allOf`/`anyOf`/`oneOf` lists before adding the new `ObjectSchema` to the cache.  The fix is to reorder this behavior so that the cached `ObjectSchema` is already in the cache before it is seen again in the schema graph.

I also had to address an issue where repeated words in operation group names were being removed causing a name collision for this schema.  More specifically, there were two operation groups with the following names:

- `drive`
- `drive.drive`

In the `prenamer` phase, the `drive.drive` name was being normalized to `Drive` causing a collision with the other `Drive`.  @fearthecowboy does this seem like an appropriate fix in this case?  Do you forsee any possible problems with not removing duplicate segments in operation group names?