### PR TITLE
Remove empty parent object schemas in allOf lists with PreChecker

### DIFF
--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -6,73 +6,21 @@
 import * as assert from "assert";
 import { suite, test } from "mocha-typescript";
 import { ModelerFour } from "../../modeler/modelerfour";
-import { fail } from "@azure-tools/codegen";
-import { startSession } from "@azure-tools/autorest-extension-base";
-import { values } from "@azure-tools/linq";
-import { CodeModel, Schema, SchemaUsage } from "@azure-tools/codemodel";
-import { Model } from "@azure-tools/openapi";
-import { codeModelSchema } from "@azure-tools/codemodel";
-
-let modelerErrors: any[] = [];
-
-async function createTestSession(config: any, openApiModel: any) {
-  const openApiText = JSON.stringify(openApiModel);
-  const ii = [
-    {
-      model: openApiModel as Model,
-      filename: "openapi-3.json",
-      content: openApiText
-    }
-  ];
-
-  return await startSession<Model>(
-    {
-      ReadFile: async (filename: string): Promise<string> =>
-        (
-          values(ii).first(each => each.filename === filename) ||
-          fail(`missing input '${filename}'`)
-        ).content,
-      GetValue: async (key: string): Promise<any> => {
-        if (!key) {
-          return config;
-        }
-        return config[key];
-      },
-      ListInputs: async (artifactType?: string): Promise<Array<string>> =>
-        ii.map(each => each.filename),
-
-      ProtectFiles: async (path: string): Promise<void> => {
-        // test
-      },
-      WriteFile: (
-        filename: string,
-        content: string,
-        sourceMap?: any,
-        artifactType?: string
-      ): void => {
-        // test
-      },
-      Message: (message: any): void => {
-        // test
-        if (
-          message.Channel === "warning" ||
-          message.Channel === "error" ||
-          message.Channel === "verbose"
-        ) {
-          if (message.Channel === "error") {
-            modelerErrors.push(message);
-          }
-        }
-      },
-      UpdateConfigurationFile: (filename: string, content: string): void => {
-        // test
-      },
-      GetConfigurationFile: async (filename: string): Promise<string> => ""
-    },
-    {},
-    codeModelSchema
-  );
-}
+import {
+  createTestSession,
+  createTestSpec,
+  addSchema,
+  addOperation,
+  response,
+  InitialTestSpec,
+  responses
+} from "./unitTestUtil";
+import {
+  CodeModel,
+  Schema,
+  SchemaUsage,
+  ObjectSchema
+} from "@azure-tools/codemodel";
 
 const cfg = {
   modelerfour: {
@@ -94,92 +42,14 @@ const cfg = {
   "payload-flattening-threshold": 2
 };
 
-export type TestSpecCustomizer = (spec: any) => any;
-
-const InitialTestSpec = {
-  info: {
-    title: "Test OpenAPI 3 Specification",
-    description: "A test document",
-    contact: {
-      name: "Microsoft Corporation",
-      url: "https://microsoft.com",
-      email: "devnull@microsoft.com"
-    },
-    license: "MIT",
-    version: "1.0"
-  },
-  paths: {},
-  components: {
-    schemas: {}
-  }
-};
-
-function createTestSpec(...customizers: TestSpecCustomizer[]): any {
-  return customizers.reduce<any>(
-    (spec: any, customizer: TestSpecCustomizer) => {
-      return customizer(spec);
-    },
-    { ...InitialTestSpec } // Don't modify the original
-  );
-}
-
-function addOperation(
-  spec: any,
-  path: string,
-  operationDict: any,
-  metadata: any = { apiVersions: ["1.0.0"] }
-): void {
-  operationDict = { ...operationDict, ...{ "x-ms-metadata": metadata } };
-  spec.paths[path] = operationDict;
-}
-
-function addSchema(
-  spec: any,
-  name: string,
-  schemaDict: any,
-  metadata: any = { apiVersions: ["1.0.0"] }
-): void {
-  schemaDict = { ...schemaDict, ...{ "x-ms-metadata": metadata } };
-  spec.components.schemas[name] = schemaDict;
-}
-
 async function runModeler(spec: any): Promise<CodeModel> {
-  modelerErrors = [];
-  const session = await createTestSession(cfg, spec);
+  const modelerErrors: any[] = [];
+  const session = await createTestSession(cfg, spec, modelerErrors);
   const modeler = await new ModelerFour(session).init();
 
   assert.equal(modelerErrors.length, 0);
 
   return modeler.process();
-}
-
-function response(
-  code: number | "default",
-  contentType: string,
-  schema: any,
-  description: string = "The response."
-) {
-  return {
-    [code]: {
-      description,
-      content: {
-        [contentType]: {
-          schema
-        }
-      }
-    }
-  };
-}
-
-function responses(...responses: any[]) {
-  return responses.reduce(
-    (responsesDict, response) => Object.assign(responsesDict, response),
-    {}
-  );
-}
-
-function properties(...properties: any[]) {
-  // TODO: Accept string or property object
 }
 
 function assertSchema(

--- a/modelerfour/test/unit/prechecker.test.ts
+++ b/modelerfour/test/unit/prechecker.test.ts
@@ -1,0 +1,89 @@
+import * as assert from "assert";
+import { suite, test } from "mocha-typescript";
+import { QualityPreChecker } from "../../quality-precheck/prechecker";
+import {
+  Model,
+  Refable,
+  Dereferenced,
+  dereference,
+  Schema,
+  PropertyDetails,
+  JsonType,
+  StringFormat
+} from "@azure-tools/openapi";
+import {
+  createTestSession,
+  createTestSpec,
+  addSchema,
+  addOperation,
+  response,
+  InitialTestSpec,
+  responses
+} from "./unitTestUtil";
+
+class PreCheckerClient {
+  private constructor(private input: Model, public result: Model) {}
+
+  resolve<T>(item: Refable<T>): Dereferenced<T> {
+    return dereference(this.input, item);
+  }
+
+  static async create(spec: any): Promise<PreCheckerClient> {
+    const precheckerErrors: any[] = [];
+    const session = await createTestSession({}, spec, precheckerErrors);
+    const prechecker = await new QualityPreChecker(session).init();
+
+    const client = new PreCheckerClient(prechecker.input, prechecker.process());
+
+    assert.equal(precheckerErrors.length, 0);
+
+    return client;
+  }
+}
+
+@suite
+class PreChecker {
+  @test
+  async "removes empty object schemas from allOf list when other parents are present"() {
+    const spec = createTestSpec();
+
+    addSchema(spec, "ParentSchema", {
+      type: "object",
+      nullable: true,
+      properties: {
+        hack: {
+          type: "boolean"
+        }
+      }
+    });
+
+    addSchema(spec, "ChildSchema", {
+      type: "object",
+      allOf: [
+        { type: "object" },
+        { $ref: "#/components/schemas/ParentSchema" }
+      ],
+      properties: {
+        childOfHack: {
+          type: "integer"
+        }
+      }
+    });
+
+    const client = await PreCheckerClient.create(spec);
+    const model = client.result;
+
+    const childSchemaRef =
+      model.components?.schemas && model.components?.schemas["ChildSchema"];
+    if (childSchemaRef) {
+      const childSchema = client.resolve<Schema>(childSchemaRef);
+      assert.strictEqual(childSchema.instance.allOf?.length, 1);
+      const parent = client.resolve(
+        childSchema.instance.allOf && childSchema.instance.allOf[0]
+      );
+      assert.strictEqual(parent.name, "ParentSchema");
+    } else {
+      assert.fail("No 'ChildSchema' found!");
+    }
+  }
+}

--- a/modelerfour/test/unit/unitTestUtil.ts
+++ b/modelerfour/test/unit/unitTestUtil.ts
@@ -1,0 +1,146 @@
+import { fail } from "@azure-tools/codegen";
+import { startSession } from "@azure-tools/autorest-extension-base";
+import { values, clone } from "@azure-tools/linq";
+import { Model } from "@azure-tools/openapi";
+import { codeModelSchema } from "@azure-tools/codemodel";
+
+export async function createTestSession(
+  config: any,
+  openApiModel: any,
+  messageList: any[]
+) {
+  const openApiText = JSON.stringify(openApiModel);
+  const ii = [
+    {
+      model: openApiModel as Model,
+      filename: "openapi-3.json",
+      content: openApiText
+    }
+  ];
+
+  return await startSession<Model>(
+    {
+      ReadFile: async (filename: string): Promise<string> =>
+        (
+          values(ii).first(each => each.filename === filename) ||
+          fail(`missing input '${filename}'`)
+        ).content,
+      GetValue: async (key: string): Promise<any> => {
+        if (!key) {
+          return config;
+        }
+        return config[key];
+      },
+      ListInputs: async (artifactType?: string): Promise<Array<string>> =>
+        ii.map(each => each.filename),
+
+      ProtectFiles: async (path: string): Promise<void> => {
+        // test
+      },
+      WriteFile: (
+        filename: string,
+        content: string,
+        sourceMap?: any,
+        artifactType?: string
+      ): void => {
+        // test
+      },
+      Message: (message: any): void => {
+        // test
+        if (
+          message.Channel === "warning" ||
+          message.Channel === "error" ||
+          message.Channel === "verbose"
+        ) {
+          if (message.Channel === "error") {
+            messageList.push(message);
+          }
+        }
+      },
+      UpdateConfigurationFile: (filename: string, content: string): void => {
+        // test
+      },
+      GetConfigurationFile: async (filename: string): Promise<string> => ""
+    },
+    {},
+    codeModelSchema
+  );
+}
+
+export function response(
+  code: number | "default",
+  contentType: string,
+  schema: any,
+  description: string = "The response."
+) {
+  return {
+    [code]: {
+      description,
+      content: {
+        [contentType]: {
+          schema
+        }
+      }
+    }
+  };
+}
+
+export function responses(...responses: any[]) {
+  return responses.reduce(
+    (responsesDict, response) => Object.assign(responsesDict, response),
+    {}
+  );
+}
+
+export function properties(...properties: any[]) {
+  // TODO: Accept string or property object
+}
+
+export const InitialTestSpec = {
+  info: {
+    title: "Test OpenAPI 3 Specification",
+    description: "A test document",
+    contact: {
+      name: "Microsoft Corporation",
+      url: "https://microsoft.com",
+      email: "devnull@microsoft.com"
+    },
+    license: "MIT",
+    version: "1.0"
+  },
+  paths: {},
+  components: {
+    schemas: {}
+  }
+};
+
+export type TestSpecCustomizer = (spec: any) => any;
+
+export function createTestSpec(...customizers: TestSpecCustomizer[]): any {
+  return customizers.reduce<any>(
+    (spec: any, customizer: TestSpecCustomizer) => {
+      return customizer(spec);
+    },
+    clone(InitialTestSpec)
+  );
+}
+
+export function addOperation(
+  spec: any,
+  path: string,
+  operationDict: any,
+  metadata: any = { apiVersions: ["1.0.0"] }
+): void {
+  operationDict = { ...operationDict, ...{ "x-ms-metadata": metadata } };
+  spec.paths[path] = operationDict;
+}
+
+export function addSchema(
+  spec: any,
+  name: string,
+  schemaDict: any,
+  metadata: any = { apiVersions: ["1.0.0"] }
+): void {
+  schemaDict = { ...schemaDict, ...{ "x-ms-metadata": metadata } };
+  spec.components.schemas[name] = schemaDict;
+}


### PR DESCRIPTION
This change addresses #255 which reports that an `AnySchema` is being added as a parent to `ObjectSchemas` which contain an empty `{ type: object }` schema in their `allOf` list.  This change just filters `AnySchema` out of all parent schema lists in `ObjectSchemas`.

~This change will have to be merged with #304 once it gets merged since they touch the same code path.~ Done now.