### PR TITLE
Convert schemas with x-ms-enum's modelAsString: true to ChoiceSchema

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -501,7 +501,8 @@ export class ModelerFour {
     name = (xmse && xmse.name) || this.interpret.getName(name, schema);
     const sealed = xmse && !(xmse.modelAsString);
 
-    if (length(schema.enum) === 1 || length(xmse?.values) === 1) {
+    // model as string forces it to be a choice/enum.
+    if (xmse?.modelAsString !== true && (length(schema.enum) === 1 || length(xmse?.values) === 1)) {
       const constVal = length(xmse?.values) === 1 ? xmse?.values?.[0]?.value : schema?.enum?.[0];
 
       return this.codeModel.schemas.add(new ConstantSchema(name, this.interpret.getDescription(``, schema), {

--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/modelerfour",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "description": "AutoRest Modeler Version Four (component)",
   "directories": {
     "doc": "docs"

--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -1,6 +1,9 @@
 # AutoRest Modeler Four 
 
 ## Changelog:
+#### 4.15.x
+  - Schemas with `x-ms-enum`'s `modelAsString` set to `true` will now be represented as `ChoiceSchema` even with a single value.
+
 #### 4.14.x
   - added `exception` SchemaContext for `usage` when used as an exception response
   - changed `output` SchemaContext for `usage` to no longer include exception response uses

--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -324,6 +324,24 @@ schemas: !<!Schemas>
           name: CMYKColors
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_59
+      choices:
+        - !<!ChoiceValue> 
+          value: Kind1
+          language:
+            default:
+              name: Kind1
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: MyKind
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_42
       choices:
         - !<!ChoiceValue> 
@@ -365,19 +383,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-2016-02-29
           description: Api Version (2016-02-29)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_59
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      value: !<!ConstantValue> 
-        value: Kind1
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: MyKind
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_24

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -324,6 +324,24 @@ schemas: !<!Schemas>
           name: CMYKColors
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_59
+      choices:
+        - !<!ChoiceValue> 
+          value: Kind1
+          language:
+            default:
+              name: Kind1
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: MyKind
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_42
       choices:
         - !<!ChoiceValue> 
@@ -365,19 +383,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-2016-02-29
           description: Api Version (2016-02-29)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_59
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      value: !<!ConstantValue> 
-        value: Kind1
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: MyKind
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_24

--- a/modelerfour/test/scenarios/a-playground/modeler.yaml
+++ b/modelerfour/test/scenarios/a-playground/modeler.yaml
@@ -327,6 +327,24 @@ schemas: !<!Schemas>
     - !<!ChoiceSchema> &ref_50
       choices:
         - !<!ChoiceValue> 
+          value: Kind1
+          language:
+            default:
+              name: Kind1
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      choiceType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: MyKind
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_51
+      choices:
+        - !<!ChoiceValue> 
           value: pink
           language:
             default:
@@ -365,19 +383,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-2016-02-29
           description: Api Version (2016-02-29)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_51
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      value: !<!ConstantValue> 
-        value: Kind1
-      valueType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: MyKind
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_67
@@ -1321,7 +1326,7 @@ schemas: !<!Schemas>
                           description: ''
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_50
+                      schema: *ref_51
                       serializedName: color
                       language: !<!Languages> 
                         default:
@@ -1716,7 +1721,7 @@ schemas: !<!Schemas>
         immediate:
           Kind1: *ref_46
         property: !<!Property> &ref_43
-          schema: *ref_51
+          schema: *ref_50
           isDiscriminator: true
           required: true
           serializedName: kind

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -324,6 +324,24 @@ schemas: !<!Schemas>
           name: CMYKColors
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_59
+      choices:
+        - !<!ChoiceValue> 
+          value: Kind1
+          language:
+            default:
+              name: Kind1
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: MyKind
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_42
       choices:
         - !<!ChoiceValue> 
@@ -365,19 +383,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion20160229
           description: Api Version (2016-02-29)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_59
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      value: !<!ConstantValue> 
-        value: Kind1
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: MyKind
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_24

--- a/modelerfour/test/scenarios/advisor/flattened.yaml
+++ b/modelerfour/test/scenarios/advisor/flattened.yaml
@@ -394,6 +394,24 @@ schemas: !<!Schemas>
           description: The link used to get the next page of suppressions.
       protocol: !<!Protocols> {}
   choices:
+    - !<!ChoiceSchema> &ref_8
+      choices:
+        - !<!ChoiceValue> 
+          value: Alerts
+          language:
+            default:
+              name: Alerts
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Scenario
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_34
       choices:
         - !<!ChoiceValue> 
@@ -506,19 +524,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-2017-04-19
           description: Api Version (2017-04-19)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_8
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      value: !<!ConstantValue> 
-        value: Alerts
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: Scenario
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_19

--- a/modelerfour/test/scenarios/advisor/grouped.yaml
+++ b/modelerfour/test/scenarios/advisor/grouped.yaml
@@ -394,6 +394,24 @@ schemas: !<!Schemas>
           description: The link used to get the next page of suppressions.
       protocol: !<!Protocols> {}
   choices:
+    - !<!ChoiceSchema> &ref_8
+      choices:
+        - !<!ChoiceValue> 
+          value: Alerts
+          language:
+            default:
+              name: Alerts
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Scenario
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_34
       choices:
         - !<!ChoiceValue> 
@@ -506,19 +524,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-2017-04-19
           description: Api Version (2017-04-19)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_8
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      value: !<!ConstantValue> 
-        value: Alerts
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: Scenario
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_19

--- a/modelerfour/test/scenarios/advisor/modeler.yaml
+++ b/modelerfour/test/scenarios/advisor/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: AdvisorManagementClient
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_62
+    - !<!BooleanSchema> &ref_65
       type: boolean
       language: !<!Languages> 
         default:
@@ -92,7 +92,7 @@ schemas: !<!Schemas>
           name: MetadataEntityProperties-dependsOnItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           name: MetadataSupportedValueDetail-id
           description: The id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -112,7 +112,7 @@ schemas: !<!Schemas>
           name: MetadataSupportedValueDetail-displayName
           description: The display name.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -122,7 +122,7 @@ schemas: !<!Schemas>
           name: ARMErrorResponseBody-message
           description: Gets or sets the string that describes the error in detail and provides debugging information.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -132,7 +132,7 @@ schemas: !<!Schemas>
           name: ARMErrorResponseBody-code
           description: Gets or sets the string that can be used to programmatically identify the error.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -142,7 +142,7 @@ schemas: !<!Schemas>
           name: MetadataEntityListResult-nextLink
           description: The link used to get the next page of metadata.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_15
+    - !<!StringSchema> &ref_14
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -152,7 +152,7 @@ schemas: !<!Schemas>
           name: ConfigData-id
           description: The resource Id of the configuration resource.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_16
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -162,7 +162,7 @@ schemas: !<!Schemas>
           name: ConfigData-type
           description: The type of the configuration resource.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_16
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -172,7 +172,7 @@ schemas: !<!Schemas>
           name: ConfigData-name
           description: The name of the configuration resource.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_18
+    - !<!StringSchema> &ref_17
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -182,7 +182,7 @@ schemas: !<!Schemas>
           name: ConfigData-properties-low_cpu_threshold
           description: 'Minimum percentage threshold for Advisor low CPU utilization evaluation. Valid only for subscriptions. Valid values: 5 (default), 10, 15 or 20.'
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_20
+    - !<!StringSchema> &ref_19
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -203,7 +203,7 @@ schemas: !<!Schemas>
           description: ''
           header: Retry-After
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_30
+    - !<!StringSchema> &ref_29
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -213,7 +213,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_23
+    - !<!StringSchema> &ref_22
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -223,7 +223,7 @@ schemas: !<!Schemas>
           name: ResourceRecommendationBaseListResult-nextLink
           description: The link used to get the next page of recommendations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_24
+    - !<!StringSchema> &ref_23
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -233,7 +233,7 @@ schemas: !<!Schemas>
           name: RecommendationProperties-impactedField
           description: The resource type identified by Advisor.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_25
+    - !<!StringSchema> &ref_24
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -243,7 +243,7 @@ schemas: !<!Schemas>
           name: RecommendationProperties-impactedValue
           description: The resource identified by Advisor.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_27
+    - !<!StringSchema> &ref_26
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -253,7 +253,7 @@ schemas: !<!Schemas>
           name: RecommendationProperties-recommendationTypeId
           description: The recommendation-type GUID.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_28
+    - !<!StringSchema> &ref_27
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -263,7 +263,7 @@ schemas: !<!Schemas>
           name: ShortDescription-problem
           description: The issue or opportunity identified by the recommendation.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_29
+    - !<!StringSchema> &ref_28
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -273,7 +273,7 @@ schemas: !<!Schemas>
           name: ShortDescription-solution
           description: The remediation action suggested by the recommendation.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_31
+    - !<!StringSchema> &ref_30
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -283,7 +283,7 @@ schemas: !<!Schemas>
           name: Resource-id
           description: The resource ID.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_32
+    - !<!StringSchema> &ref_31
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -293,7 +293,7 @@ schemas: !<!Schemas>
           name: Resource-name
           description: The name of the resource.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
+    - !<!StringSchema> &ref_32
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -303,7 +303,7 @@ schemas: !<!Schemas>
           name: Resource-type
           description: The type of the resource.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_41
+    - !<!StringSchema> &ref_40
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -313,7 +313,7 @@ schemas: !<!Schemas>
           name: OperationEntityListResult-nextLink
           description: The link used to get the next page of operations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_42
+    - !<!StringSchema> &ref_41
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -323,7 +323,7 @@ schemas: !<!Schemas>
           name: OperationEntity-name
           description: 'Operation name: {provider}/{resource}/{operation}.'
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_43
+    - !<!StringSchema> &ref_42
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -333,7 +333,7 @@ schemas: !<!Schemas>
           name: OperationDisplayInfo-description
           description: The description of the operation.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_44
+    - !<!StringSchema> &ref_43
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -343,7 +343,7 @@ schemas: !<!Schemas>
           name: OperationDisplayInfo-operation
           description: 'The action that users can perform, based on their permission level.'
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_45
+    - !<!StringSchema> &ref_44
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -353,7 +353,7 @@ schemas: !<!Schemas>
           name: OperationDisplayInfo-provider
           description: 'Service provider: Microsoft Advisor.'
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_46
+    - !<!StringSchema> &ref_45
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -363,7 +363,7 @@ schemas: !<!Schemas>
           name: OperationDisplayInfo-resource
           description: Resource on which the operation is performed.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_35
+    - !<!StringSchema> &ref_34
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -373,7 +373,7 @@ schemas: !<!Schemas>
           name: SuppressionProperties-suppressionId
           description: The GUID of the suppression.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_36
+    - !<!StringSchema> &ref_35
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
           name: SuppressionProperties-ttl
           description: The duration for which the suppression is valid.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_50
+    - !<!StringSchema> &ref_49
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -394,7 +394,25 @@ schemas: !<!Schemas>
           description: The link used to get the next page of suppressions.
       protocol: !<!Protocols> {}
   choices:
-    - !<!ChoiceSchema> &ref_64
+    - !<!ChoiceSchema> &ref_59
+      choices:
+        - !<!ChoiceValue> 
+          value: Alerts
+          language:
+            default:
+              name: Alerts
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Scenario
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_60
       choices:
         - !<!ChoiceValue> 
           value: HighAvailability
@@ -436,7 +454,7 @@ schemas: !<!Schemas>
           name: category
           description: The category of the recommendation.
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_65
+    - !<!ChoiceSchema> &ref_61
       choices:
         - !<!ChoiceValue> 
           value: High
@@ -466,7 +484,7 @@ schemas: !<!Schemas>
           name: impact
           description: The business impact of the recommendation.
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_66
+    - !<!ChoiceSchema> &ref_62
       choices:
         - !<!ChoiceValue> 
           value: Error
@@ -507,23 +525,10 @@ schemas: !<!Schemas>
           name: ApiVersion-2017-04-19
           description: Api Version (2017-04-19)
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_6
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      value: !<!ConstantValue> 
-        value: Alerts
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: Scenario
-          description: ''
-      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_19
+    - !<!DictionarySchema> &ref_18
       type: dictionary
-      elementType: !<!AnySchema> &ref_26
+      elementType: !<!AnySchema> &ref_25
         type: any
         language: !<!Languages> 
           default:
@@ -535,17 +540,17 @@ schemas: !<!Schemas>
           name: ConfigData-properties
           description: The list of property name/value pairs.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_60
+    - !<!DictionarySchema> &ref_63
       type: dictionary
-      elementType: *ref_26
+      elementType: *ref_25
       language: !<!Languages> 
         default:
           name: RecommendationProperties-metadata
           description: The recommendation metadata.
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_61
+    - !<!DictionarySchema> &ref_64
       type: dictionary
-      elementType: *ref_30
+      elementType: *ref_29
       nullableItems: false
       language: !<!Languages> 
         default:
@@ -553,7 +558,7 @@ schemas: !<!Schemas>
           description: Extended properties
       protocol: !<!Protocols> {}
   any:
-    - *ref_26
+    - *ref_25
   dateTimes:
     - !<!DateTimeSchema> &ref_67
       type: date-time
@@ -577,7 +582,7 @@ schemas: !<!Schemas>
           name: uuid
           description: ''
       protocol: !<!Protocols> {}
-    - !<!UuidSchema> &ref_63
+    - !<!UuidSchema> &ref_66
       type: uuid
       apiVersions:
         - !<!ApiVersion> 
@@ -588,7 +593,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_13
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -619,7 +624,7 @@ schemas: !<!Schemas>
               description: The name of the metadata entity.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ObjectSchema> &ref_9
+          schema: !<!ObjectSchema> &ref_8
             type: object
             apiVersions:
               - !<!ApiVersion> 
@@ -634,7 +639,7 @@ schemas: !<!Schemas>
                     description: The display name.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ArraySchema> &ref_51
+                schema: !<!ArraySchema> &ref_50
                   type: array
                   apiVersions:
                     - !<!ApiVersion> 
@@ -652,12 +657,12 @@ schemas: !<!Schemas>
                     description: The list of keys on which this entity depends on.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ArraySchema> &ref_52
+                schema: !<!ArraySchema> &ref_51
                   type: array
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2017-04-19'
-                  elementType: *ref_6
+                  elementType: *ref_59
                   language: !<!Languages> 
                     default:
                       name: MetadataEntityProperties-applicableScenarios
@@ -670,19 +675,19 @@ schemas: !<!Schemas>
                     description: The list of scenarios applicable to this metadata entity.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: !<!ArraySchema> &ref_53
+                schema: !<!ArraySchema> &ref_52
                   type: array
                   apiVersions:
                     - !<!ApiVersion> 
                       version: '2017-04-19'
-                  elementType: !<!ObjectSchema> &ref_10
+                  elementType: !<!ObjectSchema> &ref_9
                     type: object
                     apiVersions:
                       - !<!ApiVersion> 
                         version: '2017-04-19'
                     properties:
                       - !<!Property> 
-                        schema: *ref_7
+                        schema: *ref_6
                         serializedName: id
                         language: !<!Languages> 
                           default:
@@ -690,7 +695,7 @@ schemas: !<!Schemas>
                             description: The id.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_8
+                        schema: *ref_7
                         serializedName: displayName
                         language: !<!Languages> 
                           default:
@@ -746,8 +751,8 @@ schemas: !<!Schemas>
           description: The metadata entity contract.
           namespace: ''
       protocol: !<!Protocols> {}
+    - *ref_8
     - *ref_9
-    - *ref_10
     - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
@@ -755,7 +760,7 @@ schemas: !<!Schemas>
           version: '2017-04-19'
       properties:
         - !<!Property> 
-          schema: *ref_11
+          schema: *ref_10
           serializedName: message
           language: !<!Languages> 
             default:
@@ -763,7 +768,7 @@ schemas: !<!Schemas>
               description: Gets or sets the string that describes the error in detail and provides debugging information.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_11
           serializedName: code
           language: !<!Languages> 
             default:
@@ -787,12 +792,12 @@ schemas: !<!Schemas>
           version: '2017-04-19'
       properties:
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_54
+          schema: !<!ArraySchema> &ref_53
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
-            elementType: *ref_13
+            elementType: *ref_12
             language: !<!Languages> 
               default:
                 name: MetadataEntityListResult-value
@@ -805,7 +810,7 @@ schemas: !<!Schemas>
               description: The list of metadata entities.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_14
+          schema: *ref_13
           serializedName: nextLink
           language: !<!Languages> 
             default:
@@ -829,19 +834,19 @@ schemas: !<!Schemas>
           version: '2017-04-19'
       properties:
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_55
+          schema: !<!ArraySchema> &ref_54
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
-            elementType: !<!ObjectSchema> &ref_21
+            elementType: !<!ObjectSchema> &ref_20
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: '2017-04-19'
               properties:
                 - !<!Property> 
-                  schema: *ref_15
+                  schema: *ref_14
                   serializedName: id
                   language: !<!Languages> 
                     default:
@@ -849,7 +854,7 @@ schemas: !<!Schemas>
                       description: The resource Id of the configuration resource.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_16
+                  schema: *ref_15
                   serializedName: type
                   language: !<!Languages> 
                     default:
@@ -857,7 +862,7 @@ schemas: !<!Schemas>
                       description: The type of the configuration resource.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_17
+                  schema: *ref_16
                   serializedName: name
                   language: !<!Languages> 
                     default:
@@ -865,19 +870,19 @@ schemas: !<!Schemas>
                       description: The name of the configuration resource.
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!ObjectSchema> &ref_22
+                  schema: !<!ObjectSchema> &ref_21
                     type: object
                     apiVersions:
                       - !<!ApiVersion> 
                         version: '2017-04-19'
                     parents: !<!Relations> 
                       all:
-                        - *ref_19
+                        - *ref_18
                       immediate:
-                        - *ref_19
+                        - *ref_18
                     properties:
                       - !<!Property> 
-                        schema: *ref_62
+                        schema: *ref_65
                         serializedName: exclude
                         language: !<!Languages> 
                           default:
@@ -885,7 +890,7 @@ schemas: !<!Schemas>
                             description: 'Exclude the resource from Advisor evaluations. Valid values: False (default) or True.'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_18
+                        schema: *ref_17
                         serializedName: low_cpu_threshold
                         language: !<!Languages> 
                           default:
@@ -932,7 +937,7 @@ schemas: !<!Schemas>
               description: The list of configurations.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_20
+          schema: *ref_19
           serializedName: nextLink
           language: !<!Languages> 
             default:
@@ -949,8 +954,8 @@ schemas: !<!Schemas>
           description: The list of Advisor configurations.
           namespace: ''
       protocol: !<!Protocols> {}
+    - *ref_20
     - *ref_21
-    - *ref_22
     - !<!ObjectSchema> &ref_88
       type: object
       apiVersions:
@@ -958,7 +963,7 @@ schemas: !<!Schemas>
           version: '2017-04-19'
       properties:
         - !<!Property> 
-          schema: *ref_23
+          schema: *ref_22
           serializedName: nextLink
           language: !<!Languages> 
             default:
@@ -966,46 +971,46 @@ schemas: !<!Schemas>
               description: The link used to get the next page of recommendations.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_57
+          schema: !<!ArraySchema> &ref_56
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
-            elementType: !<!ObjectSchema> &ref_34
+            elementType: !<!ObjectSchema> &ref_33
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: '2017-04-19'
               parents: !<!Relations> 
                 all:
-                  - !<!ObjectSchema> &ref_37
+                  - !<!ObjectSchema> &ref_36
                     type: object
                     apiVersions:
                       - !<!ApiVersion> 
                         version: '2017-04-19'
                     children: !<!Relations> 
                       all:
-                        - *ref_34
-                        - !<!ObjectSchema> &ref_38
+                        - *ref_33
+                        - !<!ObjectSchema> &ref_37
                           type: object
                           apiVersions:
                             - !<!ApiVersion> 
                               version: '2017-04-19'
                           parents: !<!Relations> 
                             all:
-                              - *ref_37
+                              - *ref_36
                             immediate:
-                              - *ref_37
+                              - *ref_36
                           properties:
                             - !<!Property> 
-                              schema: !<!ObjectSchema> &ref_49
+                              schema: !<!ObjectSchema> &ref_48
                                 type: object
                                 apiVersions:
                                   - !<!ApiVersion> 
                                     version: '2017-04-19'
                                 properties:
                                   - !<!Property> 
-                                    schema: *ref_35
+                                    schema: *ref_34
                                     serializedName: suppressionId
                                     language: !<!Languages> 
                                       default:
@@ -1013,7 +1018,7 @@ schemas: !<!Schemas>
                                         description: The GUID of the suppression.
                                     protocol: !<!Protocols> {}
                                   - !<!Property> 
-                                    schema: *ref_36
+                                    schema: *ref_35
                                     serializedName: ttl
                                     language: !<!Languages> 
                                       default:
@@ -1051,11 +1056,11 @@ schemas: !<!Schemas>
                               namespace: ''
                           protocol: !<!Protocols> {}
                       immediate:
-                        - *ref_34
-                        - *ref_38
+                        - *ref_33
+                        - *ref_37
                     properties:
                       - !<!Property> 
-                        schema: *ref_31
+                        schema: *ref_30
                         readOnly: true
                         serializedName: id
                         language: !<!Languages> 
@@ -1064,7 +1069,7 @@ schemas: !<!Schemas>
                             description: The resource ID.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_32
+                        schema: *ref_31
                         readOnly: true
                         serializedName: name
                         language: !<!Languages> 
@@ -1073,7 +1078,7 @@ schemas: !<!Schemas>
                             description: The name of the resource.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_33
+                        schema: *ref_32
                         readOnly: true
                         serializedName: type
                         language: !<!Languages> 
@@ -1095,17 +1100,17 @@ schemas: !<!Schemas>
                         namespace: ''
                     protocol: !<!Protocols> {}
                 immediate:
-                  - *ref_37
+                  - *ref_36
               properties:
                 - !<!Property> 
-                  schema: !<!ObjectSchema> &ref_39
+                  schema: !<!ObjectSchema> &ref_38
                     type: object
                     apiVersions:
                       - !<!ApiVersion> 
                         version: '2017-04-19'
                     properties:
                       - !<!Property> 
-                        schema: *ref_64
+                        schema: *ref_60
                         serializedName: category
                         language: !<!Languages> 
                           default:
@@ -1113,7 +1118,7 @@ schemas: !<!Schemas>
                             description: The category of the recommendation.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_65
+                        schema: *ref_61
                         serializedName: impact
                         language: !<!Languages> 
                           default:
@@ -1121,7 +1126,7 @@ schemas: !<!Schemas>
                             description: The business impact of the recommendation.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_24
+                        schema: *ref_23
                         serializedName: impactedField
                         language: !<!Languages> 
                           default:
@@ -1129,7 +1134,7 @@ schemas: !<!Schemas>
                             description: The resource type identified by Advisor.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_25
+                        schema: *ref_24
                         serializedName: impactedValue
                         language: !<!Languages> 
                           default:
@@ -1145,7 +1150,7 @@ schemas: !<!Schemas>
                             description: The most recent time that Advisor checked the validity of the recommendation.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_60
+                        schema: *ref_63
                         serializedName: metadata
                         language: !<!Languages> 
                           default:
@@ -1153,7 +1158,7 @@ schemas: !<!Schemas>
                             description: The recommendation metadata.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_27
+                        schema: *ref_26
                         serializedName: recommendationTypeId
                         language: !<!Languages> 
                           default:
@@ -1161,7 +1166,7 @@ schemas: !<!Schemas>
                             description: The recommendation-type GUID.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_66
+                        schema: *ref_62
                         serializedName: risk
                         language: !<!Languages> 
                           default:
@@ -1169,14 +1174,14 @@ schemas: !<!Schemas>
                             description: The potential risk of not implementing the recommendation.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: !<!ObjectSchema> &ref_40
+                        schema: !<!ObjectSchema> &ref_39
                           type: object
                           apiVersions:
                             - !<!ApiVersion> 
                               version: '2017-04-19'
                           properties:
                             - !<!Property> 
-                              schema: *ref_28
+                              schema: *ref_27
                               serializedName: problem
                               language: !<!Languages> 
                                 default:
@@ -1184,7 +1189,7 @@ schemas: !<!Schemas>
                                   description: The issue or opportunity identified by the recommendation.
                               protocol: !<!Protocols> {}
                             - !<!Property> 
-                              schema: *ref_29
+                              schema: *ref_28
                               serializedName: solution
                               language: !<!Languages> 
                                 default:
@@ -1209,12 +1214,12 @@ schemas: !<!Schemas>
                             description: A summary of the recommendation.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: !<!ArraySchema> &ref_56
+                        schema: !<!ArraySchema> &ref_55
                           type: array
                           apiVersions:
                             - !<!ApiVersion> 
                               version: '2017-04-19'
-                          elementType: *ref_63
+                          elementType: *ref_66
                           language: !<!Languages> 
                             default:
                               name: RecommendationProperties-suppressionIds
@@ -1227,7 +1232,7 @@ schemas: !<!Schemas>
                             description: The list of snoozed and dismissed rules for the recommendation.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_61
+                        schema: *ref_64
                         serializedName: extendedProperties
                         language: !<!Languages> 
                           default:
@@ -1285,10 +1290,10 @@ schemas: !<!Schemas>
           description: The list of Advisor recommendations.
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_34
+    - *ref_33
+    - *ref_38
     - *ref_39
-    - *ref_40
-    - *ref_37
+    - *ref_36
     - !<!ObjectSchema> &ref_91
       type: object
       apiVersions:
@@ -1296,7 +1301,7 @@ schemas: !<!Schemas>
           version: '2017-04-19'
       properties:
         - !<!Property> 
-          schema: *ref_41
+          schema: *ref_40
           serializedName: nextLink
           language: !<!Languages> 
             default:
@@ -1304,19 +1309,19 @@ schemas: !<!Schemas>
               description: The link used to get the next page of operations.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_58
+          schema: !<!ArraySchema> &ref_57
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
-            elementType: !<!ObjectSchema> &ref_47
+            elementType: !<!ObjectSchema> &ref_46
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: '2017-04-19'
               properties:
                 - !<!Property> 
-                  schema: *ref_42
+                  schema: *ref_41
                   serializedName: name
                   language: !<!Languages> 
                     default:
@@ -1324,14 +1329,14 @@ schemas: !<!Schemas>
                       description: 'Operation name: {provider}/{resource}/{operation}.'
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: !<!ObjectSchema> &ref_48
+                  schema: !<!ObjectSchema> &ref_47
                     type: object
                     apiVersions:
                       - !<!ApiVersion> 
                         version: '2017-04-19'
                     properties:
                       - !<!Property> 
-                        schema: *ref_43
+                        schema: *ref_42
                         serializedName: description
                         language: !<!Languages> 
                           default:
@@ -1339,7 +1344,7 @@ schemas: !<!Schemas>
                             description: The description of the operation.
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_44
+                        schema: *ref_43
                         serializedName: operation
                         language: !<!Languages> 
                           default:
@@ -1347,7 +1352,7 @@ schemas: !<!Schemas>
                             description: 'The action that users can perform, based on their permission level.'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_45
+                        schema: *ref_44
                         serializedName: provider
                         language: !<!Languages> 
                           default:
@@ -1355,7 +1360,7 @@ schemas: !<!Schemas>
                             description: 'Service provider: Microsoft Advisor.'
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_46
+                        schema: *ref_45
                         serializedName: resource
                         language: !<!Languages> 
                           default:
@@ -1409,10 +1414,10 @@ schemas: !<!Schemas>
           description: The list of Advisor operations.
           namespace: ''
       protocol: !<!Protocols> {}
+    - *ref_46
     - *ref_47
+    - *ref_37
     - *ref_48
-    - *ref_38
-    - *ref_49
     - !<!ObjectSchema> &ref_104
       type: object
       apiVersions:
@@ -1420,7 +1425,7 @@ schemas: !<!Schemas>
           version: '2017-04-19'
       properties:
         - !<!Property> 
-          schema: *ref_50
+          schema: *ref_49
           serializedName: nextLink
           language: !<!Languages> 
             default:
@@ -1428,12 +1433,12 @@ schemas: !<!Schemas>
               description: The link used to get the next page of suppressions.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_59
+          schema: !<!ArraySchema> &ref_58
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: '2017-04-19'
-            elementType: *ref_38
+            elementType: *ref_37
             language: !<!Languages> 
               default:
                 name: SuppressionContractListResult-value
@@ -1456,6 +1461,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
+    - *ref_50
     - *ref_51
     - *ref_52
     - *ref_53
@@ -1464,7 +1470,6 @@ schemas: !<!Schemas>
     - *ref_56
     - *ref_57
     - *ref_58
-    - *ref_59
 globalParameters:
   - !<!Parameter> &ref_76
     schema: *ref_68
@@ -1547,7 +1552,7 @@ operationGroups:
           - *ref_70
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1687,7 +1692,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_77
-                schema: *ref_21
+                schema: *ref_20
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1824,7 +1829,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_80
-                schema: *ref_21
+                schema: *ref_20
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1996,7 +2001,7 @@ operationGroups:
           - *ref_76
           - *ref_73
           - !<!Parameter> &ref_85
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2018,7 +2023,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> &ref_87
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2074,7 +2079,7 @@ operationGroups:
         parameters:
           - *ref_72
           - !<!Parameter> &ref_89
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2086,7 +2091,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> &ref_90
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2114,7 +2119,7 @@ operationGroups:
           - *ref_90
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_34
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -2197,7 +2202,7 @@ operationGroups:
         parameters:
           - *ref_72
           - !<!Parameter> &ref_92
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2209,7 +2214,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> &ref_93
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2221,7 +2226,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> &ref_94
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2250,7 +2255,7 @@ operationGroups:
           - *ref_94
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2274,7 +2279,7 @@ operationGroups:
         parameters:
           - *ref_72
           - !<!Parameter> &ref_95
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2286,7 +2291,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> &ref_96
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2298,7 +2303,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> &ref_97
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2314,7 +2319,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> &ref_98
-                schema: *ref_38
+                schema: *ref_37
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2345,7 +2350,7 @@ operationGroups:
           - *ref_97
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2369,7 +2374,7 @@ operationGroups:
         parameters:
           - *ref_72
           - !<!Parameter> &ref_99
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2381,7 +2386,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> &ref_100
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2393,7 +2398,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> &ref_101
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2455,7 +2460,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> &ref_103
-            schema: *ref_30
+            schema: *ref_29
             implementation: Method
             language: !<!Languages> 
               default:

--- a/modelerfour/test/scenarios/advisor/namer.yaml
+++ b/modelerfour/test/scenarios/advisor/namer.yaml
@@ -394,6 +394,24 @@ schemas: !<!Schemas>
           description: The link used to get the next page of suppressions.
       protocol: !<!Protocols> {}
   choices:
+    - !<!ChoiceSchema> &ref_8
+      choices:
+        - !<!ChoiceValue> 
+          value: Alerts
+          language:
+            default:
+              name: Alerts
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2017-04-19'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Scenario
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_34
       choices:
         - !<!ChoiceValue> 
@@ -506,19 +524,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion20170419
           description: Api Version (2017-04-19)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_8
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2017-04-19'
-      value: !<!ConstantValue> 
-        value: Alerts
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: Scenario
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_19

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -317,6 +317,24 @@ schemas: !<!Schemas>
           name: CMYKColors
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_59
+      choices:
+        - !<!ChoiceValue> 
+          value: Kind1
+          language:
+            default:
+              name: Kind1
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: MyKind
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_42
       choices:
         - !<!ChoiceValue> 
@@ -370,19 +388,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-2016-02-29
           description: Api Version (2016-02-29)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_59
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      value: !<!ConstantValue> 
-        value: Kind1
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: MyKind
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_24

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -317,6 +317,24 @@ schemas: !<!Schemas>
           name: CMYKColors
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_59
+      choices:
+        - !<!ChoiceValue> 
+          value: Kind1
+          language:
+            default:
+              name: Kind1
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: MyKind
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_42
       choices:
         - !<!ChoiceValue> 
@@ -370,19 +388,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-2016-02-29
           description: Api Version (2016-02-29)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_59
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      value: !<!ConstantValue> 
-        value: Kind1
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: MyKind
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_24

--- a/modelerfour/test/scenarios/body-complex/modeler.yaml
+++ b/modelerfour/test/scenarios/body-complex/modeler.yaml
@@ -320,6 +320,24 @@ schemas: !<!Schemas>
     - !<!ChoiceSchema> &ref_50
       choices:
         - !<!ChoiceValue> 
+          value: Kind1
+          language:
+            default:
+              name: Kind1
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      choiceType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: MyKind
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_51
+      choices:
+        - !<!ChoiceValue> 
           value: pink
           language:
             default:
@@ -370,19 +388,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-2016-02-29
           description: Api Version (2016-02-29)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_51
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      value: !<!ConstantValue> 
-        value: Kind1
-      valueType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: MyKind
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_67
@@ -1326,7 +1331,7 @@ schemas: !<!Schemas>
                           description: ''
                       protocol: !<!Protocols> {}
                     - !<!Property> 
-                      schema: *ref_50
+                      schema: *ref_51
                       serializedName: color
                       language: !<!Languages> 
                         default:
@@ -1721,7 +1726,7 @@ schemas: !<!Schemas>
         immediate:
           Kind1: *ref_46
         property: !<!Property> &ref_43
-          schema: *ref_51
+          schema: *ref_50
           isDiscriminator: true
           required: true
           serializedName: kind

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -317,6 +317,24 @@ schemas: !<!Schemas>
           name: CMYKColors
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ChoiceSchema> &ref_59
+      choices:
+        - !<!ChoiceValue> 
+          value: Kind1
+          language:
+            default:
+              name: Kind1
+              description: ''
+      type: choice
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2016-02-29'
+      choiceType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: MyKind
+          description: ''
+      protocol: !<!Protocols> {}
     - !<!ChoiceSchema> &ref_42
       choices:
         - !<!ChoiceValue> 
@@ -370,19 +388,6 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion20160229
           description: Api Version (2016-02-29)
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_59
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2016-02-29'
-      value: !<!ConstantValue> 
-        value: Kind1
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
-          name: MyKind
-          description: ''
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_24

--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -265,6 +265,40 @@ class Modeler {
   }
 
   @test
+  async "modelAsString=true creates ChoiceSchema for single-value enum"() {
+    const spec = createTestSpec();
+
+    addSchema(spec, "ShouldBeConstant", {
+      type: "string",
+      enum: ["html_strip"]
+    });
+
+    addSchema(spec, "ShouldBeChoice", {
+      type: "string",
+      enum: ["html_strip"],
+      "x-ms-enum": {
+        modelAsString: true
+      }
+    });
+
+    const codeModel = await runModeler(spec);
+
+    assertSchema(
+      "ShouldBeConstant",
+      codeModel.schemas.constants,
+      s => s.value.value,
+      "html_strip"
+    );
+
+    assertSchema(
+      "ShouldBeChoice",
+      codeModel.schemas.choices,
+      s => s.choices[0].value,
+      "html_strip"
+    );
+  }
+
+  @test
   async "propagates 'nullable' to properties, parameters, and collections"() {
     const spec = createTestSpec();
 


### PR DESCRIPTION
This change addresses issue #206 which reports that schemas with a single `enum` value and `x-ms-enum`'s `modelAsString` property set to `true` would be treated as `ConstantSchema` rather than `ChoiceSchema`.  The fix in this change comes from @fearthecowboy's PR #215 with some unit tests added.

I've also bumped the version to `4.15.0` because this is a breaking change.

/cc @srnagar 
