### PR TITLE
Propagate x-ms-client-default to properties and operation params

### DIFF
--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -22,8 +22,9 @@ specs:
      - body-duration.json
      - body-dictionary.json
      - body-file.json
-     - body-formdata-urlencoded.json
-     - body-formdata.json
+     # Not yet supported by AutoRest v3 and Modelerfour
+     # - body-formdata-urlencoded.json
+     # - body-formdata.json
      - body-integer.json
      - body-number.json
      - body-number.quirks.json
@@ -59,38 +60,26 @@ specs:
      - xms-error-responses.json
 languages:
   - language: python
-    excludeSpecs:
-      # The following specs aren't yet supported by @autorest/modelerfour
-      - body-formdata-urlencoded.json
-      - body-formdata.json
     outputPath: ../modelerfour/test/regression/python
     oldArgs:
       - --v3
-      - --use:@autorest/python@5.0.0-dev.20200326.1
+      - --use:@autorest/python@5.1.0-preview.3
+      - --use:@autorest/modelerfour@4.15.375
     newArgs:
       - --v3
       - --use:../modelerfour
-      - --use:@autorest/python@5.0.0-dev.20200326.1
+      - --use:@autorest/python@5.1.0-preview.3
   - language: typescript
-    excludeSpecs:
-      # The following specs currently crash the v3 TypeScript generator
-      - azure-special-properties.json
-      - body-formdata-urlencoded.json
-      - body-formdata.json
-      - lro.json
-      - media_types.json
-      - model-flattening.json
-      - multiapi-v3.json
-      - required-optional.json
     outputPath: ../modelerfour/test/regression/typescript
     oldArgs:
       - --v3
       - --package-name:test-package
       - --title:TestClient
-      - --use:@autorest/typescript@6.0.0-dev.20200325.1
+      - --use:@autorest/typescript@6.0.0-dev.20200626.1
+      - --use:@autorest/modelerfour@4.15.375
     newArgs:
       - --v3
       - --package-name:test-package
       - --title:TestClient
       - --use:../modelerfour
-      - --use:@autorest/typescript@6.0.0-dev.20200325.1
+      - --use:@autorest/typescript@6.0.0-dev.20200626.1

--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -71,6 +71,9 @@ languages:
       - --use:@autorest/python@5.1.0-preview.3
   - language: typescript
     outputPath: ../modelerfour/test/regression/typescript
+    excludeSpecs:
+      # The paging spec currently fails, will re-enable once it's fixed
+     - paging.json
     oldArgs:
       - --v3
       - --package-name:test-package

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -91,5 +91,5 @@ steps:
 - script: autorest-compare --compare:.scripts/regression-compare.yaml --language:python
   displayName: Regression Test - @autorest/python
 
-# - script: autorest-compare --compare:.scripts/regression-compare.yaml --language:typescript
-#   displayName: Regression Test - @autorest/typescript
+- script: autorest-compare --compare:.scripts/regression-compare.yaml --language:typescript
+  displayName: Regression Test - @autorest/typescript

--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -620,7 +620,7 @@ export class ModelerFour {
           serializedName: propertyName,
           isDiscriminator: discriminatorProperty === propertyName ? true : undefined,
           extensions: this.interpret.getExtensionProperties(property, propertyDeclaration),
-          clientDefaultValue: this.interpret.getClientDefault(property, propertyDeclaration),
+          clientDefaultValue: this.interpret.getClientDefault(property.instance, propertyDeclaration),
         }));
         if (prop.isDiscriminator) {
           objectSchema.discriminator = new Discriminator(prop);
@@ -1108,7 +1108,8 @@ export class ModelerFour {
         })
       },
       implementation: ImplementationLocation.Method,
-      required: true
+      required: true,
+      clientDefaultValue: this.interpret.getClientDefault(body?.instance || {}, {})
     }));
 
     return operation.addRequest(httpRequest);
@@ -1166,7 +1167,8 @@ export class ModelerFour {
           style: <SerializationStyle><any>kmt,
         })
       },
-      implementation: ImplementationLocation.Method
+      implementation: ImplementationLocation.Method,
+      clientDefaultValue: this.interpret.getClientDefault(body?.instance || {}, {})
     }));
     return operation.addRequest(httpRequest);
   }

--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -49,7 +49,7 @@
     "eslint": "~6.6.0",
     "@azure-tools/async-io": "~3.0.0",
     "source-map-support": "0.5.13",
-    "@microsoft.azure/autorest.testserver": "~2.10.10",
+    "@microsoft.azure/autorest.testserver": "~2.10.46",
     "@azure-tools/uri": "~3.0.0",
     "js-yaml": "3.13.1",
     "@azure-tools/codegen": "~2.5.0",

--- a/modelerfour/package.json
+++ b/modelerfour/package.json
@@ -19,6 +19,7 @@
     "watch": "tsc -p . --watch",
     "build": "tsc -p .",
     "prepack": "npm run static-link && npm run build",
+    "unit-test": "npm run build && mocha dist/test/unit",
     "test": "npm run build && mocha dist/test --timeout=200000 && mocha dist/test/unit"
   },
   "repository": {


### PR DESCRIPTION
This change addresses issue #268 which reports that `x-ms-client-default` isn't being propagated to the `clientDefaultValue` field of model properties and operation parameters.  I've wired up `clientDefaultValue` handling for the following scenarios:

- `ObjectSchema` property (It was already implemented but looking for `x-ms-client-default` in the wrong place)
- Operation parameters (query, path, header)
- Operation request bodies

I've also added a unit test that exercises these paths.  I'll run Laurent's new [testserver spec](https://github.com/Azure/autorest.testserver/pull/195) with this to see whether it handles all of the cases there correctly.

/cc @lmazuel 
