### PR TITLE
Add missing x-nullable support for body params, responses, and collection schemas

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -1109,6 +1109,7 @@ export class ModelerFour {
       },
       implementation: ImplementationLocation.Method,
       required: true,
+      nullable: requestSchema?.instance?.nullable,
       clientDefaultValue: this.interpret.getClientDefault(body?.instance || {}, {})
     }));
 
@@ -1162,6 +1163,7 @@ export class ModelerFour {
       pSchema, {
       extensions: this.interpret.getExtensionProperties(body.instance),
       required: !!body.instance.required,
+      nullable: requestSchema?.instance?.nullable,
       protocol: {
         http: new HttpParameter(ParameterLocation.Body, {
           style: <SerializationStyle><any>kmt,
@@ -1575,7 +1577,8 @@ export class ModelerFour {
             }
 
             const rsp = new SchemaResponse(s, {
-              extensions: this.interpret.getExtensionProperties(response)
+              extensions: this.interpret.getExtensionProperties(response),
+              nullable: schema.nullable
             });
 
             rsp.protocol.http = SetType(HttpResponse, {

--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -564,7 +564,7 @@ export class ModelerFour {
       if (ei && this.interpret.isEmptyObject(ei)) {
         elementSchema = this.anySchema;
       } else {
-        elementNullable = (ei && ei.nullable) || false;
+        elementNullable = (<any>schema.additionalProperties)["nullable"] || (ei && ei.nullable) || undefined;
         elementSchema = this.processSchema(eschema.name || '', <OpenAPI.Schema>eschema.instance);
       }
     }

--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -407,7 +407,7 @@ export class ModelerFour {
       apiVersions: this.interpret.getApiVersions(schema),
       example: this.interpret.getExample(schema),
       externalDocs: this.interpret.getExternalDocs(schema),
-      nullableItems: itemSchema.instance.nullable,
+      nullableItems: (<any>schema.items).nullable || itemSchema.instance?.nullable,
       serialization: this.interpret.getSerialization(schema),
       maxItems: schema.maxItems ? Number(schema.maxItems) : undefined,
       minItems: schema.minItems ? Number(schema.minItems) : undefined,

--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -388,7 +388,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -388,7 +388,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/a-playground/modeler.yaml
+++ b/modelerfour/test/scenarios/a-playground/modeler.yaml
@@ -388,7 +388,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_67
       type: dictionary
       elementType: *ref_12
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -388,7 +388,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryWrapperDefaultProgram

--- a/modelerfour/test/scenarios/additionalProperties/flattened.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/flattened.yaml
@@ -145,7 +145,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPString
@@ -154,7 +153,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInProperties-additionalProperties
@@ -163,7 +161,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_16
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
@@ -172,7 +169,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_19
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString-additionalProperties

--- a/modelerfour/test/scenarios/additionalProperties/grouped.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/grouped.yaml
@@ -145,7 +145,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPString
@@ -154,7 +153,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInProperties-additionalProperties
@@ -163,7 +161,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_16
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
@@ -172,7 +169,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_19
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString-additionalProperties

--- a/modelerfour/test/scenarios/additionalProperties/modeler.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/modeler.yaml
@@ -145,7 +145,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_13
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPString
@@ -154,7 +153,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInProperties-additionalProperties
@@ -163,7 +161,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_19
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
@@ -172,7 +169,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_18
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString-additionalProperties

--- a/modelerfour/test/scenarios/additionalProperties/namer.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/namer.yaml
@@ -145,7 +145,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPString
@@ -154,7 +153,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesAdditionalProperties
@@ -163,7 +161,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_16
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
@@ -172,7 +169,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_19
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPStringAdditionalProperties

--- a/modelerfour/test/scenarios/advisor/flattened.yaml
+++ b/modelerfour/test/scenarios/advisor/flattened.yaml
@@ -551,7 +551,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_45
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: RecommendationProperties-extendedProperties

--- a/modelerfour/test/scenarios/advisor/grouped.yaml
+++ b/modelerfour/test/scenarios/advisor/grouped.yaml
@@ -551,7 +551,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_45
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: RecommendationProperties-extendedProperties

--- a/modelerfour/test/scenarios/advisor/modeler.yaml
+++ b/modelerfour/test/scenarios/advisor/modeler.yaml
@@ -551,7 +551,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_64
       type: dictionary
       elementType: *ref_29
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: RecommendationProperties-extendedProperties

--- a/modelerfour/test/scenarios/advisor/namer.yaml
+++ b/modelerfour/test/scenarios/advisor/namer.yaml
@@ -551,7 +551,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_45
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: RecommendationPropertiesExtendedProperties

--- a/modelerfour/test/scenarios/azure-report/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-report/flattened.yaml
@@ -55,7 +55,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·obr50g·report-azure·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/azure-report/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-report/grouped.yaml
@@ -55,7 +55,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·obr50g·report-azure·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/azure-report/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-report/modeler.yaml
@@ -55,7 +55,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_6
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·obr50g·report-azure·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/azure-report/namer.yaml
+++ b/modelerfour/test/scenarios/azure-report/namer.yaml
@@ -55,7 +55,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger

--- a/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
@@ -104,7 +104,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceX-tags
@@ -233,7 +232,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -242,7 +240,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
@@ -104,7 +104,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceX-tags
@@ -233,7 +232,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -242,7 +240,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
@@ -104,7 +104,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceX-tags
@@ -250,7 +249,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -259,7 +257,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_13
       type: dictionary
       elementType: *ref_8
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -104,7 +104,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceXTags
@@ -233,7 +232,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfFlattenedProduct
@@ -242,7 +240,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollectionDictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource/flattened.yaml
@@ -104,7 +104,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -233,7 +232,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -242,7 +240,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource/grouped.yaml
@@ -104,7 +104,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -233,7 +232,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -242,7 +240,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource/modeler.yaml
@@ -104,7 +104,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -250,7 +249,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -259,7 +257,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_13
       type: dictionary
       elementType: *ref_8
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -104,7 +104,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_4
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceTags
@@ -233,7 +232,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfFlattenedProduct
@@ -242,7 +240,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_12
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollectionDictionaryofresources

--- a/modelerfour/test/scenarios/blob-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/blob-storage/flattened.yaml
@@ -7397,7 +7397,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_42
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ContainerMetadata
@@ -7406,7 +7405,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_90
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: BlobMetadata

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -7397,7 +7397,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_42
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ContainerMetadata
@@ -7406,7 +7405,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_90
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: BlobMetadata

--- a/modelerfour/test/scenarios/blob-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/blob-storage/modeler.yaml
@@ -7397,7 +7397,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_131
       type: dictionary
       elementType: *ref_26
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ContainerMetadata
@@ -7406,7 +7405,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_65
       type: dictionary
       elementType: *ref_64
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: BlobMetadata

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -7397,7 +7397,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_138
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ContainerMetadata
@@ -7406,7 +7405,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_186
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: BlobMetadata

--- a/modelerfour/test/scenarios/body-array/flattened.yaml
+++ b/modelerfour/test/scenarios/body-array/flattened.yaml
@@ -202,7 +202,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_25
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·p8a977·array-dictionary-null·get·responses·200·content·application-json·schema·items

--- a/modelerfour/test/scenarios/body-array/grouped.yaml
+++ b/modelerfour/test/scenarios/body-array/grouped.yaml
@@ -202,7 +202,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_25
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·p8a977·array-dictionary-null·get·responses·200·content·application-json·schema·items

--- a/modelerfour/test/scenarios/body-array/modeler.yaml
+++ b/modelerfour/test/scenarios/body-array/modeler.yaml
@@ -202,7 +202,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_25
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·p8a977·array-dictionary-null·get·responses·200·content·application-json·schema·items

--- a/modelerfour/test/scenarios/body-array/namer.yaml
+++ b/modelerfour/test/scenarios/body-array/namer.yaml
@@ -202,7 +202,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_25
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfString

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -393,7 +393,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -393,7 +393,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/body-complex/modeler.yaml
+++ b/modelerfour/test/scenarios/body-complex/modeler.yaml
@@ -393,7 +393,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_67
       type: dictionary
       elementType: *ref_12
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: dictionary-wrapper-defaultProgram

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -393,7 +393,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryWrapperDefaultProgram

--- a/modelerfour/test/scenarios/body-dictionary/flattened.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/flattened.yaml
@@ -129,7 +129,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
@@ -138,7 +137,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
@@ -147,7 +145,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_28
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
@@ -156,7 +153,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_31
       type: dictionary
       elementType: *ref_3
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
@@ -165,7 +161,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_4
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -174,7 +169,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_35
       type: dictionary
       elementType: *ref_5
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -192,7 +186,6 @@ schemas: !<!Schemas>
             name: date
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
@@ -211,7 +204,6 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
@@ -230,7 +222,6 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
@@ -248,7 +239,6 @@ schemas: !<!Schemas>
             name: duration
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
@@ -267,7 +257,6 @@ schemas: !<!Schemas>
             name: paths·lgwr7z·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
@@ -286,7 +275,6 @@ schemas: !<!Schemas>
             name: paths·ul7uf·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
@@ -327,7 +315,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
@@ -346,7 +333,6 @@ schemas: !<!Schemas>
             name: paths·1y9iid6·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
@@ -365,7 +351,6 @@ schemas: !<!Schemas>
             name: paths·afa1hv·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
@@ -384,7 +369,6 @@ schemas: !<!Schemas>
             name: paths·1dxz488·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema

--- a/modelerfour/test/scenarios/body-dictionary/grouped.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/grouped.yaml
@@ -129,7 +129,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
@@ -138,7 +137,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
@@ -147,7 +145,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_28
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
@@ -156,7 +153,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_31
       type: dictionary
       elementType: *ref_3
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
@@ -165,7 +161,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_4
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -174,7 +169,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_35
       type: dictionary
       elementType: *ref_5
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -192,7 +186,6 @@ schemas: !<!Schemas>
             name: date
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
@@ -211,7 +204,6 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
@@ -230,7 +222,6 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
@@ -248,7 +239,6 @@ schemas: !<!Schemas>
             name: duration
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
@@ -267,7 +257,6 @@ schemas: !<!Schemas>
             name: paths·lgwr7z·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
@@ -286,7 +275,6 @@ schemas: !<!Schemas>
             name: paths·ul7uf·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
@@ -327,7 +315,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
@@ -346,7 +333,6 @@ schemas: !<!Schemas>
             name: paths·1y9iid6·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
@@ -365,7 +351,6 @@ schemas: !<!Schemas>
             name: paths·afa1hv·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
@@ -384,7 +369,6 @@ schemas: !<!Schemas>
             name: paths·1dxz488·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema

--- a/modelerfour/test/scenarios/body-dictionary/modeler.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/modeler.yaml
@@ -129,7 +129,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_23
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
@@ -138,7 +137,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
@@ -147,7 +145,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_28
       type: dictionary
       elementType: *ref_11
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
@@ -156,7 +153,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_31
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
@@ -165,7 +161,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_3
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -174,7 +169,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_35
       type: dictionary
       elementType: *ref_4
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
@@ -192,7 +186,6 @@ schemas: !<!Schemas>
             name: date
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
@@ -211,7 +204,6 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
@@ -230,7 +222,6 @@ schemas: !<!Schemas>
             name: date-time
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
@@ -248,7 +239,6 @@ schemas: !<!Schemas>
             name: duration
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
@@ -267,7 +257,6 @@ schemas: !<!Schemas>
             name: paths·lgwr7z·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
@@ -286,7 +275,6 @@ schemas: !<!Schemas>
             name: paths·ul7uf·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
@@ -327,7 +315,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
@@ -346,7 +333,6 @@ schemas: !<!Schemas>
             name: paths·1y9iid6·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
@@ -365,7 +351,6 @@ schemas: !<!Schemas>
             name: paths·afa1hv·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
@@ -384,7 +369,6 @@ schemas: !<!Schemas>
             name: paths·1dxz488·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema

--- a/modelerfour/test/scenarios/body-dictionary/namer.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/namer.yaml
@@ -129,7 +129,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger
@@ -138,7 +137,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfString
@@ -147,7 +145,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_28
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfBoolean
@@ -156,7 +153,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_31
       type: dictionary
       elementType: *ref_3
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger
@@ -165,7 +161,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_4
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfNumber
@@ -174,7 +169,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_35
       type: dictionary
       elementType: *ref_5
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfNumber
@@ -192,7 +186,6 @@ schemas: !<!Schemas>
             name: Date
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfDate
@@ -211,7 +204,6 @@ schemas: !<!Schemas>
             name: DateTime
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfDateTime
@@ -230,7 +222,6 @@ schemas: !<!Schemas>
             name: DateTime
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfDateTime
@@ -248,7 +239,6 @@ schemas: !<!Schemas>
             name: Duration
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfDuration
@@ -267,7 +257,6 @@ schemas: !<!Schemas>
             name: ByteArray
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfByteArray
@@ -286,7 +275,6 @@ schemas: !<!Schemas>
             name: ByteArray
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfByteArray
@@ -327,7 +315,6 @@ schemas: !<!Schemas>
             description: ''
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfWidget
@@ -346,7 +333,6 @@ schemas: !<!Schemas>
             name: ArrayOfGet200ApplicationJsonAdditionalPropertiesItem
             description: Array of Get200ApplicationJsonAdditionalPropertiesItem
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfpaths1Y9Iid6DictionaryArrayNullGetResponses200ContentApplicationJsonSchemaAdditionalproperties
@@ -365,7 +351,6 @@ schemas: !<!Schemas>
             name: ArrayOfString
             description: Array of String
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfpathsAfa1HvDictionaryArrayEmptyGetResponses200ContentApplicationJsonSchemaAdditionalproperties
@@ -384,7 +369,6 @@ schemas: !<!Schemas>
             name: ArrayOfPutContentSchemaItemsItem
             description: Array of PutContentSchemaItemsItem
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfpaths1Dxz488DictionaryArrayValidPutRequestbodyContentApplicationJsonSchemaAdditionalproperties

--- a/modelerfour/test/scenarios/cognitive-search/flattened.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/flattened.yaml
@@ -817,7 +817,6 @@ schemas: !<!Schemas>
             name: components·1039crn·schemas·documentsearchresult·properties·search-facets·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Facets
@@ -844,7 +843,6 @@ schemas: !<!Schemas>
             name: components·1fouik0·schemas·searchresult·properties·search-highlights·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Highlights

--- a/modelerfour/test/scenarios/cognitive-search/grouped.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/grouped.yaml
@@ -817,7 +817,6 @@ schemas: !<!Schemas>
             name: components·1039crn·schemas·documentsearchresult·properties·search-facets·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Facets
@@ -844,7 +843,6 @@ schemas: !<!Schemas>
             name: components·1fouik0·schemas·searchresult·properties·search-highlights·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Highlights

--- a/modelerfour/test/scenarios/cognitive-search/modeler.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/modeler.yaml
@@ -817,7 +817,6 @@ schemas: !<!Schemas>
             name: components·1039crn·schemas·documentsearchresult·properties·search-facets·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Facets
@@ -844,7 +843,6 @@ schemas: !<!Schemas>
             name: components·1fouik0·schemas·searchresult·properties·search-highlights·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Highlights

--- a/modelerfour/test/scenarios/cognitive-search/namer.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/namer.yaml
@@ -817,7 +817,6 @@ schemas: !<!Schemas>
             name: ArrayOfFacetResult
             description: Array of FacetResult
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Facets
@@ -844,7 +843,6 @@ schemas: !<!Schemas>
             name: ArrayOfSearchResultSearchHighlightsItemsItem
             description: Array of SearchResultSearchHighlightsItemsItem
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Highlights

--- a/modelerfour/test/scenarios/complex-model/flattened.yaml
+++ b/modelerfour/test/scenarios/complex-model/flattened.yaml
@@ -182,7 +182,6 @@ schemas: !<!Schemas>
             name: components·5px1as·schemas·catalogdictionaryofarray·properties·productdictionaryofarray·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryOfArray-productDictionaryOfArray
@@ -191,7 +190,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_10
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionary-productDictionary
@@ -200,7 +198,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_11
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogArrayOfDictionary-productArrayOfDictionaryItem

--- a/modelerfour/test/scenarios/complex-model/grouped.yaml
+++ b/modelerfour/test/scenarios/complex-model/grouped.yaml
@@ -182,7 +182,6 @@ schemas: !<!Schemas>
             name: components·5px1as·schemas·catalogdictionaryofarray·properties·productdictionaryofarray·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryOfArray-productDictionaryOfArray
@@ -191,7 +190,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_10
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionary-productDictionary
@@ -200,7 +198,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_11
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogArrayOfDictionary-productArrayOfDictionaryItem

--- a/modelerfour/test/scenarios/complex-model/modeler.yaml
+++ b/modelerfour/test/scenarios/complex-model/modeler.yaml
@@ -182,7 +182,6 @@ schemas: !<!Schemas>
             name: components·5px1as·schemas·catalogdictionaryofarray·properties·productdictionaryofarray·additionalproperties
             description: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryOfArray-productDictionaryOfArray
@@ -191,7 +190,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_13
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionary-productDictionary
@@ -200,7 +198,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_14
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogArrayOfDictionary-productArrayOfDictionaryItem

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -182,7 +182,6 @@ schemas: !<!Schemas>
             name: ArrayOfProduct
             description: Array of Product
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryOfArrayProductDictionaryOfArray
@@ -191,7 +190,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_10
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogDictionaryProductDictionary
@@ -200,7 +198,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_11
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CatalogArrayOfDictionaryProductArrayOfDictionaryItem

--- a/modelerfour/test/scenarios/keyvault/flattened.yaml
+++ b/modelerfour/test/scenarios/keyvault/flattened.yaml
@@ -1557,7 +1557,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyCreateParameters-tags
@@ -1566,7 +1565,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_36
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyBundle-tags
@@ -1575,7 +1573,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_43
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyImportParameters-tags
@@ -1584,7 +1581,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_44
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyUpdateParameters-tags
@@ -1593,7 +1589,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_49
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyItem-tags
@@ -1602,7 +1597,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_64
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretSetParameters-tags
@@ -1611,7 +1605,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_74
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretBundle-tags
@@ -1620,7 +1613,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_78
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretUpdateParameters-tags
@@ -1629,7 +1621,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_83
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretItem-tags
@@ -1638,7 +1629,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_96
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateItem-tags
@@ -1647,7 +1637,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_122
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateBundle-tags
@@ -1656,7 +1645,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_158
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateCreateParameters-tags
@@ -1665,7 +1653,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_168
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateImportParameters-tags
@@ -1674,7 +1661,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_169
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateUpdateParameters-tags
@@ -1683,7 +1669,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_171
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateMergeParameters-tags
@@ -1692,7 +1677,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_183
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountItem-tags
@@ -1701,7 +1685,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_193
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageBundle-tags
@@ -1710,7 +1693,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_201
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountCreateParameters-tags
@@ -1719,7 +1701,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_204
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountUpdateParameters-tags
@@ -1728,7 +1709,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_213
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionItem-tags
@@ -1737,7 +1717,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_223
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionBundle-tags
@@ -1746,7 +1725,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_228
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionCreateParameters-tags
@@ -1755,7 +1733,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_231
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionUpdateParameters-tags

--- a/modelerfour/test/scenarios/keyvault/grouped.yaml
+++ b/modelerfour/test/scenarios/keyvault/grouped.yaml
@@ -1557,7 +1557,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyCreateParameters-tags
@@ -1566,7 +1565,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_36
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyBundle-tags
@@ -1575,7 +1573,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_43
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyImportParameters-tags
@@ -1584,7 +1581,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_44
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyUpdateParameters-tags
@@ -1593,7 +1589,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_49
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyItem-tags
@@ -1602,7 +1597,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_64
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretSetParameters-tags
@@ -1611,7 +1605,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_74
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretBundle-tags
@@ -1620,7 +1613,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_78
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretUpdateParameters-tags
@@ -1629,7 +1621,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_83
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretItem-tags
@@ -1638,7 +1629,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_96
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateItem-tags
@@ -1647,7 +1637,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_122
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateBundle-tags
@@ -1656,7 +1645,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_158
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateCreateParameters-tags
@@ -1665,7 +1653,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_168
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateImportParameters-tags
@@ -1674,7 +1661,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_169
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateUpdateParameters-tags
@@ -1683,7 +1669,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_171
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateMergeParameters-tags
@@ -1692,7 +1677,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_183
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountItem-tags
@@ -1701,7 +1685,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_193
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageBundle-tags
@@ -1710,7 +1693,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_201
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountCreateParameters-tags
@@ -1719,7 +1701,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_204
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountUpdateParameters-tags
@@ -1728,7 +1709,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_213
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionItem-tags
@@ -1737,7 +1717,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_223
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionBundle-tags
@@ -1746,7 +1725,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_228
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionCreateParameters-tags
@@ -1755,7 +1733,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_231
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionUpdateParameters-tags

--- a/modelerfour/test/scenarios/keyvault/modeler.yaml
+++ b/modelerfour/test/scenarios/keyvault/modeler.yaml
@@ -1557,7 +1557,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_204
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyCreateParameters-tags
@@ -1566,7 +1565,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_205
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyBundle-tags
@@ -1575,7 +1573,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_206
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyImportParameters-tags
@@ -1584,7 +1581,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_207
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyUpdateParameters-tags
@@ -1593,7 +1589,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_208
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyItem-tags
@@ -1602,7 +1597,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_209
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretSetParameters-tags
@@ -1611,7 +1605,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_210
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretBundle-tags
@@ -1620,7 +1613,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_211
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretUpdateParameters-tags
@@ -1629,7 +1621,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_212
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretItem-tags
@@ -1638,7 +1629,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_213
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateItem-tags
@@ -1647,7 +1637,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_214
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateBundle-tags
@@ -1656,7 +1645,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_215
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateCreateParameters-tags
@@ -1665,7 +1653,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_216
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateImportParameters-tags
@@ -1674,7 +1661,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_217
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateUpdateParameters-tags
@@ -1683,7 +1669,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_218
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateMergeParameters-tags
@@ -1692,7 +1677,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_219
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountItem-tags
@@ -1701,7 +1685,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_220
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageBundle-tags
@@ -1710,7 +1693,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_221
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountCreateParameters-tags
@@ -1719,7 +1701,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_222
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountUpdateParameters-tags
@@ -1728,7 +1709,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_223
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionItem-tags
@@ -1737,7 +1717,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_224
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionBundle-tags
@@ -1746,7 +1725,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_225
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionCreateParameters-tags
@@ -1755,7 +1733,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_226
       type: dictionary
       elementType: *ref_6
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionUpdateParameters-tags

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -1557,7 +1557,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_15
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyCreateParametersTags
@@ -1566,7 +1565,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_36
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyBundleTags
@@ -1575,7 +1573,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_43
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyImportParametersTags
@@ -1584,7 +1581,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_44
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyUpdateParametersTags
@@ -1593,7 +1589,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_49
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: KeyItemTags
@@ -1602,7 +1597,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_64
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretSetParametersTags
@@ -1611,7 +1605,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_74
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretBundleTags
@@ -1620,7 +1613,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_78
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretUpdateParametersTags
@@ -1629,7 +1621,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_83
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SecretItemTags
@@ -1638,7 +1629,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_96
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateItemTags
@@ -1647,7 +1637,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_122
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateBundleTags
@@ -1656,7 +1645,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_158
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateCreateParametersTags
@@ -1665,7 +1653,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_168
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateImportParametersTags
@@ -1674,7 +1661,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_169
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateUpdateParametersTags
@@ -1683,7 +1669,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_171
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: CertificateMergeParametersTags
@@ -1692,7 +1677,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_183
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountItemTags
@@ -1701,7 +1685,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_193
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageBundleTags
@@ -1710,7 +1693,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_201
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountCreateParametersTags
@@ -1719,7 +1701,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_204
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: StorageAccountUpdateParametersTags
@@ -1728,7 +1709,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_213
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionItemTags
@@ -1737,7 +1717,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_223
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionBundleTags
@@ -1746,7 +1725,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_228
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionCreateParametersTags
@@ -1755,7 +1733,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_231
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: SasDefinitionUpdateParametersTags

--- a/modelerfour/test/scenarios/lro/flattened.yaml
+++ b/modelerfour/test/scenarios/lro/flattened.yaml
@@ -400,7 +400,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/lro/grouped.yaml
+++ b/modelerfour/test/scenarios/lro/grouped.yaml
@@ -400,7 +400,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/lro/modeler.yaml
+++ b/modelerfour/test/scenarios/lro/modeler.yaml
@@ -400,7 +400,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_23
       type: dictionary
       elementType: *ref_4
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -400,7 +400,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceTags

--- a/modelerfour/test/scenarios/model-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/model-flattening/flattened.yaml
@@ -267,7 +267,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -406,7 +405,6 @@ schemas: !<!Schemas>
             description: Flattened product.
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1r824xk·model_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -415,7 +413,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_17
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -267,7 +267,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -406,7 +405,6 @@ schemas: !<!Schemas>
             description: Flattened product.
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1r824xk·model_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -415,7 +413,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_17
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/model-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/model-flattening/modeler.yaml
@@ -267,7 +267,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_26
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags
@@ -422,7 +421,6 @@ schemas: !<!Schemas>
             description: Flattened product.
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·1r824xk·model_flatten-dictionary·put·requestbody·content·application-json·schema
@@ -431,7 +429,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_27
       type: dictionary
       elementType: *ref_10
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -267,7 +267,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_5
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceTags
@@ -406,7 +405,6 @@ schemas: !<!Schemas>
             description: Flattened product.
             namespace: ''
         protocol: !<!Protocols> {}
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfFlattenedProduct
@@ -415,7 +413,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_33
       type: dictionary
       elementType: *ref_2
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceCollectionDictionaryofresources

--- a/modelerfour/test/scenarios/parameter-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/flattened.yaml
@@ -36,7 +36,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_1
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: AvailabilitySetUpdateParameters-tags

--- a/modelerfour/test/scenarios/parameter-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/grouped.yaml
@@ -36,7 +36,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_1
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: AvailabilitySetUpdateParameters-tags

--- a/modelerfour/test/scenarios/parameter-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/modeler.yaml
@@ -36,7 +36,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_1
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: AvailabilitySetUpdateParameters-tags

--- a/modelerfour/test/scenarios/parameter-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/parameter-flattening/namer.yaml
@@ -36,7 +36,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_1
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: AvailabilitySetUpdateParametersTags

--- a/modelerfour/test/scenarios/report/flattened.yaml
+++ b/modelerfour/test/scenarios/report/flattened.yaml
@@ -55,7 +55,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ifo91j·report·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/report/grouped.yaml
+++ b/modelerfour/test/scenarios/report/grouped.yaml
@@ -55,7 +55,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ifo91j·report·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/report/modeler.yaml
+++ b/modelerfour/test/scenarios/report/modeler.yaml
@@ -55,7 +55,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_6
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: paths·ifo91j·report·get·responses·200·content·application-json·schema

--- a/modelerfour/test/scenarios/report/namer.yaml
+++ b/modelerfour/test/scenarios/report/namer.yaml
@@ -55,7 +55,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger

--- a/modelerfour/test/scenarios/storage/flattened.yaml
+++ b/modelerfour/test/scenarios/storage/flattened.yaml
@@ -441,7 +441,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_29
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/storage/grouped.yaml
+++ b/modelerfour/test/scenarios/storage/grouped.yaml
@@ -441,7 +441,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_29
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/storage/modeler.yaml
+++ b/modelerfour/test/scenarios/storage/modeler.yaml
@@ -441,7 +441,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_41
       type: dictionary
       elementType: *ref_8
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Resource-tags

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -441,7 +441,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_29
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: ResourceTags

--- a/modelerfour/test/scenarios/text-analytics/flattened.yaml
+++ b/modelerfour/test/scenarios/text-analytics/flattened.yaml
@@ -681,7 +681,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_21
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: InnerError-details

--- a/modelerfour/test/scenarios/text-analytics/grouped.yaml
+++ b/modelerfour/test/scenarios/text-analytics/grouped.yaml
@@ -681,7 +681,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_21
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: InnerError-details

--- a/modelerfour/test/scenarios/text-analytics/modeler.yaml
+++ b/modelerfour/test/scenarios/text-analytics/modeler.yaml
@@ -681,7 +681,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_94
       type: dictionary
       elementType: *ref_13
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: InnerError-details

--- a/modelerfour/test/scenarios/text-analytics/namer.yaml
+++ b/modelerfour/test/scenarios/text-analytics/namer.yaml
@@ -681,7 +681,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_21
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: InnerErrorDetails

--- a/modelerfour/test/scenarios/xml-service/flattened.yaml
+++ b/modelerfour/test/scenarios/xml-service/flattened.yaml
@@ -1013,7 +1013,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_32
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Metadata

--- a/modelerfour/test/scenarios/xml-service/grouped.yaml
+++ b/modelerfour/test/scenarios/xml-service/grouped.yaml
@@ -1013,7 +1013,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_32
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Metadata

--- a/modelerfour/test/scenarios/xml-service/modeler.yaml
+++ b/modelerfour/test/scenarios/xml-service/modeler.yaml
@@ -1013,7 +1013,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_67
       type: dictionary
       elementType: *ref_25
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Metadata

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -1013,7 +1013,6 @@ schemas: !<!Schemas>
     - !<!DictionarySchema> &ref_32
       type: dictionary
       elementType: *ref_1
-      nullableItems: false
       language: !<!Languages> 
         default:
           name: Metadata

--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -22,7 +22,8 @@ import {
   ObjectSchema,
   OperationGroup,
   Operation,
-  Parameter
+  Parameter,
+  SchemaResponse
 } from "@azure-tools/codemodel";
 
 const cfg = {
@@ -312,7 +313,7 @@ class Modeler {
   }
 
   @test
-  async "propagates 'nullable' to properties, parameters, and collections"() {
+  async "propagates 'nullable' to properties, parameters, collections, and responses"() {
     const spec = createTestSpec();
 
     addSchema(spec, "WannaBeNullable", {
@@ -360,7 +361,19 @@ class Modeler {
               $ref: "#/components/schemas/WannaBeNullable"
             }
           }
-        ]
+        ],
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "string",
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
       }
     });
 
@@ -388,8 +401,11 @@ class Modeler {
     );
 
     // $host param comes first then the parameter we're looking for
-    const param = codeModel.operationGroups[0].operations[0].parameters?.[1];
-    assert.strictEqual(param?.nullable, true);
+    const operation = codeModel.operationGroups[0].operations[0];
+    const param = operation.parameters![1];
+    const response: SchemaResponse = <SchemaResponse>operation.responses![0];
+    assert.strictEqual(param.nullable, true);
+    assert.strictEqual(response.nullable, true);
   }
 
   @test

--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -326,14 +326,39 @@ class Modeler {
       }
     });
 
-    addSchema(spec, "NullableArray", {
+    addSchema(spec, "NotNullable", {
+      type: "object",
+      nullable: true,
+      properties: {
+        iIsHere: {
+          type: "boolean"
+        }
+      }
+    });
+
+    addSchema(spec, "NullableArrayElement", {
+      type: "array",
+      items: {
+        nullable: true,
+        $ref: "#/components/schemas/NotNullable"
+      }
+    });
+
+    addSchema(spec, "NullableArrayElementSchema", {
       type: "array",
       items: {
         $ref: "#/components/schemas/WannaBeNullable"
       }
     });
 
-    addSchema(spec, "NullableDictionary", {
+    addSchema(spec, "NullableDictionaryElement", {
+      additionalProperties: {
+        nullable: true,
+        $ref: "#/components/schemas/NotNullable"
+      }
+    });
+
+    addSchema(spec, "NullableDictionaryElementSchema", {
       additionalProperties: {
         $ref: "#/components/schemas/WannaBeNullable"
       }
@@ -380,14 +405,28 @@ class Modeler {
     const codeModel = await runModeler(spec);
 
     assertSchema(
-      "NullableArray",
+      "NullableArrayElement",
       codeModel.schemas.arrays,
       s => s.nullableItems,
       true
     );
 
     assertSchema(
-      "NullableDictionary",
+      "NullableArrayElementSchema",
+      codeModel.schemas.arrays,
+      s => s.nullableItems,
+      true
+    );
+
+    assertSchema(
+      "NullableDictionaryElement",
+      codeModel.schemas.dictionaries,
+      s => s.nullableItems,
+      true
+    );
+
+    assertSchema(
+      "NullableDictionaryElementSchema",
       codeModel.schemas.dictionaries,
       s => s.nullableItems,
       true
@@ -403,6 +442,7 @@ class Modeler {
     // $host param comes first then the parameter we're looking for
     const operation = codeModel.operationGroups[0].operations[0];
     const param = operation.parameters![1];
+
     const response: SchemaResponse = <SchemaResponse>operation.responses![0];
     assert.strictEqual(param.nullable, true);
     assert.strictEqual(response.nullable, true);


### PR DESCRIPTION
This PR addresses https://github.com/Azure/perks/issues/109 as well as some other issues with `x-nullable` support in modelerfour:

- `SchemaResponse` now indicates whether the response is `nullable` (depends on PR https://github.com/Azure/perks/pull/115)
- `requestBody` schemas can now be `nullable`
- Dictionary schemas with `x-nullable` inside of `additionalProperties` are now respected
- Array schemas with `x-nullable` inside of `items` are now respected