### PR TITLE
Propagate OpenAPI 3 'explode' field for parameter style

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -1463,6 +1463,7 @@ export class ModelerFour {
           protocol: {
             http: new HttpParameter(parameter.in, parameter.style ? {
               style: <SerializationStyle><unknown>parameter.style,
+              explode: parameter.explode
             } : undefined),
           },
           language: {

--- a/modelerfour/test/scenarios/cognitive-search/flattened.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/flattened.yaml
@@ -2026,6 +2026,7 @@ operationGroups:
                 serializedName: facet
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
           - !<!Parameter> &ref_107
@@ -2146,6 +2147,7 @@ operationGroups:
                 serializedName: scoringParameter
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
           - !<!Parameter> &ref_115

--- a/modelerfour/test/scenarios/cognitive-search/grouped.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/grouped.yaml
@@ -1141,6 +1141,7 @@ schemas: !<!Schemas>
                   serializedName: facet
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
+                  explode: true
                   in: query
                   style: form
           serializedName: Facets
@@ -1352,6 +1353,7 @@ schemas: !<!Schemas>
                   serializedName: scoringParameter
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
+                  explode: true
                   in: query
                   style: form
           serializedName: ScoringParameters

--- a/modelerfour/test/scenarios/cognitive-search/modeler.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/modeler.yaml
@@ -2026,6 +2026,7 @@ operationGroups:
                 serializedName: facet
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
           - !<!Parameter> &ref_107
@@ -2146,6 +2147,7 @@ operationGroups:
                 serializedName: scoringParameter
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
           - !<!Parameter> &ref_115

--- a/modelerfour/test/scenarios/cognitive-search/namer.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/namer.yaml
@@ -1141,6 +1141,7 @@ schemas: !<!Schemas>
                   serializedName: facet
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
+                  explode: true
                   in: query
                   style: form
           serializedName: Facets
@@ -1352,6 +1353,7 @@ schemas: !<!Schemas>
                   serializedName: scoringParameter
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
+                  explode: true
                   in: query
                   style: form
           serializedName: ScoringParameters

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
@@ -143,6 +143,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:
@@ -203,6 +204,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:
@@ -263,6 +265,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
@@ -143,6 +143,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:
@@ -203,6 +204,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:
@@ -263,6 +265,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
@@ -143,6 +143,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:
@@ -203,6 +204,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:
@@ -263,6 +265,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
@@ -143,6 +143,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:
@@ -203,6 +204,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:
@@ -263,6 +265,7 @@ operationGroups:
                 serializedName: arrayQuery
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
+                explode: true
                 in: query
                 style: form
         requests:

--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -493,4 +493,49 @@ class Modeler {
     );
     assert.strictEqual(memeBodyParam?.clientDefaultValue, "meme.jpg");
   }
+
+  @test
+  async "propagates parameter 'expand' value"() {
+    const spec = createTestSpec();
+
+    addOperation(spec, "/test", {
+      post: {
+        operationId: "getIt",
+        description: "Get operation.",
+        parameters: [
+          {
+            name: "explodedParam",
+            in: "query",
+            style: "form",
+            explode: true,
+            schema: {
+              type: "array",
+              items: {
+                type: "string"
+              }
+            }
+          },
+          {
+            name: "nonExplodedParam",
+            in: "query",
+            style: "form",
+            schema: {
+              type: "array",
+              items: {
+                type: "string"
+              }
+            }
+          }
+        ]
+      }
+    });
+
+    const codeModel = await runModeler(spec);
+
+    const getIt = findByName("getIt", codeModel.operationGroups[0].operations);
+    const explodedParam = findByName("explodedParam", getIt!.parameters);
+    assert.strictEqual(explodedParam!.protocol.http!.explode, true);
+    const nonExplodedParam = findByName("nonExplodedParam", getIt!.parameters);
+    assert.strictEqual(nonExplodedParam!.protocol.http!.explode, undefined);
+  }
 }


### PR DESCRIPTION
This PR follows on from https://github.com/Azure/perks/pull/118 to address https://github.com/Azure/autorest.modelerfour/issues/314 which reports that we don't carry along the `explode` field for parameters with `style` of `form`.  This change takes the new `explode` field on `HttpParameter` and populates it with whatever is provided by the incoming OpenAPI 3 spec.