### PR TITLE
Improve error that appears when schema recursion is detected

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -768,7 +768,7 @@ export class ModelerFour {
   trap = new Set();
   processSchemaImpl(schema: OpenAPI.Schema, name: string): Schema {
     if (this.trap.has(schema)) {
-      throw new Error(`RECURSING!  Saw schema ${schema.title} more than once.`);
+      throw new Error(`RECURSING!  Saw schema ${schema.title || schema['x-ms-metadata']?.name || name} more than once.`);
     }
     this.trap.add(schema);
 


### PR DESCRIPTION
This change merely improves the error message that appears when schema recursion is detected, pulling the schema name from a couple more places so that we can tell which schema caused the error.