### PR TITLE
Pull x-ms-client-name from the header object, not its schema

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -1507,8 +1507,11 @@ export class ModelerFour {
         const headers = new Array<HttpHeader>();
         for (const { key: header, value: hh } of this.resolveDictionary(response.headers)) {
           this.use(hh.schema, (n, sch) => {
-            const hsch = this.processSchema(this.interpret.getName(header, sch), sch);
+            // Override the name picked from the schema if the header has its own
+            const hsch = this.processSchema('', sch);
+            hsch.language.default.name = this.interpret.getName(hsch.language.default.name, hh)
             hsch.language.default.header = header;
+            hsch.language.default.description = this.interpret.getDescription('', hh);
             headers.push(new HttpHeader(header, hsch));
           });
         }
@@ -1527,8 +1530,11 @@ export class ModelerFour {
           const headers = new Array<HttpHeader>();
           for (const { key: header, value: hh } of this.resolveDictionary(response.headers)) {
             this.use(hh.schema, (n, sch) => {
-              const hsch = this.processSchema(this.interpret.getName(header, sch), sch);
+              // Override the name picked from the schema if the header has its own
+              const hsch = this.processSchema('', sch);
+              hsch.language.default.name = this.interpret.getName(hsch.language.default.name, hh)
               hsch.language.default.header = header;
+              hsch.language.default.description = this.interpret.getDescription('', hh);
               headers.push(new HttpHeader(header, hsch));
             });
           }


### PR DESCRIPTION
@joheredi pointed out that modelerfour isn't properly applying `x-ms-client-name` to request and response header names in the code model.  For example:

```
            "headers": {
              "x-ms-client-request-id": {
                "x-ms-client-name": "ClientRequestId",
                "type": "string",
                "description": "If a client request id header is sent in the request, this header will be present in the response with the same value."
              },
```

https://github.com/Azure/azure-rest-api-specs/blob/2adcc6851f4854ca17227f976a65ebbfba76ab42/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json#L115-L120

In this case, the header's name turns out to be one of the generated names which doesn't add any value.  A counter example is what happens with the existing code when the [header has a schema](https://github.com/Azure/azure-rest-api-specs/blob/2adcc6851f4854ca17227f976a65ebbfba76ab42/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json#L3109-L3121) with a name:

```
              "x-ms-lease-status": {
                "x-ms-client-name": "LeaseStatus",
                "description": "The current lease status of the blob.",
                "type": "string",
                "enum": [
                  "locked",
                  "unlocked"
                ],
                "x-ms-enum": {
                  "name": "LeaseStatusType",
                  "modelAsString": false
                }
              },
```

The header ends up with the name `LeaseStatusType` which is clearly wrong; it should be `LeaseStatus`.

This PR fixes the issue but I want to make sure @fearthecowboy doesn't think it will cause unintended consequences.