### PR TITLE
Exclude test folder from npm package

### DIFF
--- a/modelerfour/.npmignore
+++ b/modelerfour/.npmignore
@@ -1,6 +1,7 @@
 !dist/**/*
 src/
 dist/test/
+test/
 package/
 .npmignore
 tsconfig.json


### PR DESCRIPTION
This change excludes the `test/` folder from the `npm` package when `npm pack` is run.  This folder contains a large number of YAML and JSON files which bloat the resulting `tgz` to 5.5 mb (!!).  After this change the package is 2.4 mb.